### PR TITLE
Provide polyfill for Object.getOwnPropertyDescriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ It is often useful for implementation class files to inherit from each other, if
 
 However, it is not required! The wrapper classes will have a correct inheritance chain, regardless of the implementation class inheritance chain. Just make sure that, either via inheritance or manual implementation, you implement all of the expected operations and attributes.
 
+### Other requirements
+
+The generated interface wrapper files use modern JavaScript features such as `class` definitions and `Proxy`. They will not work on JavaScript runtimes that do not support the ECMAScript 2015 standard.
+
 ## The generated utilities file
 
 Along with the generated wrapper class files, webidl2js will also generate a utilities file, `utils.js`, in the same directory. (We may make the name less generic; see [#52](https://github.com/jsdom/webidl2js/issues/52) for this and other concerns.) This contains several functions for converting between wrapper and implementation classes.

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -1414,7 +1414,7 @@ class Interface {
       this.str += `
         Object.defineProperties(
           obj,
-          Object.getOwnPropertyDescriptors({ ${methods.join(", ")} })
+          utils.getOwnPropertyDescriptors({ ${methods.join(", ")} })
         );
       `;
     }

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -9,6 +9,30 @@ function hasOwn(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
+const getOwnPropertyDescriptors = typeof Object.getOwnPropertyDescriptors === "function" ?
+  Object.getOwnPropertyDescriptors :
+  // Polyfill exists before we require Node.js v6.x
+  // https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptors
+  obj => {
+    if (obj === undefined || obj === null) {
+      throw new TypeError("Cannot convert undefined or null to object");
+    }
+    const ownKeys = Reflect.ownKeys(obj);
+    const descriptors = {};
+    for (const key of ownKeys) {
+      const descriptor = Object.getOwnPropertyDescriptor(obj, key);
+      if (descriptor !== undefined) {
+        Object.defineProperty(descriptors, key, {
+          value: descriptor,
+          writable: true,
+          enumerable: true,
+          configurable: true
+        });
+      }
+    }
+    return descriptors;
+  };
+
 const wrapperSymbol = Symbol("wrapper");
 const implSymbol = Symbol("impl");
 const sameObjectCaches = Symbol("SameObject caches");
@@ -77,6 +101,7 @@ const namedDelete = Symbol("named property delete");
 module.exports = exports = {
   isObject,
   hasOwn,
+  getOwnPropertyDescriptors,
   wrapperSymbol,
   implSymbol,
   getSameObject,

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -11,18 +11,19 @@ function hasOwn(obj, prop) {
 
 const getOwnPropertyDescriptors = typeof Object.getOwnPropertyDescriptors === "function" ?
   Object.getOwnPropertyDescriptors :
-  // Polyfill exists before we require Node.js v6.x
+  // Polyfill exists until we require Node.js v8.x
   // https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptors
   obj => {
     if (obj === undefined || obj === null) {
       throw new TypeError("Cannot convert undefined or null to object");
     }
+    obj = Object(obj);
     const ownKeys = Reflect.ownKeys(obj);
     const descriptors = {};
     for (const key of ownKeys) {
-      const descriptor = Object.getOwnPropertyDescriptor(obj, key);
+      const descriptor = Reflect.getOwnPropertyDescriptor(obj, key);
       if (descriptor !== undefined) {
-        Object.defineProperty(descriptors, key, {
+        Reflect.defineProperty(descriptors, key, {
           value: descriptor,
           writable: true,
           enumerable: true,

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -542,7 +542,7 @@ const iface = {
   _internalSetup(obj) {
     Object.defineProperties(
       obj,
-      Object.getOwnPropertyDescriptors({
+      utils.getOwnPropertyDescriptors({
         op() {
           if (!this || !module.exports.is(this)) {
             throw new TypeError(\\"Illegal invocation\\");
@@ -5967,7 +5967,7 @@ const iface = {
   _internalSetup(obj) {
     Object.defineProperties(
       obj,
-      Object.getOwnPropertyDescriptors({
+      utils.getOwnPropertyDescriptors({
         assign(url) {
           if (!this || !module.exports.is(this)) {
             throw new TypeError(\\"Illegal invocation\\");
@@ -6147,7 +6147,7 @@ const iface = {
   _internalSetup(obj) {
     Object.defineProperties(
       obj,
-      Object.getOwnPropertyDescriptors({
+      utils.getOwnPropertyDescriptors({
         get a() {
           if (!this || !module.exports.is(this)) {
             throw new TypeError(\\"Illegal invocation\\");


### PR DESCRIPTION
We still support Node.js v6.x, which does not have `Object.getOwnPropertyDescriptors()`.