### PR TITLE
Make all symbol props non-writable non-enumerable

### DIFF
--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -191,11 +191,12 @@ Interface.prototype.generateExport = function () {
     this.str += `
   createDefaultIterator(target, kind) {
     const iterator = Object.create(IteratorPrototype);
-    iterator[utils.iterInternalSymbol] = {
-      target,
-      kind,
-      index: 0
-    };
+    Object.defineProperty(iterator, utils.iterInternalSymbol, {
+      value: { target, kind, index: 0 },
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
     return iterator;
   },`;
   }
@@ -286,7 +287,12 @@ Interface.prototype.generateIface = function () {
 
   const implClass = require(this.opts.implDir + "/" + this.name + this.opts.implSuffix);
   this.str += `
-    obj[impl] = new Impl.implementation(constructorArgs, privateData);
+    Object.defineProperty(obj, impl, {
+      value: new Impl.implementation(constructorArgs, privateData),
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
     obj[impl][utils.wrapperSymbol] = obj;`;
     if (implClass.init) {
       this.str += `
@@ -368,9 +374,20 @@ Interface.prototype.generateSymbols = function () {
 
   if (Object.keys(unscopables).length) {
     this.str += `
-${this.name}.prototype[Symbol.unscopables] = ${JSON.stringify(unscopables, null, '  ')};\n`;
+Object.defineProperty(${this.name}.prototype, Symbol.unscopables, {
+  value: ${JSON.stringify(unscopables, null, '  ')},
+  writable: false,
+  enumerable: false,
+  configurable: true
+});\n`;
   }
-  this.str += `\n${this.name}.prototype[Symbol.toStringTag] = ${JSON.stringify(this.name)};\n`;
+  this.str += `
+Object.defineProperty(${this.name}.prototype, Symbol.toStringTag, {
+  value: "${this.name}",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});\n`;
 };
 
 Interface.prototype.generate = function () {


### PR DESCRIPTION
Node.js v8.x starts to display all enumerable symbols in inspection, which means that w/o this change the implementation of all DOM objects will be visible to the user.

A similar change is done to `@@toStringTag` and `@@unscopables` to maintain compatibility with Chrome.