### PR TITLE
Minimal implementation to HTMLElement interface

### DIFF
--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -111,9 +111,21 @@ Interface.prototype.generateConstructor = function () {
     this.str += `
   iface.setup(this${passArgs});
 }\n`;
+  } else if (this.name === 'HTMLElement') {
+    this.str += `function ${this.name}() {
+  const { document, customElements } = global.window;
+  const ownerDocument = window.document[impl];
+  let localName = null;
+  customElements[registry].forEach((Ctor, tagName) => {
+    if (this.constructor = Ctor) {
+      localName = tagName;
+    }
+  });
+  module.exports.setup(this, arguments, { localName, ownerDocument });
+}\n`;
   } else {
     this.str += `function ${this.name}() {
-  throw new TypeError("Illegal constructor");
+  throw new TypeError('lol this is the DOM not JavaScript ya dummy');
 }\n`;
   }
 
@@ -131,6 +143,10 @@ Interface.prototype.generateRequires = function () {
   }
 
   requireStr += `const impl = utils.implSymbol;\n`;
+
+  if (this.name === 'HTMLElement') {
+    requireStr += `const registry = utils.registrySymbol;\n`;
+  }
 
   if (this.mixins.length !== 0) {
     requireStr += `const mixin = utils.mixin;\n`;


### PR DESCRIPTION
Please don't close because this code sucks. I'm hoping to get folks talking about what integration could look like for Custom Elements / Shadow DOM in jsdom. I really like jsdom and it's a good tool for me to get my testing work done. This is one of the de-facto DOM implementations in Node and it would be a huge win to the Web Components community if we could get them working in jsdom.

I am a complete newb to the source, so I can't shake the feeling I'm doing everything wrong and would like feedback on how to improve it.

This is also not anywhere's close to feature complete. I would need to walk through the specification and ensure that everything works to a reasonable degree.