### PR TITLE
Use [Unscopable] extended attribute from mixins

### DIFF
--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -1251,7 +1251,7 @@ class Interface {
     });
 
     const unscopables = Object.create(null);
-    for (const member of this.idl.members) {
+    for (const member of this.members()) {
       if (utils.getExtAttr(member.extAttrs, "Unscopable")) {
         unscopables[member.name] = true;
       }

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -6430,11 +6430,32 @@ class Unscopable {
 
     this[impl][\\"unscopableTest\\"] = V;
   }
+
+  get unscopableMixin() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"unscopableMixin\\"];
+  }
+
+  set unscopableMixin(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"boolean\\"](V, {
+      context: \\"Failed to set the 'unscopableMixin' property on 'Unscopable': The provided value\\"
+    });
+
+    this[impl][\\"unscopableMixin\\"] = V;
+  }
 }
 Object.defineProperties(Unscopable.prototype, {
   unscopableTest: { enumerable: true },
+  unscopableMixin: { enumerable: true },
   [Symbol.toStringTag]: { value: \\"Unscopable\\", configurable: true },
-  [Symbol.unscopables]: { value: { unscopableTest: true }, configurable: true }
+  [Symbol.unscopables]: { value: { unscopableTest: true, unscopableMixin: true }, configurable: true }
 });
 const iface = {
   // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`

--- a/test/cases/Unscopable.webidl
+++ b/test/cases/Unscopable.webidl
@@ -1,3 +1,8 @@
 interface Unscopable {
   [Unscopable] attribute boolean unscopableTest;
 };
+Unscopable includes UnscopableMixin;
+
+interface mixin UnscopableMixin {
+  [Unscopable] attribute boolean unscopableMixin;
+};


### PR DESCRIPTION
I saw that jsdom was failing the test [remove-unscopable.html](https://github.com/web-platform-tests/wpt/blob/master/dom/nodes/remove-unscopable.html) since only the `[Unscopable]` extended attribute of the current interface would be part of the output. With this change, mixins with properties using `[Unscopable]` will be taken into account as well.