### PR TITLE
Fix access to implementation of static operations

### DIFF
--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -41,8 +41,8 @@ class Attribute {
 
     if (this.static) {
       brandCheck = "";
-      getterBody = `return Impl["${this.idl.name}"];`;
-      setterBody = `Impl["${this.idl.name}"] = V;`;
+      getterBody = `return Impl.implementation["${this.idl.name}"];`;
+      setterBody = `Impl.implementation["${this.idl.name}"] = V;`;
     } else if (shouldReflect) {
       if (!reflector[this.idl.idlType.idlType]) {
         throw new Error("Unknown reflector type: " + this.idl.idlType.idlType);

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -74,7 +74,7 @@ class Operation {
       `;
     }
 
-    const callOn = this.static ? "Impl" : "this[impl]";
+    const callOn = this.static ? "Impl.implementation" : "this[impl]";
     // In case of stringifiers, use the named implementation function rather than hardcoded "toString".
     // All overloads will have the same name, so pick the first one.
     const implFunc = this.idls[0].name || this.name;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1807,13 +1807,13 @@ Object.defineProperty(Static.prototype, \\"abc\\", {
 
 Object.defineProperty(Static, \\"abc\\", {
   get() {
-    return Impl[\\"abc\\"];
+    return Impl.implementation[\\"abc\\"];
   },
 
   set(V) {
     V = conversions[\\"DOMString\\"](V, { context: \\"Failed to set the 'abc' property on 'Static': The provided value\\" });
 
-    Impl[\\"abc\\"] = V;
+    Impl.implementation[\\"abc\\"] = V;
   },
 
   enumerable: true,

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1779,7 +1779,7 @@ Static.prototype.def = function def() {
 };
 
 Static.def = function def() {
-  return Impl.def();
+  return Impl.implementation.def();
 };
 
 Object.defineProperty(Static.prototype, \\"abc\\", {
@@ -5191,7 +5191,7 @@ UnderscoredProperties.static = function _(_void) {
     context: \\"Failed to execute 'static' on 'UnderscoredProperties': parameter 1\\"
   });
 
-  return Impl.static(...args);
+  return Impl.implementation.static(...args);
 };
 
 Object.defineProperty(UnderscoredProperties.prototype, \\"attribute\\", {


### PR DESCRIPTION
I ran into the error `Impl.escape is not a function` while implementing the following IDL:

```webidl
interface CSS {
  static CSSOMString escape(CSSOMString ident);
};
```

This pull request resolves the issue by using `Impl.implementation` rather than `Impl` directly. Given that I am not familiar with all parts of webidl2js, I'm not entirely convinced that this is the correct solution or merely one which obscures a larger issue.