### PR TITLE
Remove unnecessary usage of suppressErrors

### DIFF
--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -58,17 +58,16 @@ class Interface {
             msg += ` (defined in ${member.definingInterface})`;
           }
           msg += ": ";
-          if (member.arguments.length < 1 ||
-              (!this.ctx.options.suppressErrors && member.arguments.length !== 1)) {
+          if (member.arguments.length !== 1) {
             throw new Error(msg + `1 argument should be present, found ${member.arguments.length}`);
           }
           if (isIndexed(member)) {
-            if (!this.ctx.options.suppressErrors && this.indexedGetter) {
+            if (this.indexedGetter) {
               throw new Error(msg + "duplicated indexed getter");
             }
             this.indexedGetter = member;
           } else if (isNamed(member)) {
-            if (!this.ctx.options.suppressErrors && this.namedGetter) {
+            if (this.namedGetter) {
               throw new Error(msg + "duplicated named getter");
             }
             this.namedGetter = member;
@@ -83,17 +82,16 @@ class Interface {
           }
           msg += ": ";
 
-          if (member.arguments.length < 2 ||
-              (!this.ctx.options.suppressErrors && member.arguments.length !== 2)) {
+          if (member.arguments.length !== 2) {
             throw new Error(msg + `2 arguments should be present, found ${member.arguments.length}`);
           }
           if (isIndexed(member)) {
-            if (!this.ctx.options.suppressErrors && this.indexedSetter) {
+            if (this.indexedSetter) {
               throw new Error(msg + "duplicated indexed setter");
             }
             this.indexedSetter = member;
           } else if (isNamed(member)) {
-            if (!this.ctx.options.suppressErrors && this.namedSetter) {
+            if (this.namedSetter) {
               throw new Error(msg + "duplicated named setter");
             }
             this.namedSetter = member;
@@ -108,12 +106,11 @@ class Interface {
           }
           msg += ": ";
 
-          if (member.arguments.length < 1 ||
-              (!this.ctx.options.suppressErrors && member.arguments.length !== 1)) {
+          if (member.arguments.length !== 1) {
             throw new Error(msg + `1 arguments should be present, found ${member.arguments.length}`);
           }
           if (isNamed(member)) {
-            if (!this.ctx.options.suppressErrors && this.namedDeleter) {
+            if (this.namedDeleter) {
               throw new Error(msg + "duplicated named deleter");
             }
             this.namedDeleter = member;
@@ -172,16 +169,14 @@ class Interface {
           if (!member.arguments) {
             member.arguments = [];
           }
-          if (!this.ctx.options.suppressErrors) {
-            if (member.arguments.length > 0) {
-              throw new Error(msg + "takes more than zero arguments");
-            }
-            if (member.idlType.idlType !== "DOMString" || member.idlType.nullable) {
-              throw new Error(msg + "returns something other than a plain DOMString");
-            }
-            if (this.stringifier) {
-              throw new Error(msg + "duplicated stringifier");
-            }
+          if (member.arguments.length > 0) {
+            throw new Error(msg + "takes more than zero arguments");
+          }
+          if (member.idlType.idlType !== "DOMString" || member.idlType.nullable) {
+            throw new Error(msg + "returns something other than a plain DOMString");
+          }
+          if (this.stringifier) {
+            throw new Error(msg + "duplicated stringifier");
           }
           const op = new Operation(this.ctx, this, member);
           op.name = "toString";
@@ -190,11 +185,9 @@ class Interface {
           if (member.static) {
             throw new Error(msg + "keyword cannot be placed on static attribute");
           }
-          if (!this.ctx.options.suppressErrors) {
-            if (member.idlType.idlType !== "DOMString" && member.idlType.idlType !== "USVString" ||
-                member.idlType.nullable) {
-              throw new Error(msg + "attribute can only be of type DOMString or USVString");
-            }
+          if (member.idlType.idlType !== "DOMString" && member.idlType.idlType !== "USVString" ||
+              member.idlType.nullable) {
+            throw new Error(msg + "attribute can only be of type DOMString or USVString");
           }
           // Implemented in Attribute class.
         } else {


### PR DESCRIPTION
`suppressErrors` is only intended to be used to suppress errors related to missing interface definitions, not a get-out-of-jail-free card for all situations.