### PR TITLE
Update dependencies

### DIFF
--- a/lib/constructs/constant.js
+++ b/lib/constructs/constant.js
@@ -14,11 +14,11 @@ class Constant {
   generate() {
     const body = `
       Object.defineProperty(${this.interface.name}, "${this.idl.name}", {
-        value: ${JSON.stringify(this.idl.value.value)},
+        value: ${utils.getDefault(this.idl.value)},
         enumerable: true
       });
       Object.defineProperty(${this.interface.name}.prototype, "${this.idl.name}", {
-        value: ${JSON.stringify(this.idl.value.value)},
+        value: ${utils.getDefault(this.idl.value)},
         enumerable: true
       });
     `;

--- a/lib/constructs/enumeration.js
+++ b/lib/constructs/enumeration.js
@@ -9,7 +9,7 @@ class Enumeration {
   }
 
   generate() {
-    const values = new Set(this.idl.values);
+    const values = new Set(this.idl.values.map(val => val.value));
     if (values.size !== this.idl.values.length) {
       throw new Error(`Duplicates found in ${this.name}'s enumeration values`);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,9 +3,10 @@
 function getDefault(dflt) {
   switch (dflt.type) {
     case "boolean":
-    case "number":
     case "string":
       return JSON.stringify(dflt.value);
+    case "number":
+      return dflt.value;
     case "null":
     case "NaN":
       return dflt.type;

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "pn": "^1.0.0",
     "prettier": "^1.5.3",
     "webidl-conversions": "^4.0.0",
-    "webidl2": "^4.1.0"
+    "webidl2": "^8.1.0"
   },
   "devDependencies": {
     "eslint": "^4.3.0",
-    "jest": "^20.0.4"
+    "jest": "^21.2.1"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
webidl2.js has dropped official support for Node.js v6.x in v8.0.0 (which we still want to support), but it still fully works with it (as shown by our test suite). Let's wait until https://github.com/w3c/webidl2.js/pull/102#issuecomment-343706702 is resolved before this is merged.