### PR TITLE
Track IDL and Impl directories using absolute paths in transformer.js

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -22,7 +22,7 @@ class Transformer {
       }
     });
 
-    this.sources = [];  // Absolute paths to the IDL and Impl directories.
+    this.sources = []; // Absolute paths to the IDL and Impl directories.
     this.utilPath = null;
   }
 
@@ -178,8 +178,7 @@ class Transformer {
       let source = obj.toString();
 
       const implDir = obj.opts.implDir.replace(/\\/g, "/"); // fix windows file paths
-      let implFile = path.relative(
-        outputDir, path.resolve(implDir, obj.name + this.ctx.implSuffix));
+      const implFile = path.relative(outputDir, path.resolve(implDir, obj.name + this.ctx.implSuffix));
 
       let relativeUtils = path.relative(outputDir, this.utilPath).replace(/\\/g, "/");
       if (relativeUtils[0] !== ".") {

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -177,8 +177,8 @@ class Transformer {
     for (const obj of interfaces.values()) {
       let source = obj.toString();
 
-      const implDir = obj.opts.implDir.replace(/\\/g, "/"); // fix windows file paths
-      let implFile = path.relative(outputDir, path.resolve(implDir, obj.name + this.ctx.implSuffix));
+      let implFile = path.relative(outputDir, path.resolve(obj.opts.implDir, obj.name + this.ctx.implSuffix));
+      implFile = implFile.replace(/\\/g, "/"); // fix windows file paths
       if (implFile[0] !== ".") {
         implFile = "./" + implFile;
       }

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -22,7 +22,7 @@ class Transformer {
       }
     });
 
-    this.sources = [];
+    this.sources = [];  // Absolute paths to the IDL and Impl directories.
     this.utilPath = null;
   }
 
@@ -33,7 +33,7 @@ class Transformer {
     if (typeof impl !== "string") {
       throw new TypeError("impl path has to be a string");
     }
-    this.sources.push({ idlPath: idl, impl });
+    this.sources.push({ idlPath: path.resolve(idl), impl: path.resolve(impl) });
     return this;
   }
 
@@ -93,7 +93,7 @@ class Transformer {
             }
 
             obj = new Interface(this.ctx, instruction, {
-              implDir: path.resolve(outputDir, file.impl)
+              implDir: file.impl
             });
             interfaces.set(obj.name, obj);
             customTypes.set(obj.name, "interface");
@@ -177,11 +177,9 @@ class Transformer {
     for (const obj of interfaces.values()) {
       let source = obj.toString();
 
-      const implDir = path.relative(outputDir, obj.opts.implDir).replace(/\\/g, "/"); // fix windows file paths
-      let implFile = implDir + "/" + obj.name + this.ctx.implSuffix;
-      if (implFile[0] !== ".") {
-        implFile = "./" + implFile;
-      }
+      const implDir = obj.opts.implDir.replace(/\\/g, "/"); // fix windows file paths
+      let implFile = path.relative(
+        outputDir, path.resolve(implDir, obj.name + this.ctx.implSuffix));
 
       let relativeUtils = path.relative(outputDir, this.utilPath).replace(/\\/g, "/");
       if (relativeUtils[0] !== ".") {

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -178,7 +178,10 @@ class Transformer {
       let source = obj.toString();
 
       const implDir = obj.opts.implDir.replace(/\\/g, "/"); // fix windows file paths
-      const implFile = path.relative(outputDir, path.resolve(implDir, obj.name + this.ctx.implSuffix));
+      let implFile = path.relative(outputDir, path.resolve(implDir, obj.name + this.ctx.implSuffix));
+      if (implFile[0] !== ".") {
+        implFile = "./" + implFile;
+      }
 
       let relativeUtils = path.relative(outputDir, this.utilPath).replace(/\\/g, "/");
       if (relativeUtils[0] !== ".") {


### PR DESCRIPTION
Convert IDL and Impl directories to absolute paths before using them in addSource() and generate() as a fix for #80.

Ran npm test and everything passes.