### PR TITLE
Fix mixins, stringifiers, and static attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ webidl2js is implementing an ever-growing subset of the Web IDL specification. S
 - `typedef`s
 - Partial interfaces and dictionaries
 - Basic types (via [webidl-conversions][])
-- Mixins, i.e. `implements` (with a [notable bug](https://github.com/jsdom/webidl2js/issues/49))
+- Mixins, i.e. `implements`
 - Overload resolution (although [tricky cases are not easy on the implementation class](#overloaded-operations))
 - Variadic arguments ([only non-overloaded operations](#variadic-operations) are supported though)
 - `[Clamp]`

--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -12,6 +12,7 @@ class Attribute {
     this.obj = obj;
     this.interface = I;
     this.idl = idl;
+    this.static = idl.static;
   }
 
   generate() {
@@ -23,7 +24,7 @@ class Attribute {
     const sameObject = utils.getExtAttr(this.idl.extAttrs, "SameObject");
 
     let objName = `this`;
-    let definedOn = this.obj.name + (this.idl.static ? "" : ".prototype");
+    let definedOn = this.obj.name + (this.static ? "" : ".prototype");
     if (utils.isOnInstance(this.idl, this.interface)) { // we're in a setup method
       objName = `obj`;
       definedOn = `obj`;
@@ -39,7 +40,7 @@ class Attribute {
       getterBody = `return ${objName}[impl]["${this.idl.name}"];`;
     }
 
-    if (this.idl.static) {
+    if (this.static) {
       brandCheck = "";
       getterBody = `return Impl["${this.idl.name}"];`;
       setterBody = `Impl["${this.idl.name}"] = V;`;

--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -7,9 +7,8 @@ const reflector = require("../reflector");
 const Types = require("../types");
 
 class Attribute {
-  constructor(ctx, obj, I, idl) {
+  constructor(ctx, I, idl) {
     this.ctx = ctx;
-    this.obj = obj;
     this.interface = I;
     this.idl = idl;
     this.static = idl.static;
@@ -24,8 +23,8 @@ class Attribute {
     const sameObject = utils.getExtAttr(this.idl.extAttrs, "SameObject");
 
     let objName = `this`;
-    let definedOn = this.obj.name + (this.static ? "" : ".prototype");
-    if (utils.isOnInstance(this.idl, this.interface)) { // we're in a setup method
+    let definedOn = this.interface.name + (this.static ? "" : ".prototype");
+    if (utils.isOnInstance(this.idl, this.interface.idl)) { // we're in a setup method
       objName = `obj`;
       definedOn = `obj`;
     }

--- a/lib/constructs/constant.js
+++ b/lib/constructs/constant.js
@@ -3,9 +3,8 @@
 const utils = require("../utils");
 
 class Constant {
-  constructor(ctx, obj, I, idl) {
+  constructor(ctx, I, idl) {
     this.ctx = ctx;
-    this.obj = obj;
     this.interface = I;
     this.idl = idl;
 
@@ -14,11 +13,11 @@ class Constant {
 
   generate() {
     const body = `
-      Object.defineProperty(${this.obj.name}, "${this.idl.name}", {
+      Object.defineProperty(${this.interface.name}, "${this.idl.name}", {
         value: ${JSON.stringify(this.idl.value.value)},
         enumerable: true
       });
-      Object.defineProperty(${this.obj.name}.prototype, "${this.idl.name}", {
+      Object.defineProperty(${this.interface.name}.prototype, "${this.idl.name}", {
         value: ${JSON.stringify(this.idl.value.value)},
         enumerable: true
       });

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -33,7 +33,9 @@ class Interface {
     this.mixins = [];
 
     this.operations = new Map();
+    this.staticOperations = new Map();
     this.attributes = new Map();
+    this.staticAttributes = new Map();
     this.constants = new Map();
 
     this.indexedGetter = null;
@@ -55,14 +57,17 @@ class Interface {
         continue;
       }
       if (!definingInterface) {
+        let key;
         switch (member.type) {
           case "operation":
-            if (member.name && !this.operations.has(member.name)) {
-              this.operations.set(member.name, new Operation(this.ctx, this, this.idl, member));
+            key = member.static ? "staticOperations" : "operations";
+            if (member.name && !this[key].has(member.name)) {
+              this[key].set(member.name, new Operation(this.ctx, this, this.idl, member));
             }
             break;
           case "attribute":
-            this.attributes.set(member.name, new Attribute(this.ctx, this, this.idl, member));
+            key = member.static ? "staticAttributes" : "attributes";
+            this[key].set(member.name, new Attribute(this.ctx, this, this.idl, member));
             break;
           case "const":
             this.constants.set(member.name, new Constant(this.ctx, this, this.idl, member));
@@ -1145,7 +1150,7 @@ class Interface {
       this.str += `${this.name}.prototype.forEach = ${expr};`;
     }
 
-    for (const member of this.operations.values()) {
+    for (const member of [...this.operations.values(), ...this.staticOperations.values()]) {
       if (!utils.isOnInstance(member.idl, this.idl)) {
         const data = member.generate();
         this.requires.merge(data.requires);
@@ -1160,7 +1165,7 @@ class Interface {
   }
 
   generateAttributes() {
-    for (const member of [...this.attributes.values(), ...this.constants.values()]) {
+    for (const member of [...this.attributes.values(), ...this.staticAttributes.values(), ...this.constants.values()]) {
       if (member instanceof Attribute && utils.isOnInstance(member.idl, this.idl)) {
         continue;
       }

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -61,22 +61,26 @@ class Interface {
         switch (member.type) {
           case "operation":
             key = member.static ? "staticOperations" : "operations";
-            if (member.name && !this[key].has(member.name)) {
-              this[key].set(member.name, new Operation(this.ctx, this, this.idl, member));
+            if (member.name) {
+              if (!this[key].has(member.name)) {
+                this[key].set(member.name, new Operation(this.ctx, this, member));
+              } else {
+                this[key].get(member.name).idls.push(member);
+              }
             }
             break;
           case "attribute":
             key = member.static ? "staticAttributes" : "attributes";
-            this[key].set(member.name, new Attribute(this.ctx, this, this.idl, member));
+            this[key].set(member.name, new Attribute(this.ctx, this, member));
             break;
           case "const":
-            this.constants.set(member.name, new Constant(this.ctx, this, this.idl, member));
+            this.constants.set(member.name, new Constant(this.ctx, this, member));
             break;
           case "iterable":
             if (this.iterable) {
               throw new Error(`Interface ${this.name} has more than one iterable declaration`);
             }
-            this.iterable = new Iterable(this.ctx, this, this.idl, member);
+            this.iterable = new Iterable(this.ctx, this, member);
             break;
           default:
             if (!this.ctx.options.suppressErrors) {
@@ -184,7 +188,7 @@ class Interface {
               throw new Error(msg + "duplicated stringifier");
             }
           }
-          const op = new Operation(this.ctx, this, this.idl, member);
+          const op = new Operation(this.ctx, this, member);
           op.name = "toString";
           this.operations.set("toString", op);
         } else if (member.type === "attribute") {
@@ -300,7 +304,7 @@ class Interface {
   }
 
   generateConstructor() {
-    const overloads = Overloads.getEffectiveOverloads("constructor", 0, this.idl, null);
+    const overloads = Overloads.getEffectiveOverloads("constructor", this.name, 0, this);
 
     if (overloads.length !== 0) {
       let minConstructor = overloads[0];
@@ -1031,7 +1035,14 @@ class Interface {
       `;
     }
 
-    for (const member of [...this.operations.values(), ...this.attributes.values()]) {
+    for (const member of this.operations.values()) {
+      if (member.isOnInstance()) {
+        const data = member.generate();
+        this.requires.merge(data.requires);
+        this.str += data.body;
+      }
+    }
+    for (const member of this.attributes.values()) {
       if (utils.isOnInstance(member.idl, this.idl)) {
         const data = member.generate();
         this.requires.merge(data.requires);
@@ -1151,7 +1162,7 @@ class Interface {
     }
 
     for (const member of [...this.operations.values(), ...this.staticOperations.values()]) {
-      if (!utils.isOnInstance(member.idl, this.idl)) {
+      if (!member.isOnInstance()) {
         const data = member.generate();
         this.requires.merge(data.requires);
         this.str += data.body;

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -41,6 +41,7 @@ class Interface {
     this.namedGetter = null;
     this.namedSetter = null;
     this.namedDeleter = null;
+    this.stringifier = null;
 
     this.iterable = null;
     this._analyzed = false;
@@ -55,16 +56,11 @@ class Interface {
       }
       if (!definingInterface) {
         switch (member.type) {
-          case "operation": {
-            let name = member.name;
-            if (name === null && member.stringifier) {
-              name = "toString";
-            }
-            if (name !== null && !this.operations.has(name)) {
-              this.operations.set(name, new Operation(this.ctx, this, this.idl, member));
+          case "operation":
+            if (member.name && !this.operations.has(member.name)) {
+              this.operations.set(member.name, new Operation(this.ctx, this, this.idl, member));
             }
             break;
-          }
           case "attribute":
             this.attributes.set(member.name, new Attribute(this.ctx, this, this.idl, member));
             break;
@@ -163,9 +159,49 @@ class Interface {
           }
         }
       }
+      if (!definingInterface && member.stringifier) {
+        const msg = `Invalid stringifier ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}: `;
+        if (member.type === "operation") {
+          if (!member.idlType) {
+            member.idlType = { idlType: "DOMString" };
+          }
+          if (!member.arguments) {
+            member.arguments = [];
+          }
+          if (!this.ctx.options.suppressErrors) {
+            if (member.arguments.length > 0) {
+              throw new Error(msg + "takes more than zero arguments");
+            }
+            if (member.idlType.idlType !== "DOMString" || member.idlType.nullable) {
+              throw new Error(msg + "returns something other than a plain DOMString");
+            }
+            if (this.stringifier) {
+              throw new Error(msg + "duplicated stringifier");
+            }
+          }
+          const op = new Operation(this.ctx, this, this.idl, member);
+          op.name = "toString";
+          this.operations.set("toString", op);
+        } else if (member.type === "attribute") {
+          if (member.static) {
+            throw new Error(msg + "keyword cannot be placed on static attribute");
+          }
+          if (!this.ctx.options.suppressErrors) {
+            if (member.idlType.idlType !== "DOMString" && member.idlType.idlType !== "USVString" ||
+                member.idlType.nullable) {
+              throw new Error(msg + "attribute can only be of type DOMString or USVString");
+            }
+          }
+          // Implemented in Attribute class.
+        } else {
+          throw new Error(msg + `keyword placed on incompatible type ${member.type}`);
+        }
+        this.stringifier = member;
+      }
     }
 
-    const forbiddenMembers = new Set();
+    // https://heycam.github.io/webidl/#dfn-reserved-identifier
+    const forbiddenMembers = new Set(["constructor", "toString"]);
     if (this.iterable) {
       if (this.iterable.isValue) {
         if (!this.supportsIndexedProperties) {
@@ -185,7 +221,7 @@ class Interface {
         definingInterface = member[1];
         continue;
       }
-      if (forbiddenMembers.has(member.name)) {
+      if (forbiddenMembers.has(member.name) || (member.name && member.name[0] === "_")) {
         let msg = `${member.name} is forbidden in interface ${this.name}`;
         if (definingInterface) {
           msg += ` (defined in ${definingInterface})`;

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -10,9 +10,6 @@ const Overloads = require("../overloads");
 const Parameters = require("../parameters");
 const keywords = require("../keywords");
 
-// Used as a sentinel in inheritedMembers to signify that the following members are inherited.
-const inherited = Symbol("inherited");
-
 function isNamed(idl) {
   return idl.arguments[0].idlType.idlType === "DOMString";
 }
@@ -26,6 +23,9 @@ class Interface {
     this.idl = idl;
     this.name = idl.name;
     this.factory = Boolean(utils.getExtAttr(this.idl.extAttrs, "WebIDL2JSFactory"));
+    for (const member of this.idl.members) {
+      member.definingInterface = this.name;
+    }
 
     this.str = null;
     this.opts = opts;
@@ -50,58 +50,12 @@ class Interface {
   }
 
   _analyzeMembers() {
-    let definingInterface = null;
-    for (const member of this.inheritedMembers()) {
-      if (member[0] === inherited) {
-        definingInterface = member[1];
-        continue;
-      }
-      if (!definingInterface) {
-        let key;
-        switch (member.type) {
-          case "operation":
-            key = member.static ? "staticOperations" : "operations";
-            if (member.name) {
-              if (!this[key].has(member.name)) {
-                this[key].set(member.name, new Operation(this.ctx, this, member));
-              } else {
-                this[key].get(member.name).idls.push(member);
-              }
-            }
-            break;
-          case "attribute":
-            key = member.static ? "staticAttributes" : "attributes";
-            this[key].set(member.name, new Attribute(this.ctx, this, member));
-            break;
-          case "const":
-            this.constants.set(member.name, new Constant(this.ctx, this, member));
-            break;
-          case "iterable":
-            if (this.iterable) {
-              throw new Error(`Interface ${this.name} has more than one iterable declaration`);
-            }
-            this.iterable = new Iterable(this.ctx, this, member);
-            break;
-          default:
-            if (!this.ctx.options.suppressErrors) {
-              throw new Error(`Unknown IDL member type "${member.type}" in interface ${this.name}`);
-            }
-        }
-      } else {
-        switch (member.type) {
-          case "iterable":
-            if (this.iterable) {
-              throw new Error(`Iterable interface ${this.name} inherits from another iterable interface ` +
-                              `${definingInterface}`);
-            }
-            break;
-        }
-      }
+    const handleSpecialOperations = member => {
       if (member.type === "operation") {
         if (member.getter) {
           let msg = `Invalid getter ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
-          if (definingInterface) {
-            msg += ` (defined in ${definingInterface})`;
+          if (member.definingInterface !== this.name) {
+            msg += ` (defined in ${member.definingInterface})`;
           }
           msg += ": ";
           if (member.arguments.length < 1 ||
@@ -124,8 +78,8 @@ class Interface {
         }
         if (member.setter) {
           let msg = `Invalid setter ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
-          if (definingInterface) {
-            msg += ` (defined in ${definingInterface})`;
+          if (member.definingInterface !== this.name) {
+            msg += ` (defined in ${member.definingInterface})`;
           }
           msg += ": ";
 
@@ -149,8 +103,8 @@ class Interface {
         }
         if (member.deleter) {
           let msg = `Invalid deleter ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
-          if (definingInterface) {
-            msg += ` (defined in ${definingInterface})`;
+          if (member.definingInterface !== this.name) {
+            msg += ` (defined in ${member.definingInterface})`;
           }
           msg += ": ";
 
@@ -168,8 +122,49 @@ class Interface {
           }
         }
       }
-      if (!definingInterface && member.stringifier) {
-        const msg = `Invalid stringifier ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}: `;
+    };
+
+    const seen = new Set([this.name]);
+    for (const member of this.members(seen)) {
+      let key;
+      switch (member.type) {
+        case "operation":
+          key = member.static ? "staticOperations" : "operations";
+          if (member.name) {
+            if (!this[key].has(member.name)) {
+              this[key].set(member.name, new Operation(this.ctx, this, member));
+            } else {
+              this[key].get(member.name).idls.push(member);
+            }
+          }
+          break;
+        case "attribute":
+          key = member.static ? "staticAttributes" : "attributes";
+          this[key].set(member.name, new Attribute(this.ctx, this, member));
+          break;
+        case "const":
+          this.constants.set(member.name, new Constant(this.ctx, this, member));
+          break;
+        case "iterable":
+          if (this.iterable) {
+            throw new Error(`Interface ${this.name} has more than one iterable declaration`);
+          }
+          this.iterable = new Iterable(this.ctx, this, member);
+          break;
+        default:
+          if (!this.ctx.options.suppressErrors) {
+            throw new Error(`Unknown IDL member type "${member.type}" in interface ${this.name}`);
+          }
+      }
+
+      handleSpecialOperations(member);
+
+      if (member.stringifier) {
+        let msg = `Invalid stringifier ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
+        if (member.definingInterface !== this.name) {
+          msg += ` (defined in ${member.definingInterface})`;
+        }
+        msg += ": ";
         if (member.type === "operation") {
           if (!member.idlType) {
             member.idlType = { idlType: "DOMString" };
@@ -208,6 +203,14 @@ class Interface {
         this.stringifier = member;
       }
     }
+    for (const member of this.inheritedMembers(seen)) {
+      if (this.iterable && member.type === "iterable") {
+        throw new Error(`Iterable interface ${this.name} inherits from another iterable interface ` +
+                        `${member.definingInterface}`);
+      }
+
+      handleSpecialOperations(member);
+    }
 
     // https://heycam.github.io/webidl/#dfn-reserved-identifier
     const forbiddenMembers = new Set(["constructor", "toString"]);
@@ -224,16 +227,11 @@ class Interface {
         forbiddenMembers.add(n);
       }
     }
-    definingInterface = null;
-    for (const member of this.inheritedMembers()) {
-      if (member[0] === inherited) {
-        definingInterface = member[1];
-        continue;
-      }
+    for (const member of this.allMembers()) {
       if (forbiddenMembers.has(member.name) || (member.name && member.name[0] === "_")) {
         let msg = `${member.name} is forbidden in interface ${this.name}`;
-        if (definingInterface) {
-          msg += ` (defined in ${definingInterface})`;
+        if (member.definingInterface !== this.name) {
+          msg += ` (defined in ${member.definingInterface})`;
         }
         throw new Error(msg);
       }
@@ -253,6 +251,14 @@ class Interface {
   }
 
   implements(source) {
+    const iface = this.ctx.interfaces.get(source);
+    if (!iface) {
+      if (this.ctx.options.suppressErrors) {
+        return;
+      }
+      throw new Error(`${source} interface not found (used as a mixin for ${this.name})`);
+    }
+
     this.mixins.push(source);
   }
 
@@ -372,14 +378,34 @@ class Interface {
     `;
   }
 
-  * inheritedMembers() {
+  // Members that will be visible on this interface's prototype object, i.e. members from this
+  // interface and its consequential interfaces.
+  // https://heycam.github.io/webidl/#dfn-consequential-interfaces
+  * members(seen = new Set([this.name]), root = this.name) {
     yield* this.idl.members;
-    for (const iface of [...this.mixins, this.idl.inheritance]) {
-      if (this.ctx.interfaces.has(iface)) {
-        yield [inherited, iface];
-        yield* this.ctx.interfaces.get(iface).inheritedMembers();
+    for (const mixin of this.mixins) {
+      if (seen.has(mixin)) {
+        throw new Error(`${root} has a dependency cycle`);
       }
+      seen.add(mixin);
+      yield* this.ctx.interfaces.get(mixin).allMembers(seen, root);
     }
+  }
+
+  // Members from this interface's inherited interfaces and their consequential interfaces.
+  * inheritedMembers(seen = new Set([this.name]), root = this.name) {
+    if (this.idl.inheritance && this.ctx.interfaces.has(this.idl.inheritance)) {
+      if (seen.has(this.idl.inheritance)) {
+        throw new Error(`${root} has an inheritance cycle`);
+      }
+      seen.add(this.idl.inheritance);
+      yield* this.ctx.interfaces.get(this.idl.inheritance).allMembers(seen, root);
+    }
+  }
+
+  * allMembers(seen = new Set([this.name]), root = this.name) {
+    yield* this.members(seen, root);
+    yield* this.inheritedMembers(seen, root);
   }
 
   generateRequires() {
@@ -389,11 +415,8 @@ class Interface {
       this.requires.add(this.idl.inheritance);
     }
 
-    if (this.mixins.length !== 0) {
-      this.requires.addRaw("mixin", "utils.mixin");
-      for (const mixin of this.mixins) {
-        this.requires.add(mixin);
-      }
+    for (const mixin of this.mixins) {
+      this.requires.add(mixin);
     }
 
     this.str = `
@@ -406,7 +429,6 @@ class Interface {
   generateMixins() {
     for (const mixin of this.mixins) {
       this.str += `
-        mixin(${this.name}.prototype, ${mixin}.interface.prototype);
         ${mixin}.mixedInto.push(${this.name});
       `;
     }
@@ -869,10 +891,7 @@ class Interface {
     let needFallback = false;
     if (this.supportsNamedProperties && !utils.isGlobal(this.idl)) {
       const unforgeable = new Set();
-      for (const m of this.inheritedMembers()) {
-        if (m[0] === inherited) {
-          continue;
-        }
+      for (const m of this.allMembers()) {
         if ((m.type === "attribute" || m.type === "operation") && !m.static &&
             utils.getExtAttr(m.extAttrs, "Unforgeable")) {
           unforgeable.add(m.name);

--- a/lib/constructs/iterable.js
+++ b/lib/constructs/iterable.js
@@ -4,9 +4,8 @@ const keywords = require("../keywords");
 const utils = require("../utils");
 
 class Iterable {
-  constructor(ctx, obj, I, idl) {
+  constructor(ctx, I, idl) {
     this.ctx = ctx;
-    this.obj = obj;
     this.interface = I;
     this.idl = idl;
     this.name = idl.type;
@@ -32,7 +31,7 @@ class Iterable {
     const propExpr = typeof key === "symbol" ? `[${keyExpr}]` : `.${key}`;
 
     return `
-      ${this.obj.name}.prototype${propExpr} = function ${fnName}() {
+      ${this.interface.name}.prototype${propExpr} = function ${fnName}() {
         if (!this || !module.exports.is(this)) {
           throw new TypeError("Illegal invocation");
         }
@@ -46,15 +45,15 @@ class Iterable {
 
     if (this.isPair) {
       str += `
-        ${this.obj.name}.prototype.entries = ${this.obj.name}.prototype[Symbol.iterator];
+        ${this.interface.name}.prototype.entries = ${this.interface.name}.prototype[Symbol.iterator];
         ${this.generateFunction("keys", "key")}
         ${this.generateFunction("values", "value")}
       `;
     } else {
       str += `
-        ${this.obj.name}.prototype.entries = Array.prototype.entries;
-        ${this.obj.name}.prototype.keys = Array.prototype.keys;
-        ${this.obj.name}.prototype.values = Array.prototype[Symbol.iterator];
+        ${this.interface.name}.prototype.entries = Array.prototype.entries;
+        ${this.interface.name}.prototype.keys = Array.prototype.keys;
+        ${this.interface.name}.prototype.values = Array.prototype[Symbol.iterator];
       `;
     }
 

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -14,6 +14,7 @@ class Operation {
     this.interface = I;
     this.idl = idl;
     this.name = idl.name;
+    this.static = idl.static;
   }
 
   generate() {
@@ -24,7 +25,7 @@ class Operation {
       throw new Error(`Internal error: this operation does not have a name (in interface ${this.obj.name})`);
     }
 
-    let targetObj = this.obj.name + (this.idl.static ? "" : ".prototype");
+    let targetObj = this.obj.name + (this.static ? "" : ".prototype");
     if (utils.isOnInstance(this.idl, this.interface)) {
       targetObj = "obj";
     }
@@ -44,7 +45,7 @@ class Operation {
     str += `
       ${targetObj}.${this.name} = function ${fnName}(${minConstructor.nameList.join(", ")}) {
     `;
-    if (!this.idl.static) {
+    if (!this.static) {
       str += `
         if (!this || !module.exports.is(this)) {
           throw new TypeError("Illegal invocation");
@@ -62,7 +63,7 @@ class Operation {
       `;
     }
 
-    const callOn = this.idl.static ? "Impl" : "this[impl]";
+    const callOn = this.static ? "Impl" : "this[impl]";
     // In case of stringifiers, use the named implementation function rather than hardcoded "toString".
     const implFunc = this.idl.name || this.name;
 

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -8,13 +8,22 @@ const Parameters = require("../parameters");
 const keywords = require("../keywords");
 
 class Operation {
-  constructor(ctx, obj, I, idl) {
+  constructor(ctx, I, idl) {
     this.ctx = ctx;
-    this.obj = obj;
     this.interface = I;
-    this.idl = idl;
+    this.idls = [idl];
     this.name = idl.name;
     this.static = idl.static;
+  }
+
+  isOnInstance() {
+    const firstOverloadOnInstance = utils.isOnInstance(this.idls[0], this.interface.idl);
+    for (const overload of this.idls.slice(1)) {
+      if (utils.isOnInstance(overload, this.interface.idl) !== firstOverloadOnInstance) {
+        throw new Error(`[Unforgeable] is not applied uniformly to operation "${this.name}" on ${this.interface.name}`);
+      }
+    }
+    return firstOverloadOnInstance;
   }
 
   generate() {
@@ -22,15 +31,16 @@ class Operation {
     let str = "";
 
     if (!this.name) {
-      throw new Error(`Internal error: this operation does not have a name (in interface ${this.obj.name})`);
+      throw new Error(`Internal error: this operation does not have a name (in interface ${this.interface.name})`);
     }
 
-    let targetObj = this.obj.name + (this.static ? "" : ".prototype");
-    if (utils.isOnInstance(this.idl, this.interface)) {
+    let targetObj = this.interface.name + (this.static ? "" : ".prototype");
+    if (this.isOnInstance()) {
       targetObj = "obj";
     }
 
-    const overloads = Overloads.getEffectiveOverloads(this.name, 0, this.interface, null);
+    const type = this.static ? "static operation" : "regular operation";
+    const overloads = Overloads.getEffectiveOverloads(type, this.name, 0, this.interface);
     let minConstructor = overloads[0];
 
     for (let i = 1; i < overloads.length; ++i) {
@@ -57,18 +67,20 @@ class Operation {
       const plural = minConstructor.nameList.length > 1 ? "s" : "";
       str += `
         if (arguments.length < ${minConstructor.nameList.length}) {
-          throw new TypeError("Failed to execute '${this.name}' on '${this.obj.name}': ${minConstructor.nameList.length} " +
-                              "argument${plural} required, but only " + arguments.length + " present.");
+          throw new TypeError("Failed to execute '${this.name}' on '${this.interface.name}': " +
+                              "${minConstructor.nameList.length} argument${plural} required, but only " +
+                              arguments.length + " present.");
         }
       `;
     }
 
     const callOn = this.static ? "Impl" : "this[impl]";
     // In case of stringifiers, use the named implementation function rather than hardcoded "toString".
-    const implFunc = this.idl.name || this.name;
+    // All overloads will have the same name, so pick the first one.
+    const implFunc = this.idls[0].name || this.name;
 
     const parameterConversions = Parameters.generateOverloadConversions(
-      this.ctx, overloads, this.interface.name, `Failed to execute '${this.name}' on '${this.obj.name}': `);
+      this.ctx, overloads, this.interface.name, `Failed to execute '${this.name}' on '${this.interface.name}': `);
     const argsSpread = parameterConversions.hasArgs ? "...args" : "";
     requires.merge(parameterConversions.requires);
     str += parameterConversions.body;

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -20,13 +20,8 @@ class Operation {
     const requires = new utils.RequiresMap(this.ctx);
     let str = "";
 
-    let name = this.idl.name;
-    if (!name) {
-      if (this.idl.stringifier) {
-        name = "toString";
-      } else {
-        return { requires, body: "" };
-      }
+    if (!this.name) {
+      throw new Error(`Internal error: this operation does not have a name (in interface ${this.obj.name})`);
     }
 
     let targetObj = this.obj.name + (this.idl.static ? "" : ".prototype");
@@ -34,7 +29,7 @@ class Operation {
       targetObj = "obj";
     }
 
-    const overloads = Overloads.getEffectiveOverloads(name, 0, this.interface, null);
+    const overloads = Overloads.getEffectiveOverloads(this.name, 0, this.interface, null);
     let minConstructor = overloads[0];
 
     for (let i = 1; i < overloads.length; ++i) {
@@ -43,11 +38,11 @@ class Operation {
       }
     }
 
-    const fnName = keywords.has(name) ? "_" : name;
+    const fnName = keywords.has(this.name) ? "_" : this.name;
     minConstructor.nameList = minConstructor.nameList.map(n => (keywords.has(n) ? "_" : "") + n);
 
     str += `
-      ${targetObj}.${name} = function ${fnName}(${minConstructor.nameList.join(", ")}) {
+      ${targetObj}.${this.name} = function ${fnName}(${minConstructor.nameList.join(", ")}) {
     `;
     if (!this.idl.static) {
       str += `
@@ -61,28 +56,30 @@ class Operation {
       const plural = minConstructor.nameList.length > 1 ? "s" : "";
       str += `
         if (arguments.length < ${minConstructor.nameList.length}) {
-          throw new TypeError("Failed to execute '${name}' on '${this.obj.name}': ${minConstructor.nameList.length} " +
+          throw new TypeError("Failed to execute '${this.name}' on '${this.obj.name}': ${minConstructor.nameList.length} " +
                               "argument${plural} required, but only " + arguments.length + " present.");
         }
       `;
     }
 
     const callOn = this.idl.static ? "Impl" : "this[impl]";
+    // In case of stringifiers, use the named implementation function rather than hardcoded "toString".
+    const implFunc = this.idl.name || this.name;
 
     const parameterConversions = Parameters.generateOverloadConversions(
-      this.ctx, overloads, this.interface.name, `Failed to execute '${name}' on '${this.obj.name}': `);
+      this.ctx, overloads, this.interface.name, `Failed to execute '${this.name}' on '${this.obj.name}': `);
     const argsSpread = parameterConversions.hasArgs ? "...args" : "";
     requires.merge(parameterConversions.requires);
     str += parameterConversions.body;
 
-    if (this.idl.stringifier || overloads.every(overload => conversions[overload.operation.idlType.idlType])) {
+    if (overloads.every(overload => conversions[overload.operation.idlType.idlType])) {
       str += `
-          return ${callOn}.${name}(${argsSpread});
+          return ${callOn}.${implFunc}(${argsSpread});
         };
       `;
     } else {
       str += `
-          return utils.tryWrapperForImpl(${callOn}.${name}(${argsSpread}));
+          return utils.tryWrapperForImpl(${callOn}.${implFunc}(${argsSpread}));
         };
       `;
     }

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -20,17 +20,6 @@ function getCopyToBytes(bufferSource) {
   return Buffer.from(getReferenceToBytes(bufferSource));
 }
 
-function mixin(target, source) {
-  const keys = Object.getOwnPropertyNames(source);
-  for (let i = 0; i < keys.length; ++i) {
-    if (keys[i] in target) {
-      continue;
-    }
-
-    Object.defineProperty(target, keys[i], Object.getOwnPropertyDescriptor(source, keys[i]));
-  }
-}
-
 const wrapperSymbol = Symbol("wrapper");
 const implSymbol = Symbol("impl");
 const sameObjectCaches = Symbol("SameObject caches");
@@ -100,7 +89,6 @@ module.exports = exports = {
   isObject,
   getReferenceToBytes,
   getCopyToBytes,
-  mixin,
   wrapperSymbol,
   implSymbol,
   getSameObject,

--- a/lib/overloads.js
+++ b/lib/overloads.js
@@ -1,23 +1,26 @@
 "use strict";
 
-module.exports.getEffectiveOverloads = function (A, N, I) { // No |C| since we don't support callback function yet.
+module.exports.getEffectiveOverloads = function (type, A, N, I) {
   const S = [];
   let F = null;
 
-  if (A === "constructor") { // let's hope no-one specs a member named "constructor"
-    F = I.extAttrs.filter(a => a.name === "Constructor");
-    for (const c of F) {
-      if (!c.arguments) {
-        c.arguments = [];
+  switch (type) {
+    case "regular operation":
+      F = I.operations.get(A).idls;
+      break;
+    case "static operation":
+      F = I.staticOperations.get(A).idls;
+      break;
+    case "constructor":
+      F = I.idl.extAttrs.filter(a => a.name === "Constructor");
+      for (const c of F) {
+        if (!c.arguments) {
+          c.arguments = [];
+        }
       }
-    }
-  } else if (typeof A === "string") {
-    F = I.members.filter(m => m.name === A || (A === "toString" && m.stringifier));
-    for (const m of F) {
-      if (m.stringifier) {
-        m.arguments = [];
-      }
-    }
+      break;
+    default:
+      throw new RangeError(`${type}s are not yet supported`);
   }
 
   let maxArgs = 0;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,7 +33,7 @@ function isGlobal(idl) {
 }
 
 function isOnInstance(memberIDL, interfaceIDL) {
-  return getExtAttr(memberIDL.extAttrs, "Unforgeable") || isGlobal(interfaceIDL);
+  return !memberIDL.static && (getExtAttr(memberIDL.extAttrs, "Unforgeable") || isGlobal(interfaceIDL));
 }
 
 class RequiresMap extends Map {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -355,6 +355,780 @@ const Impl = require(\\"../implementations/LegacyArrayClass.js\\");
 "
 `;
 
+exports[`MixedIn.idl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const impl = utils.implSymbol;
+const Mixin = require(\\"./Mixin.js\\");
+
+function MixedIn() {
+  throw new TypeError(\\"Illegal constructor\\");
+}
+
+Object.defineProperty(MixedIn, \\"prototype\\", {
+  value: MixedIn.prototype,
+  writable: false,
+  enumerable: false,
+  configurable: false
+});
+
+Mixin.mixedInto.push(MixedIn);
+
+MixedIn.prototype.mixedInOp = function mixedInOp() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixedInOp();
+};
+
+MixedIn.prototype.mixinOp = function mixinOp() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixinOp();
+};
+
+MixedIn.prototype.mixinMixinOp = function mixinMixinOp() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixinMixinOp();
+};
+
+MixedIn.prototype.mixinInheritedOp = function mixinInheritedOp() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixinInheritedOp();
+};
+
+MixedIn.prototype.toString = function toString() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixinInheritedOp();
+};
+
+Object.defineProperty(MixedIn.prototype, \\"mixedInAttr\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"mixedInAttr\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, {
+      context: \\"Failed to set the 'mixedInAttr' property on 'MixedIn': The provided value\\"
+    });
+
+    this[impl][\\"mixedInAttr\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(MixedIn.prototype, \\"mixinAttr\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"mixinAttr\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, {
+      context: \\"Failed to set the 'mixinAttr' property on 'MixedIn': The provided value\\"
+    });
+
+    this[impl][\\"mixinAttr\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(MixedIn.prototype, \\"mixinMixinAttr\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"mixinMixinAttr\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, {
+      context: \\"Failed to set the 'mixinMixinAttr' property on 'MixedIn': The provided value\\"
+    });
+
+    this[impl][\\"mixinMixinAttr\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(MixedIn.prototype, \\"mixinInheritedAttr\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"mixinInheritedAttr\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, {
+      context: \\"Failed to set the 'mixinInheritedAttr' property on 'MixedIn': The provided value\\"
+    });
+
+    this[impl][\\"mixinInheritedAttr\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(MixedIn, \\"mixedInConst\\", {
+  value: 43,
+  enumerable: true
+});
+Object.defineProperty(MixedIn.prototype, \\"mixedInConst\\", {
+  value: 43,
+  enumerable: true
+});
+
+Object.defineProperty(MixedIn, \\"mixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+Object.defineProperty(MixedIn.prototype, \\"mixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+
+Object.defineProperty(MixedIn, \\"mixinMixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+Object.defineProperty(MixedIn.prototype, \\"mixinMixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+
+Object.defineProperty(MixedIn, \\"mixinInheritedConst\\", {
+  value: 42,
+  enumerable: true
+});
+Object.defineProperty(MixedIn.prototype, \\"mixinInheritedConst\\", {
+  value: 42,
+  enumerable: true
+});
+
+Object.defineProperty(MixedIn.prototype, Symbol.toStringTag, {
+  value: \\"MixedIn\\",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+
+const iface = {
+  mixedInto: [],
+  is(obj) {
+    if (obj) {
+      if (obj[impl] instanceof Impl.implementation) {
+        return true;
+      }
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (obj instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  isImpl(obj) {
+    if (obj) {
+      if (obj instanceof Impl.implementation) {
+        return true;
+      }
+
+      const wrapper = utils.wrapperForImpl(obj);
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (wrapper instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  convert(obj, { context = \\"The provided value\\" } = {}) {
+    if (module.exports.is(obj)) {
+      return utils.implForWrapper(obj);
+    }
+    throw new TypeError(\`\${context} is not of type 'MixedIn'.\`);
+  },
+
+  create(constructorArgs, privateData) {
+    let obj = Object.create(MixedIn.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return obj;
+  },
+  createImpl(constructorArgs, privateData) {
+    let obj = Object.create(MixedIn.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return utils.implForWrapper(obj);
+  },
+  _internalSetup(obj) {},
+  setup(obj, constructorArgs, privateData) {
+    if (!privateData) privateData = {};
+
+    privateData.wrapper = obj;
+
+    this._internalSetup(obj);
+    Object.defineProperty(obj, impl, {
+      value: new Impl.implementation(constructorArgs, privateData),
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
+
+    obj[impl][utils.wrapperSymbol] = obj;
+    if (Impl.init) {
+      Impl.init(obj[impl], privateData);
+    }
+    return obj;
+  },
+  interface: MixedIn,
+  expose: {
+    Window: { MixedIn }
+  }
+}; // iface
+module.exports = iface;
+
+const Impl = require(\\"../implementations/MixedIn.js\\");
+"
+`;
+
+exports[`Mixin.idl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const impl = utils.implSymbol;
+const MixinInherited = require(\\"./MixinInherited.js\\");
+const MixinMixin = require(\\"./MixinMixin.js\\");
+
+function Mixin() {
+  throw new TypeError(\\"Illegal constructor\\");
+}
+
+Object.setPrototypeOf(Mixin.prototype, MixinInherited.interface.prototype);
+Object.setPrototypeOf(Mixin, MixinInherited.interface);
+
+Object.defineProperty(Mixin, \\"prototype\\", {
+  value: Mixin.prototype,
+  writable: false,
+  enumerable: false,
+  configurable: false
+});
+
+MixinMixin.mixedInto.push(Mixin);
+
+Mixin.prototype.mixinOp = function mixinOp() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixinOp();
+};
+
+Mixin.prototype.mixinMixinOp = function mixinMixinOp() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixinMixinOp();
+};
+
+Object.defineProperty(Mixin.prototype, \\"mixinAttr\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"mixinAttr\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, {
+      context: \\"Failed to set the 'mixinAttr' property on 'Mixin': The provided value\\"
+    });
+
+    this[impl][\\"mixinAttr\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(Mixin.prototype, \\"mixinMixinAttr\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"mixinMixinAttr\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, {
+      context: \\"Failed to set the 'mixinMixinAttr' property on 'Mixin': The provided value\\"
+    });
+
+    this[impl][\\"mixinMixinAttr\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(Mixin, \\"mixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+Object.defineProperty(Mixin.prototype, \\"mixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+
+Object.defineProperty(Mixin, \\"mixinMixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+Object.defineProperty(Mixin.prototype, \\"mixinMixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+
+Object.defineProperty(Mixin.prototype, Symbol.toStringTag, {
+  value: \\"Mixin\\",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+
+const iface = {
+  mixedInto: [],
+  is(obj) {
+    if (obj) {
+      if (obj[impl] instanceof Impl.implementation) {
+        return true;
+      }
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (obj instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  isImpl(obj) {
+    if (obj) {
+      if (obj instanceof Impl.implementation) {
+        return true;
+      }
+
+      const wrapper = utils.wrapperForImpl(obj);
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (wrapper instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  convert(obj, { context = \\"The provided value\\" } = {}) {
+    if (module.exports.is(obj)) {
+      return utils.implForWrapper(obj);
+    }
+    throw new TypeError(\`\${context} is not of type 'Mixin'.\`);
+  },
+
+  create(constructorArgs, privateData) {
+    let obj = Object.create(Mixin.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return obj;
+  },
+  createImpl(constructorArgs, privateData) {
+    let obj = Object.create(Mixin.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return utils.implForWrapper(obj);
+  },
+  _internalSetup(obj) {
+    MixinInherited._internalSetup(obj);
+  },
+  setup(obj, constructorArgs, privateData) {
+    if (!privateData) privateData = {};
+
+    privateData.wrapper = obj;
+
+    this._internalSetup(obj);
+    Object.defineProperty(obj, impl, {
+      value: new Impl.implementation(constructorArgs, privateData),
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
+
+    obj[impl][utils.wrapperSymbol] = obj;
+    if (Impl.init) {
+      Impl.init(obj[impl], privateData);
+    }
+    return obj;
+  },
+  interface: Mixin,
+  expose: {}
+}; // iface
+module.exports = iface;
+
+const Impl = require(\\"../implementations/Mixin.js\\");
+"
+`;
+
+exports[`MixinInherited.idl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const impl = utils.implSymbol;
+
+function MixinInherited() {
+  throw new TypeError(\\"Illegal constructor\\");
+}
+
+Object.defineProperty(MixinInherited, \\"prototype\\", {
+  value: MixinInherited.prototype,
+  writable: false,
+  enumerable: false,
+  configurable: false
+});
+
+MixinInherited.prototype.mixinInheritedOp = function mixinInheritedOp() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixinInheritedOp();
+};
+
+MixinInherited.prototype.toString = function toString() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixinInheritedOp();
+};
+
+Object.defineProperty(MixinInherited.prototype, \\"mixinInheritedAttr\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"mixinInheritedAttr\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, {
+      context: \\"Failed to set the 'mixinInheritedAttr' property on 'MixinInherited': The provided value\\"
+    });
+
+    this[impl][\\"mixinInheritedAttr\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(MixinInherited, \\"mixinInheritedConst\\", {
+  value: 42,
+  enumerable: true
+});
+Object.defineProperty(MixinInherited.prototype, \\"mixinInheritedConst\\", {
+  value: 42,
+  enumerable: true
+});
+
+Object.defineProperty(MixinInherited.prototype, Symbol.toStringTag, {
+  value: \\"MixinInherited\\",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+
+const iface = {
+  mixedInto: [],
+  is(obj) {
+    if (obj) {
+      if (obj[impl] instanceof Impl.implementation) {
+        return true;
+      }
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (obj instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  isImpl(obj) {
+    if (obj) {
+      if (obj instanceof Impl.implementation) {
+        return true;
+      }
+
+      const wrapper = utils.wrapperForImpl(obj);
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (wrapper instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  convert(obj, { context = \\"The provided value\\" } = {}) {
+    if (module.exports.is(obj)) {
+      return utils.implForWrapper(obj);
+    }
+    throw new TypeError(\`\${context} is not of type 'MixinInherited'.\`);
+  },
+
+  create(constructorArgs, privateData) {
+    let obj = Object.create(MixinInherited.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return obj;
+  },
+  createImpl(constructorArgs, privateData) {
+    let obj = Object.create(MixinInherited.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return utils.implForWrapper(obj);
+  },
+  _internalSetup(obj) {},
+  setup(obj, constructorArgs, privateData) {
+    if (!privateData) privateData = {};
+
+    privateData.wrapper = obj;
+
+    this._internalSetup(obj);
+    Object.defineProperty(obj, impl, {
+      value: new Impl.implementation(constructorArgs, privateData),
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
+
+    obj[impl][utils.wrapperSymbol] = obj;
+    if (Impl.init) {
+      Impl.init(obj[impl], privateData);
+    }
+    return obj;
+  },
+  interface: MixinInherited,
+  expose: {}
+}; // iface
+module.exports = iface;
+
+const Impl = require(\\"../implementations/MixinInherited.js\\");
+"
+`;
+
+exports[`MixinMixin.idl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const impl = utils.implSymbol;
+
+function MixinMixin() {
+  throw new TypeError(\\"Illegal constructor\\");
+}
+
+Object.defineProperty(MixinMixin, \\"prototype\\", {
+  value: MixinMixin.prototype,
+  writable: false,
+  enumerable: false,
+  configurable: false
+});
+
+MixinMixin.prototype.mixinMixinOp = function mixinMixinOp() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixinMixinOp();
+};
+
+Object.defineProperty(MixinMixin.prototype, \\"mixinMixinAttr\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"mixinMixinAttr\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, {
+      context: \\"Failed to set the 'mixinMixinAttr' property on 'MixinMixin': The provided value\\"
+    });
+
+    this[impl][\\"mixinMixinAttr\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(MixinMixin, \\"mixinMixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+Object.defineProperty(MixinMixin.prototype, \\"mixinMixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+
+Object.defineProperty(MixinMixin.prototype, Symbol.toStringTag, {
+  value: \\"MixinMixin\\",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+
+const iface = {
+  mixedInto: [],
+  is(obj) {
+    if (obj) {
+      if (obj[impl] instanceof Impl.implementation) {
+        return true;
+      }
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (obj instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  isImpl(obj) {
+    if (obj) {
+      if (obj instanceof Impl.implementation) {
+        return true;
+      }
+
+      const wrapper = utils.wrapperForImpl(obj);
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (wrapper instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  convert(obj, { context = \\"The provided value\\" } = {}) {
+    if (module.exports.is(obj)) {
+      return utils.implForWrapper(obj);
+    }
+    throw new TypeError(\`\${context} is not of type 'MixinMixin'.\`);
+  },
+
+  create(constructorArgs, privateData) {
+    let obj = Object.create(MixinMixin.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return obj;
+  },
+  createImpl(constructorArgs, privateData) {
+    let obj = Object.create(MixinMixin.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return utils.implForWrapper(obj);
+  },
+  _internalSetup(obj) {},
+  setup(obj, constructorArgs, privateData) {
+    if (!privateData) privateData = {};
+
+    privateData.wrapper = obj;
+
+    this._internalSetup(obj);
+    Object.defineProperty(obj, impl, {
+      value: new Impl.implementation(constructorArgs, privateData),
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
+
+    obj[impl][utils.wrapperSymbol] = obj;
+    if (Impl.init) {
+      Impl.init(obj[impl], privateData);
+    }
+    return obj;
+  },
+  interface: MixinMixin,
+  expose: {}
+}; // iface
+module.exports = iface;
+
+const Impl = require(\\"../implementations/MixinMixin.js\\");
+"
+`;
+
 exports[`Overloads.idl 1`] = `
 "\\"use strict\\";
 
@@ -4336,6 +5110,7 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const impl = utils.implSymbol;
+const MixinMixin = require(\\"./MixinMixin.js\\");
 
 function UnderscoredProperties() {
   throw new TypeError(\\"Illegal constructor\\");
@@ -4347,6 +5122,8 @@ Object.defineProperty(UnderscoredProperties, \\"prototype\\", {
   enumerable: false,
   configurable: false
 });
+
+MixinMixin.mixedInto.push(UnderscoredProperties);
 
 UnderscoredProperties.prototype.operation = function operation(sequence) {
   if (!this || !module.exports.is(this)) {
@@ -4385,6 +5162,14 @@ UnderscoredProperties.prototype.operation = function operation(sequence) {
   }
 
   return this[impl].operation(...args);
+};
+
+UnderscoredProperties.prototype.mixinMixinOp = function mixinMixinOp() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].mixinMixinOp();
 };
 
 UnderscoredProperties.static = function _(_void) {
@@ -4434,11 +5219,45 @@ Object.defineProperty(UnderscoredProperties.prototype, \\"attribute\\", {
   configurable: true
 });
 
+Object.defineProperty(UnderscoredProperties.prototype, \\"mixinMixinAttr\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"mixinMixinAttr\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, {
+      context: \\"Failed to set the 'mixinMixinAttr' property on 'UnderscoredProperties': The provided value\\"
+    });
+
+    this[impl][\\"mixinMixinAttr\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
 Object.defineProperty(UnderscoredProperties, \\"const\\", {
   value: 42,
   enumerable: true
 });
 Object.defineProperty(UnderscoredProperties.prototype, \\"const\\", {
+  value: 42,
+  enumerable: true
+});
+
+Object.defineProperty(UnderscoredProperties, \\"mixinMixinConst\\", {
+  value: 42,
+  enumerable: true
+});
+Object.defineProperty(UnderscoredProperties.prototype, \\"mixinMixinConst\\", {
   value: 42,
   enumerable: true
 });

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -355,6 +355,158 @@ const Impl = require(\\"../implementations/LegacyArrayClass.js\\");
 "
 `;
 
+exports[`Overloads.idl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const impl = utils.implSymbol;
+
+function Overloads() {
+  throw new TypeError(\\"Illegal constructor\\");
+}
+
+Object.defineProperty(Overloads, \\"prototype\\", {
+  value: Overloads.prototype,
+  writable: false,
+  enumerable: false,
+  configurable: false
+});
+
+Overloads.prototype.compatible = function compatible(arg1) {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  if (arguments.length < 1) {
+    throw new TypeError(
+      \\"Failed to execute 'compatible' on 'Overloads': \\" +
+        \\"1 argument required, but only \\" +
+        arguments.length +
+        \\" present.\\"
+    );
+  }
+
+  const args = [];
+  for (let i = 0; i < arguments.length && i < 3; ++i) {
+    args[i] = arguments[i];
+  }
+
+  args[0] = conversions[\\"DOMString\\"](args[0], {
+    context: \\"Failed to execute 'compatible' on 'Overloads': parameter 1\\"
+  });
+
+  return utils.tryWrapperForImpl(this[impl].compatible(...args));
+};
+
+Overloads.prototype.incompatible = function incompatible(arg1) {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  if (arguments.length < 1) {
+    throw new TypeError(
+      \\"Failed to execute 'incompatible' on 'Overloads': \\" +
+        \\"1 argument required, but only \\" +
+        arguments.length +
+        \\" present.\\"
+    );
+  }
+
+  const args = [];
+  for (let i = 0; i < arguments.length && i < 1; ++i) {
+    args[i] = arguments[i];
+  }
+
+  return this[impl].incompatible(...args);
+};
+
+Object.defineProperty(Overloads.prototype, Symbol.toStringTag, {
+  value: \\"Overloads\\",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+
+const iface = {
+  mixedInto: [],
+  is(obj) {
+    if (obj) {
+      if (obj[impl] instanceof Impl.implementation) {
+        return true;
+      }
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (obj instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  isImpl(obj) {
+    if (obj) {
+      if (obj instanceof Impl.implementation) {
+        return true;
+      }
+
+      const wrapper = utils.wrapperForImpl(obj);
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (wrapper instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  convert(obj, { context = \\"The provided value\\" } = {}) {
+    if (module.exports.is(obj)) {
+      return utils.implForWrapper(obj);
+    }
+    throw new TypeError(\`\${context} is not of type 'Overloads'.\`);
+  },
+
+  create(constructorArgs, privateData) {
+    let obj = Object.create(Overloads.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return obj;
+  },
+  createImpl(constructorArgs, privateData) {
+    let obj = Object.create(Overloads.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return utils.implForWrapper(obj);
+  },
+  _internalSetup(obj) {},
+  setup(obj, constructorArgs, privateData) {
+    if (!privateData) privateData = {};
+
+    privateData.wrapper = obj;
+
+    this._internalSetup(obj);
+    Object.defineProperty(obj, impl, {
+      value: new Impl.implementation(constructorArgs, privateData),
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
+
+    obj[impl][utils.wrapperSymbol] = obj;
+    if (Impl.init) {
+      Impl.init(obj[impl], privateData);
+    }
+    return obj;
+  },
+  interface: Overloads,
+  expose: {
+    Window: { Overloads }
+  }
+}; // iface
+module.exports = iface;
+
+const Impl = require(\\"../implementations/Overloads.js\\");
+"
+`;
+
 exports[`PromiseTypes.idl 1`] = `
 "\\"use strict\\";
 
@@ -381,8 +533,8 @@ PromiseTypes.prototype.voidPromiseConsumer = function voidPromiseConsumer(p) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'voidPromiseConsumer' on 'PromiseTypes': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'voidPromiseConsumer' on 'PromiseTypes': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -405,8 +557,8 @@ PromiseTypes.prototype.promiseConsumer = function promiseConsumer(p) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -540,8 +692,8 @@ SeqAndRec.prototype.recordConsumer = function recordConsumer(rec) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'recordConsumer' on 'SeqAndRec': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'recordConsumer' on 'SeqAndRec': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -586,8 +738,8 @@ SeqAndRec.prototype.recordConsumer2 = function recordConsumer2(rec) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -632,8 +784,8 @@ SeqAndRec.prototype.sequenceConsumer = function sequenceConsumer(seq) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'sequenceConsumer' on 'SeqAndRec': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'sequenceConsumer' on 'SeqAndRec': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -671,8 +823,8 @@ SeqAndRec.prototype.sequenceConsumer2 = function sequenceConsumer2(seq) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'sequenceConsumer2' on 'SeqAndRec': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'sequenceConsumer2' on 'SeqAndRec': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -708,8 +860,8 @@ SeqAndRec.prototype.frozenArrayConsumer = function frozenArrayConsumer(arr) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'frozenArrayConsumer' on 'SeqAndRec': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'frozenArrayConsumer' on 'SeqAndRec': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -1005,7 +1157,7 @@ Storage.prototype.key = function key(index) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'key' on 'Storage': 1 \\" + \\"argument required, but only \\" + arguments.length + \\" present.\\"
+      \\"Failed to execute 'key' on 'Storage': \\" + \\"1 argument required, but only \\" + arguments.length + \\" present.\\"
     );
   }
 
@@ -1026,7 +1178,7 @@ Storage.prototype.getItem = function getItem(key) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'getItem' on 'Storage': 1 \\" + \\"argument required, but only \\" + arguments.length + \\" present.\\"
+      \\"Failed to execute 'getItem' on 'Storage': \\" + \\"1 argument required, but only \\" + arguments.length + \\" present.\\"
     );
   }
 
@@ -1047,7 +1199,7 @@ Storage.prototype.setItem = function setItem(key, value) {
 
   if (arguments.length < 2) {
     throw new TypeError(
-      \\"Failed to execute 'setItem' on 'Storage': 2 \\" + \\"arguments required, but only \\" + arguments.length + \\" present.\\"
+      \\"Failed to execute 'setItem' on 'Storage': \\" + \\"2 arguments required, but only \\" + arguments.length + \\" present.\\"
     );
   }
 
@@ -1070,8 +1222,8 @@ Storage.prototype.removeItem = function removeItem(key) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'removeItem' on 'Storage': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'removeItem' on 'Storage': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -1853,8 +2005,8 @@ TypedefsAndUnions.prototype.numOrStrConsumer = function numOrStrConsumer(a) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'numOrStrConsumer' on 'TypedefsAndUnions': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'numOrStrConsumer' on 'TypedefsAndUnions': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -1885,8 +2037,8 @@ TypedefsAndUnions.prototype.numOrStrOrNullConsumer = function numOrStrOrNullCons
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'numOrStrOrNullConsumer' on 'TypedefsAndUnions': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'numOrStrOrNullConsumer' on 'TypedefsAndUnions': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -1923,8 +2075,8 @@ TypedefsAndUnions.prototype.numOrStrOrURLOrNullConsumer = function numOrStrOrURL
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'numOrStrOrURLOrNullConsumer' on 'TypedefsAndUnions': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'numOrStrOrURLOrNullConsumer' on 'TypedefsAndUnions': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -1963,8 +2115,8 @@ TypedefsAndUnions.prototype.urlMapInnerConsumer = function urlMapInnerConsumer(a
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -2011,8 +2163,8 @@ TypedefsAndUnions.prototype.urlMapConsumer = function urlMapConsumer(a) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -2062,8 +2214,8 @@ TypedefsAndUnions.prototype.bufferSourceOrURLConsumer = function bufferSourceOrU
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'bufferSourceOrURLConsumer' on 'TypedefsAndUnions': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'bufferSourceOrURLConsumer' on 'TypedefsAndUnions': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -2094,8 +2246,8 @@ TypedefsAndUnions.prototype.arrayBufferViewOrURLMapConsumer = function arrayBuff
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -2161,8 +2313,8 @@ TypedefsAndUnions.prototype.arrayBufferViewDupConsumer = function arrayBufferVie
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'arrayBufferViewDupConsumer' on 'TypedefsAndUnions': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'arrayBufferViewDupConsumer' on 'TypedefsAndUnions': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -2753,7 +2905,7 @@ URLList.prototype.item = function item(index) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'item' on 'URLList': 1 \\" + \\"argument required, but only \\" + arguments.length + \\" present.\\"
+      \\"Failed to execute 'item' on 'URLList': \\" + \\"1 argument required, but only \\" + arguments.length + \\" present.\\"
     );
   }
 
@@ -3204,8 +3356,8 @@ URLSearchParams.prototype.append = function append(name, value) {
 
   if (arguments.length < 2) {
     throw new TypeError(
-      \\"Failed to execute 'append' on 'URLSearchParams': 2 \\" +
-        \\"arguments required, but only \\" +
+      \\"Failed to execute 'append' on 'URLSearchParams': \\" +
+        \\"2 arguments required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -3234,8 +3386,8 @@ URLSearchParams.prototype.delete = function _(name) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'delete' on 'URLSearchParams': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'delete' on 'URLSearchParams': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -3260,8 +3412,8 @@ URLSearchParams.prototype.get = function get(name) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'get' on 'URLSearchParams': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'get' on 'URLSearchParams': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -3284,8 +3436,8 @@ URLSearchParams.prototype.getAll = function getAll(name) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'getAll' on 'URLSearchParams': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'getAll' on 'URLSearchParams': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -3310,8 +3462,8 @@ URLSearchParams.prototype.has = function has(name) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'has' on 'URLSearchParams': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'has' on 'URLSearchParams': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -3334,8 +3486,8 @@ URLSearchParams.prototype.set = function set(name, value) {
 
   if (arguments.length < 2) {
     throw new TypeError(
-      \\"Failed to execute 'set' on 'URLSearchParams': 2 \\" +
-        \\"arguments required, but only \\" +
+      \\"Failed to execute 'set' on 'URLSearchParams': \\" +
+        \\"2 arguments required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -3515,8 +3667,8 @@ URLSearchParamsCollection.prototype.item = function item(index) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'item' on 'URLSearchParamsCollection': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'item' on 'URLSearchParamsCollection': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -3541,8 +3693,8 @@ URLSearchParamsCollection.prototype.namedItem = function namedItem(name) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'namedItem' on 'URLSearchParamsCollection': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'namedItem' on 'URLSearchParamsCollection': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -4203,8 +4355,8 @@ UnderscoredProperties.prototype.operation = function operation(sequence) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'operation' on 'UnderscoredProperties': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'operation' on 'UnderscoredProperties': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -4238,8 +4390,8 @@ UnderscoredProperties.prototype.operation = function operation(sequence) {
 UnderscoredProperties.static = function _(_void) {
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'static' on 'UnderscoredProperties': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'static' on 'UnderscoredProperties': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );
@@ -4457,8 +4609,8 @@ const iface = {
 
       if (arguments.length < 1) {
         throw new TypeError(
-          \\"Failed to execute 'assign' on 'Unforgeable': 1 \\" +
-            \\"argument required, but only \\" +
+          \\"Failed to execute 'assign' on 'Unforgeable': \\" +
+            \\"1 argument required, but only \\" +
             arguments.length +
             \\" present.\\"
         );
@@ -4917,7 +5069,7 @@ Variadic.prototype.simple2 = function simple2(first) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'simple2' on 'Variadic': 1 \\" + \\"argument required, but only \\" + arguments.length + \\" present.\\"
+      \\"Failed to execute 'simple2' on 'Variadic': \\" + \\"1 argument required, but only \\" + arguments.length + \\" present.\\"
     );
   }
 
@@ -4953,8 +5105,8 @@ Variadic.prototype.overloaded2 = function overloaded2(first) {
 
   if (arguments.length < 1) {
     throw new TypeError(
-      \\"Failed to execute 'overloaded2' on 'Variadic': 1 \\" +
-        \\"argument required, but only \\" +
+      \\"Failed to execute 'overloaded2' on 'Variadic': \\" +
+        \\"1 argument required, but only \\" +
         arguments.length +
         \\" present.\\"
     );

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -825,6 +825,160 @@ const Impl = require(\\"../implementations/SeqAndRec.js\\");
 "
 `;
 
+exports[`Static.idl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const impl = utils.implSymbol;
+
+function Static() {
+  throw new TypeError(\\"Illegal constructor\\");
+}
+
+Object.defineProperty(Static, \\"prototype\\", {
+  value: Static.prototype,
+  writable: false,
+  enumerable: false,
+  configurable: false
+});
+
+Static.prototype.def = function def() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].def();
+};
+
+Static.def = function def() {
+  return Impl.def();
+};
+
+Object.defineProperty(Static.prototype, \\"abc\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"abc\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, { context: \\"Failed to set the 'abc' property on 'Static': The provided value\\" });
+
+    this[impl][\\"abc\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(Static, \\"abc\\", {
+  get() {
+    return Impl[\\"abc\\"];
+  },
+
+  set(V) {
+    V = conversions[\\"DOMString\\"](V, { context: \\"Failed to set the 'abc' property on 'Static': The provided value\\" });
+
+    Impl[\\"abc\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(Static.prototype, Symbol.toStringTag, {
+  value: \\"Static\\",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+
+const iface = {
+  mixedInto: [],
+  is(obj) {
+    if (obj) {
+      if (obj[impl] instanceof Impl.implementation) {
+        return true;
+      }
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (obj instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  isImpl(obj) {
+    if (obj) {
+      if (obj instanceof Impl.implementation) {
+        return true;
+      }
+
+      const wrapper = utils.wrapperForImpl(obj);
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (wrapper instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  convert(obj, { context = \\"The provided value\\" } = {}) {
+    if (module.exports.is(obj)) {
+      return utils.implForWrapper(obj);
+    }
+    throw new TypeError(\`\${context} is not of type 'Static'.\`);
+  },
+
+  create(constructorArgs, privateData) {
+    let obj = Object.create(Static.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return obj;
+  },
+  createImpl(constructorArgs, privateData) {
+    let obj = Object.create(Static.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return utils.implForWrapper(obj);
+  },
+  _internalSetup(obj) {},
+  setup(obj, constructorArgs, privateData) {
+    if (!privateData) privateData = {};
+
+    privateData.wrapper = obj;
+
+    this._internalSetup(obj);
+    Object.defineProperty(obj, impl, {
+      value: new Impl.implementation(constructorArgs, privateData),
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
+
+    obj[impl][utils.wrapperSymbol] = obj;
+    if (Impl.init) {
+      Impl.init(obj[impl], privateData);
+    }
+    return obj;
+  },
+  interface: Static,
+  expose: {
+    Window: { Static }
+  }
+}; // iface
+module.exports = iface;
+
+const Impl = require(\\"../implementations/Static.js\\");
+"
+`;
+
 exports[`Storage.idl 1`] = `
 "\\"use strict\\";
 
@@ -4042,28 +4196,6 @@ Object.defineProperty(UnderscoredProperties, \\"prototype\\", {
   configurable: false
 });
 
-UnderscoredProperties.static = function _(_void) {
-  if (arguments.length < 1) {
-    throw new TypeError(
-      \\"Failed to execute 'static' on 'UnderscoredProperties': 1 \\" +
-        \\"argument required, but only \\" +
-        arguments.length +
-        \\" present.\\"
-    );
-  }
-
-  const args = [];
-  for (let i = 0; i < arguments.length && i < 1; ++i) {
-    args[i] = arguments[i];
-  }
-
-  args[0] = conversions[\\"DOMString\\"](args[0], {
-    context: \\"Failed to execute 'static' on 'UnderscoredProperties': parameter 1\\"
-  });
-
-  return Impl.static(...args);
-};
-
 UnderscoredProperties.prototype.operation = function operation(sequence) {
   if (!this || !module.exports.is(this)) {
     throw new TypeError(\\"Illegal invocation\\");
@@ -4101,6 +4233,28 @@ UnderscoredProperties.prototype.operation = function operation(sequence) {
   }
 
   return this[impl].operation(...args);
+};
+
+UnderscoredProperties.static = function _(_void) {
+  if (arguments.length < 1) {
+    throw new TypeError(
+      \\"Failed to execute 'static' on 'UnderscoredProperties': 1 \\" +
+        \\"argument required, but only \\" +
+        arguments.length +
+        \\" present.\\"
+    );
+  }
+
+  const args = [];
+  for (let i = 0; i < arguments.length && i < 1; ++i) {
+    args[i] = arguments[i];
+  }
+
+  args[0] = conversions[\\"DOMString\\"](args[0], {
+    context: \\"Failed to execute 'static' on 'UnderscoredProperties': parameter 1\\"
+  });
+
+  return Impl.static(...args);
 };
 
 Object.defineProperty(UnderscoredProperties.prototype, \\"attribute\\", {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1466,6 +1466,14 @@ StringifierNamedOperation.prototype.operation = function operation() {
   return this[impl].operation();
 };
 
+StringifierNamedOperation.prototype.toString = function toString() {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  return this[impl].operation();
+};
+
 Object.defineProperty(StringifierNamedOperation.prototype, Symbol.toStringTag, {
   value: \\"StringifierNamedOperation\\",
   writable: false,
@@ -4012,6 +4020,205 @@ const iface = {
 module.exports = iface;
 
 const Impl = require(\\"../implementations/URLSearchParamsCollection2.js\\");
+"
+`;
+
+exports[`UnderscoredProperties.idl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const impl = utils.implSymbol;
+
+function UnderscoredProperties() {
+  throw new TypeError(\\"Illegal constructor\\");
+}
+
+Object.defineProperty(UnderscoredProperties, \\"prototype\\", {
+  value: UnderscoredProperties.prototype,
+  writable: false,
+  enumerable: false,
+  configurable: false
+});
+
+UnderscoredProperties.static = function _(_void) {
+  if (arguments.length < 1) {
+    throw new TypeError(
+      \\"Failed to execute 'static' on 'UnderscoredProperties': 1 \\" +
+        \\"argument required, but only \\" +
+        arguments.length +
+        \\" present.\\"
+    );
+  }
+
+  const args = [];
+  for (let i = 0; i < arguments.length && i < 1; ++i) {
+    args[i] = arguments[i];
+  }
+
+  args[0] = conversions[\\"DOMString\\"](args[0], {
+    context: \\"Failed to execute 'static' on 'UnderscoredProperties': parameter 1\\"
+  });
+
+  return Impl.static(...args);
+};
+
+UnderscoredProperties.prototype.operation = function operation(sequence) {
+  if (!this || !module.exports.is(this)) {
+    throw new TypeError(\\"Illegal invocation\\");
+  }
+
+  if (arguments.length < 1) {
+    throw new TypeError(
+      \\"Failed to execute 'operation' on 'UnderscoredProperties': 1 \\" +
+        \\"argument required, but only \\" +
+        arguments.length +
+        \\" present.\\"
+    );
+  }
+
+  const args = [];
+  for (let i = 0; i < arguments.length && i < 1; ++i) {
+    args[i] = arguments[i];
+  }
+
+  if (!utils.isObject(args[0])) {
+    throw new TypeError(
+      \\"Failed to execute 'operation' on 'UnderscoredProperties': parameter 1\\" + \\" is not an iterable object.\\"
+    );
+  } else {
+    const V = [];
+    const tmp = args[0];
+    for (let nextItem of tmp) {
+      nextItem = conversions[\\"DOMString\\"](nextItem, {
+        context: \\"Failed to execute 'operation' on 'UnderscoredProperties': parameter 1\\" + \\"'s element\\"
+      });
+
+      V.push(nextItem);
+    }
+    args[0] = V;
+  }
+
+  return this[impl].operation(...args);
+};
+
+Object.defineProperty(UnderscoredProperties.prototype, \\"attribute\\", {
+  get() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"attribute\\"];
+  },
+
+  set(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"byte\\"](V, {
+      context: \\"Failed to set the 'attribute' property on 'UnderscoredProperties': The provided value\\"
+    });
+
+    this[impl][\\"attribute\\"] = V;
+  },
+
+  enumerable: true,
+  configurable: true
+});
+
+Object.defineProperty(UnderscoredProperties, \\"const\\", {
+  value: 42,
+  enumerable: true
+});
+Object.defineProperty(UnderscoredProperties.prototype, \\"const\\", {
+  value: 42,
+  enumerable: true
+});
+
+Object.defineProperty(UnderscoredProperties.prototype, Symbol.toStringTag, {
+  value: \\"UnderscoredProperties\\",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});
+
+const iface = {
+  mixedInto: [],
+  is(obj) {
+    if (obj) {
+      if (obj[impl] instanceof Impl.implementation) {
+        return true;
+      }
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (obj instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  isImpl(obj) {
+    if (obj) {
+      if (obj instanceof Impl.implementation) {
+        return true;
+      }
+
+      const wrapper = utils.wrapperForImpl(obj);
+      for (let i = 0; i < module.exports.mixedInto.length; ++i) {
+        if (wrapper instanceof module.exports.mixedInto[i]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  convert(obj, { context = \\"The provided value\\" } = {}) {
+    if (module.exports.is(obj)) {
+      return utils.implForWrapper(obj);
+    }
+    throw new TypeError(\`\${context} is not of type 'UnderscoredProperties'.\`);
+  },
+
+  create(constructorArgs, privateData) {
+    let obj = Object.create(UnderscoredProperties.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return obj;
+  },
+  createImpl(constructorArgs, privateData) {
+    let obj = Object.create(UnderscoredProperties.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return utils.implForWrapper(obj);
+  },
+  _internalSetup(obj) {},
+  setup(obj, constructorArgs, privateData) {
+    if (!privateData) privateData = {};
+
+    privateData.wrapper = obj;
+
+    this._internalSetup(obj);
+    Object.defineProperty(obj, impl, {
+      value: new Impl.implementation(constructorArgs, privateData),
+      writable: false,
+      enumerable: false,
+      configurable: true
+    });
+
+    obj[impl][utils.wrapperSymbol] = obj;
+    if (Impl.init) {
+      Impl.init(obj[impl], privateData);
+    }
+    return obj;
+  },
+  interface: UnderscoredProperties,
+  expose: {
+    Window: { UnderscoredProperties }
+  }
+}; // iface
+module.exports = iface;
+
+const Impl = require(\\"../implementations/UnderscoredProperties.js\\");
 "
 `;
 

--- a/test/cases/MixedIn.idl
+++ b/test/cases/MixedIn.idl
@@ -1,0 +1,6 @@
+interface MixedIn {
+  attribute DOMString mixedInAttr;
+            DOMString mixedInOp();
+  const     byte      mixedInConst = 43;
+};
+MixedIn implements Mixin;

--- a/test/cases/Mixin.idl
+++ b/test/cases/Mixin.idl
@@ -1,0 +1,7 @@
+[NoInterfaceObject]
+interface Mixin : MixinInherited {
+              DOMString mixinOp();
+  attribute   DOMString mixinAttr;
+  const       byte      mixinConst = 42;
+};
+Mixin implements MixinMixin;

--- a/test/cases/MixinInherited.idl
+++ b/test/cases/MixinInherited.idl
@@ -1,0 +1,6 @@
+[NoInterfaceObject]
+interface MixinInherited {
+  stringifier DOMString mixinInheritedOp();
+  attribute   DOMString mixinInheritedAttr;
+  const       byte      mixinInheritedConst = 42;
+};

--- a/test/cases/MixinMixin.idl
+++ b/test/cases/MixinMixin.idl
@@ -1,0 +1,6 @@
+[NoInterfaceObject]
+interface MixinMixin {
+              DOMString mixinMixinOp();
+  attribute   DOMString mixinMixinAttr;
+  const       byte      mixinMixinConst = 42;
+};

--- a/test/cases/Overloads.idl
+++ b/test/cases/Overloads.idl
@@ -1,0 +1,8 @@
+interface Overloads {
+  DOMString compatible(DOMString arg1);
+  byte compatible(DOMString arg1, DOMString arg2);
+  Promise<DOMString> compatible(DOMString arg1, DOMString arg2, optional long arg3 = 0);
+
+  DOMString incompatible(DOMString arg1);
+  byte incompatible(long arg1);
+};

--- a/test/cases/Static.idl
+++ b/test/cases/Static.idl
@@ -1,0 +1,6 @@
+interface Static {
+  static attribute DOMString abc;
+  attribute DOMString abc;
+  static DOMString def();
+  DOMString def();
+};

--- a/test/cases/UnderscoredProperties.idl
+++ b/test/cases/UnderscoredProperties.idl
@@ -5,3 +5,5 @@ interface _UnderscoredProperties {
   static void _static(DOMString _void);
   void _operation(sequence<DOMString> _sequence);
 };
+
+UnderscoredProperties implements _MixinMixin;

--- a/test/cases/UnderscoredProperties.idl
+++ b/test/cases/UnderscoredProperties.idl
@@ -1,0 +1,7 @@
+// https://heycam.github.io/webidl/#idl-names
+interface _UnderscoredProperties {
+  const byte _const = 42;
+  attribute byte _attribute;
+  static void _static(DOMString _void);
+  void _operation(sequence<DOMString> _sequence);
+};


### PR DESCRIPTION
This requires a change in jsdom to move idlUtils.mixin to jsdom, as it will no longer be needed or included in webidl2js. I could keep it in webidl2js for the time being however, until the next major bump.

Note, this does not yet fix https://github.com/jsdom/webidl2js/issues/55

Fixes #49.
Fixes #67.

