### PR TITLE
Implement pair iterators

### DIFF
--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -82,7 +82,7 @@ Attribute.prototype.generate = function () {
   if (!this || !module.exports.is(this)) {
     throw new TypeError("Illegal invocation");
   }
-  return this.${this.idl.name};
+  ${getterBody};
 };\n\n`;
   }
 

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -5,6 +5,7 @@ const path = require("path");
 const utils = require("../utils");
 const Attribute = require("./attribute");
 const Constant = require("./constant");
+const Iterable = require("./iterable");
 const Operation = require("./operation");
 const Overloads = require("../overloads");
 const Parameters = require("../parameters");
@@ -18,6 +19,7 @@ function Interface(idl, opts) {
   this.requires = {};
   this.str = null;
   this.opts = opts;
+  this.iterable = false;
 }
 
 Interface.prototype.type = "interface";
@@ -130,6 +132,51 @@ Interface.prototype.generateExport = function () {
     exposers.push(keys[i] + ": { " + exposedOnObj.join(", ") + " }");
   }
 
+  if (this.iterable) {
+    this.str += `\nconst IteratorPrototype = Object.create(utils.IteratorPrototype, {
+  next: {
+    value: function next() {
+      const target = this[utils.iterTargetSymbol];
+      const kind = this[utils.iterKindSymbol];
+      const index = this[utils.iterIndexSymbol];
+      const values = Array.from(target[impl]);
+      const len = values.length;
+      if (index >= len) {
+        return { value: undefined, done: true };
+      }
+
+      const pair = values[index];
+      this[utils.iterIndexSymbol] = index + 1;
+
+      let result;
+      switch (kind) {
+        case "key":
+          result = pair[0];
+          break;
+        case "value":
+          result = pair[1];
+          break;
+        case "key+value":
+          result = [pair[0], pair[1]];
+          break;
+      }
+      return { value: result, done: false };
+    },
+    writable: true,
+    enumerable: true,
+    configurable: true
+  },
+  toString: {
+    value: function toString() {
+      return "[object ${this.name}Iterator]";
+    },
+    writable: true,
+    enumerable: false,
+    configurable: true
+  }
+});`;
+  }
+
   // since we don't have spread arg calls, we can't do new Interface(...arguments) yet
   // add initialized symbol as to not destroy the object shape and cause deopts
   this.str += `\nmodule.exports = {
@@ -171,6 +218,13 @@ Interface.prototype.generateExport = function () {
     let obj = Object.create(${this.name}.prototype);
     this.setup(obj, constructorArgs, privateData);
     return utils.implForWrapper(obj);
+  },
+  createDefaultIterator(target, kind) {
+    const iterator = Object.create(IteratorPrototype);
+    iterator[utils.iterTargetSymbol] = target;
+    iterator[utils.iterKindSymbol] = kind;
+    iterator[utils.iterIndexSymbol] = 0;
+    return iterator;
   },
   _internalSetup(obj) {`;
 
@@ -233,6 +287,10 @@ Interface.prototype.generateOperations = function () {
           continue;
         }
         done[member.name] = true;
+        break;
+      case "iterable":
+        this.iterable = true;
+        member = new Iterable(this, this.idl, memberIdl, { customTypes: this.opts.customTypes });
         break;
       default:
         //throw new Error("Can't handle member of type '" + memberIdl.type + "'");

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -136,9 +136,10 @@ Interface.prototype.generateExport = function () {
     this.str += `\nconst IteratorPrototype = Object.create(utils.IteratorPrototype, {
   next: {
     value: function next() {
-      const target = this[utils.iterTargetSymbol];
-      const kind = this[utils.iterKindSymbol];
-      const index = this[utils.iterIndexSymbol];
+      const internal = this[utils.iterInternalSymbol];
+      const target = internal.target;
+      const kind = internal.kind;
+      const index = internal.index;
       const values = Array.from(target[impl]);
       const len = values.length;
       if (index >= len) {
@@ -146,7 +147,7 @@ Interface.prototype.generateExport = function () {
       }
 
       const pair = values[index];
-      this[utils.iterIndexSymbol] = index + 1;
+      internal.index = index + 1;
 
       let result;
       switch (kind) {
@@ -221,9 +222,11 @@ Interface.prototype.generateExport = function () {
   },
   createDefaultIterator(target, kind) {
     const iterator = Object.create(IteratorPrototype);
-    iterator[utils.iterTargetSymbol] = target;
-    iterator[utils.iterKindSymbol] = kind;
-    iterator[utils.iterIndexSymbol] = 0;
+    iterator[utils.iterInternalSymbol] = {
+      target,
+      kind,
+      index: 0
+    };
     return iterator;
   },
   _internalSetup(obj) {`;

--- a/lib/constructs/iterable.js
+++ b/lib/constructs/iterable.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const conversions = require("webidl-conversions");
+const Overloads = require("../overloads");
+const Parameters = require("../parameters");
+const keywords = require("../keywords");
+
+function Iterable(obj, I, idl, opts) {
+  this.obj = obj;
+  this.interface = I;
+  this.idl = idl;
+  this.name = idl.type;
+  this.opts = opts;
+}
+
+Iterable.prototype.generateFunction = function (key, kind, keyExpr, fnName) {
+  if (fnName === undefined) {
+    fnName = typeof key === "symbol" ? "" : (keywords.has(key) ? "_" : key);
+  }
+
+  const propExpr = typeof key === "symbol" ? `[${keyExpr}]` : `.${key}`;
+
+  return `\n${this.obj.name}.prototype${propExpr} = function ${fnName}() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError("Illegal invocation");
+  }
+  return module.exports.createDefaultIterator(this, "${kind}");
+}`;
+};
+
+Iterable.prototype.generate = function () {
+  const isPairIterator = Array.isArray(this.idl.idlType) && this.idl.idlType.length === 2;
+  let str = "";
+
+  if (isPairIterator) {
+    str += this.generateFunction(Symbol.iterator, "key+value", "Symbol.iterator", "entries");
+    str += `\n${this.obj.name}.prototype.entries = ${this.obj.name}.prototype[Symbol.iterator];`;
+    str += this.generateFunction("keys", "key");
+    str += this.generateFunction("values", "value");
+    str += `\n${this.obj.name}.prototype.forEach = function forEach(callback, thisArg = undefined) {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError("Illegal invocation");
+  }
+  let pairs = Array.from(this[impl]);
+  let i = 0;
+  while (i < pairs.length) {
+    const [key, value] = pairs[i];
+    callback.call(thisArg, value, key, this);
+    pairs = Array.from(this[impl]);
+    i++;
+  }
+};`;
+  }
+
+
+  return {
+    requires: {},
+    body: str
+  }
+};
+
+module.exports = Iterable;

--- a/lib/constructs/iterable.js
+++ b/lib/constructs/iterable.js
@@ -35,10 +35,11 @@ Iterable.prototype.generate = function () {
     str += `\n${this.obj.name}.prototype.entries = ${this.obj.name}.prototype[Symbol.iterator];`;
     str += this.generateFunction("keys", "key");
     str += this.generateFunction("values", "value");
-    str += `\n${this.obj.name}.prototype.forEach = function forEach(callback, thisArg = undefined) {
+    str += `\n${this.obj.name}.prototype.forEach = function forEach(callback) {
   if (!this || !module.exports.is(this)) {
     throw new TypeError("Illegal invocation");
   }
+  const thisArg = arguments[1];
   let pairs = Array.from(this[impl]);
   let i = 0;
   while (i < pairs.length) {

--- a/lib/constructs/iterable.js
+++ b/lib/constructs/iterable.js
@@ -39,6 +39,12 @@ Iterable.prototype.generate = function () {
   if (!this || !module.exports.is(this)) {
     throw new TypeError("Illegal invocation");
   }
+  if (arguments.length < 1) {
+    throw new TypeError("Failed to execute 'forEach' on '${this.obj.name}': 1 argument required, but only 0 present.");
+  }
+  if (typeof callback !== "function") {
+    throw new TypeError("Failed to execute 'forEach' on '${this.obj.name}': The callback provided as parameter 1 is not a function.");
+  }
   const thisArg = arguments[1];
   let pairs = Array.from(this[impl]);
   let i = 0;

--- a/lib/constructs/iterable.js
+++ b/lib/constructs/iterable.js
@@ -1,8 +1,6 @@
 "use strict";
 
 const conversions = require("webidl-conversions");
-const Overloads = require("../overloads");
-const Parameters = require("../parameters");
 const keywords = require("../keywords");
 
 function Iterable(obj, I, idl, opts) {

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -32,9 +32,18 @@ function tryImplForWrapper(wrapper) {
   return impl ? impl : wrapper;
 };
 
+const iterTargetSymbol = Symbol("target");
+const iterKindSymbol = Symbol("kind");
+const iterIndexSymbol = Symbol("index");
+const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+
 module.exports.wrapperSymbol = wrapperSymbol;
 module.exports.implSymbol = implSymbol;
 module.exports.wrapperForImpl = wrapperForImpl;
 module.exports.implForWrapper = implForWrapper;
 module.exports.tryWrapperForImpl = tryWrapperForImpl;
 module.exports.tryImplForWrapper = tryImplForWrapper;
+module.exports.iterTargetSymbol = iterTargetSymbol;
+module.exports.iterKindSymbol = iterKindSymbol;
+module.exports.iterIndexSymbol = iterIndexSymbol;
+module.exports.IteratorPrototype = IteratorPrototype;

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -32,9 +32,7 @@ function tryImplForWrapper(wrapper) {
   return impl ? impl : wrapper;
 };
 
-const iterTargetSymbol = Symbol("target");
-const iterKindSymbol = Symbol("kind");
-const iterIndexSymbol = Symbol("index");
+const iterInternalSymbol = Symbol("internal");
 const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
 
 module.exports.wrapperSymbol = wrapperSymbol;
@@ -43,7 +41,5 @@ module.exports.wrapperForImpl = wrapperForImpl;
 module.exports.implForWrapper = implForWrapper;
 module.exports.tryWrapperForImpl = tryWrapperForImpl;
 module.exports.tryImplForWrapper = tryImplForWrapper;
-module.exports.iterTargetSymbol = iterTargetSymbol;
-module.exports.iterKindSymbol = iterKindSymbol;
-module.exports.iterIndexSymbol = iterIndexSymbol;
+module.exports.iterInternalSymbol = iterInternalSymbol;
 module.exports.IteratorPrototype = IteratorPrototype;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "co": "^4.6.0",
     "pn": "^1.0.0",
-    "webidl-conversions": "^2.0.0",
+    "webidl-conversions": "^3.0.0",
     "webidl2": "^2.0.11"
   },
   "devDependencies": {},

--- a/test/cases/URL.idl
+++ b/test/cases/URL.idl
@@ -1,18 +1,9 @@
+/*
 [Constructor(USVString url, optional USVString base),
  Exposed=(Window,Worker)]
 interface URL {
-  static USVString domainToASCII(USVString domain);
-  static USVString domainToUnicode(USVString domain);
-};
-URL implements URLUtils;
-URL implements URLUtilsSearchParams;
-
-[NoInterfaceObject,
- Exposed=(Window,Worker)]
-interface URLUtils {
   stringifier attribute USVString href;
   readonly attribute USVString origin;
-
            attribute USVString protocol;
            attribute USVString username;
            attribute USVString password;
@@ -21,29 +12,10 @@ interface URLUtils {
            attribute USVString port;
            attribute USVString pathname;
            attribute USVString search;
+  [SameObject] readonly attribute URLSearchParams searchParams;
            attribute USVString hash;
 };
-
-[NoInterfaceObject,
- Exposed=(Window, Worker)]
-interface URLUtilsSearchParams {
-           attribute URLSearchParams searchParams;
-};
-
-[NoInterfaceObject,
- Exposed=(Window,Worker)]
-interface URLUtilsReadOnly {
-  stringifier readonly attribute USVString href;
-  readonly attribute USVString origin;
-
-  readonly attribute USVString protocol;
-  readonly attribute USVString host;
-  readonly attribute USVString hostname;
-  readonly attribute USVString port;
-  readonly attribute USVString pathname;
-  readonly attribute USVString search;
-  readonly attribute USVString hash;
-};
+*/
 
 [Constructor(optional (USVString or URLSearchParams) init = ""),
  Exposed=(Window,Worker)]
@@ -55,5 +27,6 @@ interface URLSearchParams {
   boolean has(USVString name);
   void set(USVString name, USVString value);
   iterable<USVString, USVString>;
-  stringifier;
+  // The following operation on its own currently doesn't work.
+  // stringifier;
 };

--- a/test/implementations/URLSearchParams.js
+++ b/test/implementations/URLSearchParams.js
@@ -1,0 +1,75 @@
+"use strict";
+
+const conversions = require("webidl-conversions");
+const querystring = require("querystring");
+
+class URLSearchParamsImpl {
+  constructor(init) {
+    if (init instanceof URLSearchParamsImpl) {
+      this._list = init._list.slice();
+    } else {
+      init = conversions.USVString(init);
+      if (init[0] === "?") { init = init.slice(1); }
+
+      this._list = [];
+      const parsed = querystring.parse(init);
+      for (let name in parsed) {
+        if (Array.isArray(parsed[name])) {
+          for (let value of parsed[name]) {
+            this._list.push([name, value]);
+          }
+        } else {
+          this._list.push([name, parsed[name]]);
+        }
+      }
+    }
+  }
+
+  append(name, value) {
+    this._list.push([name, value]);
+  }
+
+  delete(name) {
+    let i = 0;
+    while (i < this._list.length) {
+      if (this._list[i][0] === name) {
+        this._list.splice(i, 1);
+      } else {
+        i++;
+      }
+    }
+  }
+
+  get(name) {
+    for (let pair of this._list) {
+      if (pair[0] === name) {
+        return pair[1];
+      }
+    }
+
+    return null;
+  }
+
+  getAll(name) {
+    const output = [];
+    for (let pair of this._list) {
+      if (pair[0] === name) {
+        output.push(pair[1]);
+      }
+    }
+    return output;
+  }
+
+  has(name) {
+    return this._list.some(pair => pair[0] === name);
+  }
+
+  set(name, value) {
+    this.delete(name);
+    this.append(name, value);
+  }
+}
+
+module.exports = {
+  implementation: URLSearchParamsImpl
+};

--- a/test/implementations/URLSearchParams.js
+++ b/test/implementations/URLSearchParams.js
@@ -68,6 +68,10 @@ class URLSearchParamsImpl {
     this.delete(name);
     this.append(name, value);
   }
+
+  [Symbol.iterator]() {
+    return this._list[Symbol.iterator]();
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
This is incomplete in the sense that it only supports pair iterators through iterable declaration (not value iterators, indexed property getter, maplike, or setlike); and it doesn't specifically handle mixins, overloading, etc. But I think this is a good start, and should cover a large swath of actual iterable API usage.