### PR TITLE
Work around a webkit particularity

### DIFF
--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -332,7 +332,7 @@ class Interface {
       if (minConstructor.nameList.length !== 0) {
         const plural = minConstructor.nameList.length > 1 ? "s" : "";
         this.str += `
-          if (!new.target) {
+          if (new.target === undefined) {
             throw new TypeError("Failed to construct '${this.name}'. Please use the 'new' operator; this constructor " +
                                 "cannot be called as a function.");
           }

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -3535,7 +3535,7 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 
 function URL(url) {
-  if (!new.target) {
+  if (new.target === undefined) {
     throw new TypeError(
       \\"Failed to construct 'URL'. Please use the 'new' operator; this constructor \\" + \\"cannot be called as a function.\\"
     );


### PR DESCRIPTION
A version of webkit doesn't allow new.target after a prefix operator.

Fixes #78.