### PR TITLE
chore(package): update webidl2

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,9 @@ webidl2js is implementing an ever-growing subset of the Web IDL specification. S
 - `FrozenArray<>` types
 - `typedef`s
 - Partial interfaces and dictionaries
+- Interface mixins
 - Basic types (via [webidl-conversions][])
-- Mixins, i.e. `implements`
+- Old-style mixins, i.e. `implements`
 - Overload resolution (although [tricky cases are not easy on the implementation class](#overloaded-operations))
 - Variadic arguments
 - `[Clamp]`

--- a/lib/constructs/interface-mixin.js
+++ b/lib/constructs/interface-mixin.js
@@ -1,0 +1,13 @@
+"use strict";
+
+class InterfaceMixin {
+  constructor(ctx, idl) {
+    this.ctx = ctx;
+    this.idl = idl;
+    this.name = idl.name;
+  }
+}
+
+InterfaceMixin.prototype.type = "interface mixin";
+
+module.exports = InterfaceMixin;

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -74,7 +74,8 @@ class Interface {
     this.str = null;
     this.opts = opts;
     this.requires = new utils.RequiresMap(ctx);
-    this.mixins = [];
+    this.implemented = [];
+    this.included = [];
 
     this.operations = new Map();
     this.staticOperations = new Map();
@@ -386,10 +387,22 @@ class Interface {
       if (this.ctx.options.suppressErrors) {
         return;
       }
-      throw new Error(`${source} interface not found (used as a mixin for ${this.name})`);
+      throw new Error(`${source} interface not found (implemented by ${this.name})`);
     }
 
-    this.mixins.push(source);
+    this.implemented.push(source);
+  }
+
+  includes(source) {
+    const mixin = this.ctx.interfaceMixins.get(source);
+    if (!mixin) {
+      if (this.ctx.options.suppressErrors) {
+        return;
+      }
+      throw new Error(`${source} interface mixin not found (included in ${this.name})`);
+    }
+
+    this.included.push(source);
   }
 
   generateIterator() {
@@ -439,12 +452,12 @@ class Interface {
 
   // https://heycam.github.io/webidl/#dfn-consequential-interfaces
   * consequentialInterfaces(seen = new Set([this.name]), root = this.name) {
-    for (const mixin of this.mixins) {
-      if (seen.has(mixin)) {
+    for (const iface of this.implemented) {
+      if (seen.has(iface)) {
         throw new Error(`${root} has a dependency cycle`);
       }
-      seen.add(mixin);
-      yield* this.ctx.interfaces.get(mixin).allInterfaces(seen);
+      seen.add(iface);
+      yield* this.ctx.interfaces.get(iface).allInterfaces(seen);
     }
   }
 
@@ -465,8 +478,11 @@ class Interface {
   // interface and its consequential interfaces.
   * members(seen = new Set([this.name]), root = this.name) {
     yield* this.idl.members;
-    for (const mixin of this.consequentialInterfaces(seen, root)) {
-      yield* this.ctx.interfaces.get(mixin).idl.members;
+    for (const mixin of this.included) {
+      yield* this.ctx.interfaceMixins.get(mixin).idl.members;
+    }
+    for (const iface of this.consequentialInterfaces(seen, root)) {
+      yield* this.ctx.interfaces.get(iface).idl.members;
     }
   }
 
@@ -482,6 +498,9 @@ class Interface {
   }
 
   * allMembers(seen = new Set([this.name]), root = this.name) {
+    for (const mixin of this.included) {
+      yield* this.ctx.interfaceMixins.get(mixin).idl.members;
+    }
     for (const iface of this.allInterfaces(seen, root)) {
       yield* this.ctx.interfaces.get(iface).idl.members;
     }
@@ -494,8 +513,8 @@ class Interface {
       this.requires.add(this.idl.inheritance);
     }
 
-    for (const mixin of this.consequentialInterfaces()) {
-      this.requires.add(mixin);
+    for (const iface of this.consequentialInterfaces()) {
+      this.requires.add(iface);
     }
 
     this.str = `
@@ -506,9 +525,9 @@ class Interface {
   }
 
   generateMixins() {
-    for (const mixin of this.consequentialInterfaces()) {
+    for (const iface of this.consequentialInterfaces()) {
       this.str += `
-        ${mixin}._mixedIntoPredicates.push(module.exports.is);
+        ${iface}._mixedIntoPredicates.push(module.exports.is);
       `;
     }
   }

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -1232,7 +1232,7 @@ class Interface {
     });
 
     const unscopables = Object.create(null);
-    for (const member of this.idl.members) {
+    for (const member of this.members()) {
       if (utils.getExtAttr(member.extAttrs, "Unscopable")) {
         unscopables[member.name] = true;
       }

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -28,11 +28,10 @@ class Operation {
   fixUpArgsExtAttrs() {
     for (const idl of this.idls) {
       for (const arg of idl.arguments) {
-        if (arg.extAttrs) {
-          if (!arg.idlType.extAttrs) {
-            arg.idlType.extAttrs = [];
-          }
-          arg.idlType.extAttrs.push(...arg.extAttrs);
+        if (arg.extAttrs.length) {
+          // Overwrite rather than push to workaround old webidl2 array-sharing bug
+          // It's safe as the two cannot coexist.
+          arg.idlType.extAttrs = [...arg.extAttrs];
         }
       }
     }

--- a/lib/context.js
+++ b/lib/context.js
@@ -20,6 +20,7 @@ class Context {
   initialize() {
     this.typedefs = new Map();
     this.interfaces = new Map();
+    this.interfaceMixins = new Map();
     this.dictionaries = new Map();
     this.enumerations = new Map();
 

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -10,6 +10,7 @@ const prettier = require("prettier");
 const Context = require("./context");
 const Typedef = require("./constructs/typedef");
 const Interface = require("./constructs/interface");
+const InterfaceMixin = require("./constructs/interface-mixin");
 const Dictionary = require("./constructs/dictionary");
 const Enumeration = require("./constructs/enumeration");
 
@@ -80,7 +81,7 @@ class Transformer {
     }));
 
     this.ctx.initialize();
-    const { interfaces, dictionaries, enumerations, typedefs } = this.ctx;
+    const { interfaces, interfaceMixins, dictionaries, enumerations, typedefs } = this.ctx;
 
     // first we're gathering all full interfaces and ignore partial ones
     for (const file of parsed) {
@@ -97,7 +98,16 @@ class Transformer {
             });
             interfaces.set(obj.name, obj);
             break;
+          case "interface mixin":
+            if (instruction.partial) {
+              break;
+            }
+
+            obj = new InterfaceMixin(this.ctx, instruction);
+            interfaceMixins.set(obj.name, obj);
+            break;
           case "implements":
+          case "includes":
             break; // handled later
           case "dictionary":
             if (instruction.partial) {
@@ -123,7 +133,7 @@ class Transformer {
       }
     }
 
-    // second we add all partial members and handle implements
+    // second we add all partial members and handle implements/includes
     for (const file of parsed) {
       for (const instruction of file.idl) {
         let oldMembers;
@@ -140,6 +150,19 @@ class Transformer {
             oldMembers = interfaces.get(instruction.name).idl.members;
             oldMembers.push(...instruction.members);
             extAttrs = interfaces.get(instruction.name).idl.extAttrs;
+            extAttrs.push(...instruction.extAttrs);
+            break;
+          case "interface mixin":
+            if (!instruction.partial) {
+              break;
+            }
+
+            if (this.ctx.options.suppressErrors && !interfaceMixins.has(instruction.name)) {
+              break;
+            }
+            oldMembers = interfaceMixins.get(instruction.name).idl.members;
+            oldMembers.push(...instruction.members);
+            extAttrs = interfaceMixins.get(instruction.name).idl.extAttrs;
             extAttrs.push(...instruction.extAttrs);
             break;
           case "dictionary":
@@ -159,6 +182,12 @@ class Transformer {
               break;
             }
             interfaces.get(instruction.target).implements(instruction.implements);
+            break;
+          case "includes":
+            if (this.ctx.options.suppressErrors && !interfaces.has(instruction.target)) {
+              break;
+            }
+            interfaces.get(instruction.target).includes(instruction.includes);
             break;
         }
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pn": "^1.1.0",
     "prettier": "^1.14.0",
     "webidl-conversions": "^4.0.0",
-    "webidl2": "10.3.0"
+    "webidl2": "^10.3.3"
   },
   "devDependencies": {
     "eslint": "^4.13.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pn": "^1.1.0",
     "prettier": "^1.14.0",
     "webidl-conversions": "^4.0.0",
-    "webidl2": "^9.0.0"
+    "webidl2": "10.3.0"
   },
   "devDependencies": {
     "eslint": "^4.13.1",

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -991,6 +991,14 @@ class MixedIn {
     return this[impl].mixedInOp();
   }
 
+  ifaceMixinOp() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl].ifaceMixinOp();
+  }
+
   mixinOp() {
     if (!this || !module.exports.is(this)) {
       throw new TypeError(\\"Illegal invocation\\");
@@ -1041,6 +1049,26 @@ class MixedIn {
     });
 
     this[impl][\\"mixedInAttr\\"] = V;
+  }
+
+  get ifaceMixinAttr() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"ifaceMixinAttr\\"];
+  }
+
+  set ifaceMixinAttr(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"DOMString\\"](V, {
+      context: \\"Failed to set the 'ifaceMixinAttr' property on 'MixedIn': The provided value\\"
+    });
+
+    this[impl][\\"ifaceMixinAttr\\"] = V;
   }
 
   get mixinAttr() {
@@ -1105,22 +1133,26 @@ class MixedIn {
 }
 Object.defineProperties(MixedIn.prototype, {
   mixedInOp: { enumerable: true },
+  ifaceMixinOp: { enumerable: true },
   mixinOp: { enumerable: true },
   mixinMixinOp: { enumerable: true },
   mixinInheritedOp: { enumerable: true },
   toString: { enumerable: true },
   mixedInAttr: { enumerable: true },
+  ifaceMixinAttr: { enumerable: true },
   mixinAttr: { enumerable: true },
   mixinMixinAttr: { enumerable: true },
   mixinInheritedAttr: { enumerable: true },
   [Symbol.toStringTag]: { value: \\"MixedIn\\", configurable: true },
   mixedInConst: { value: 43, enumerable: true },
+  ifaceMixinConst: { value: 42, enumerable: true },
   mixinConst: { value: 42, enumerable: true },
   mixinMixinConst: { value: 42, enumerable: true },
   mixinInheritedConst: { value: 42, enumerable: true }
 });
 Object.defineProperties(MixedIn, {
   mixedInConst: { value: 43, enumerable: true },
+  ifaceMixinConst: { value: 42, enumerable: true },
   mixinConst: { value: 42, enumerable: true },
   mixinMixinConst: { value: 42, enumerable: true },
   mixinInheritedConst: { value: 42, enumerable: true }

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,5 +1,214 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DOMImplementation.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const impl = utils.implSymbol;
+
+class DOMImplementation {
+  constructor() {
+    throw new TypeError(\\"Illegal constructor\\");
+  }
+
+  createDocumentType(qualifiedName, publicId, systemId) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    if (arguments.length < 3) {
+      throw new TypeError(
+        \\"Failed to execute 'createDocumentType' on 'DOMImplementation': 3 arguments required, but only \\" +
+          arguments.length +
+          \\" present.\\"
+      );
+    }
+    const args = [];
+    {
+      let curArg = arguments[0];
+      curArg = conversions[\\"DOMString\\"](curArg, {
+        context: \\"Failed to execute 'createDocumentType' on 'DOMImplementation': parameter 1\\"
+      });
+      args.push(curArg);
+    }
+    {
+      let curArg = arguments[1];
+      curArg = conversions[\\"DOMString\\"](curArg, {
+        context: \\"Failed to execute 'createDocumentType' on 'DOMImplementation': parameter 2\\"
+      });
+      args.push(curArg);
+    }
+    {
+      let curArg = arguments[2];
+      curArg = conversions[\\"DOMString\\"](curArg, {
+        context: \\"Failed to execute 'createDocumentType' on 'DOMImplementation': parameter 3\\"
+      });
+      args.push(curArg);
+    }
+    return utils.tryWrapperForImpl(this[impl].createDocumentType(...args));
+  }
+
+  createDocument(namespace, qualifiedName) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    if (arguments.length < 2) {
+      throw new TypeError(
+        \\"Failed to execute 'createDocument' on 'DOMImplementation': 2 arguments required, but only \\" +
+          arguments.length +
+          \\" present.\\"
+      );
+    }
+    const args = [];
+    {
+      let curArg = arguments[0];
+      if (curArg === null || curArg === undefined) {
+        curArg = null;
+      } else {
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'createDocument' on 'DOMImplementation': parameter 1\\"
+        });
+      }
+      args.push(curArg);
+    }
+    {
+      let curArg = arguments[1];
+      curArg = conversions[\\"DOMString\\"](curArg, {
+        context: \\"Failed to execute 'createDocument' on 'DOMImplementation': parameter 2\\",
+        treatNullAsEmptyString: true
+      });
+      args.push(curArg);
+    }
+    {
+      let curArg = arguments[2];
+      if (curArg !== undefined) {
+        if (curArg === null || curArg === undefined) {
+          curArg = null;
+        } else {
+          curArg = utils.tryImplForWrapper(curArg);
+        }
+      } else {
+        curArg = null;
+      }
+      args.push(curArg);
+    }
+    return utils.tryWrapperForImpl(this[impl].createDocument(...args));
+  }
+
+  createHTMLDocument() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+    const args = [];
+    {
+      let curArg = arguments[0];
+      if (curArg !== undefined) {
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'createHTMLDocument' on 'DOMImplementation': parameter 1\\"
+        });
+      }
+      args.push(curArg);
+    }
+    return utils.tryWrapperForImpl(this[impl].createHTMLDocument(...args));
+  }
+
+  hasFeature() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl].hasFeature();
+  }
+}
+Object.defineProperties(DOMImplementation.prototype, {
+  createDocumentType: { enumerable: true },
+  createDocument: { enumerable: true },
+  createHTMLDocument: { enumerable: true },
+  hasFeature: { enumerable: true },
+  [Symbol.toStringTag]: { value: \\"DOMImplementation\\", configurable: true }
+});
+const iface = {
+  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+  // implementing this mixin interface.
+  _mixedIntoPredicates: [],
+  is(obj) {
+    if (obj) {
+      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+        return true;
+      }
+      for (const isMixedInto of module.exports._mixedIntoPredicates) {
+        if (isMixedInto(obj)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  isImpl(obj) {
+    if (obj) {
+      if (obj instanceof Impl.implementation) {
+        return true;
+      }
+
+      const wrapper = utils.wrapperForImpl(obj);
+      for (const isMixedInto of module.exports._mixedIntoPredicates) {
+        if (isMixedInto(wrapper)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  convert(obj, { context = \\"The provided value\\" } = {}) {
+    if (module.exports.is(obj)) {
+      return utils.implForWrapper(obj);
+    }
+    throw new TypeError(\`\${context} is not of type 'DOMImplementation'.\`);
+  },
+
+  create(constructorArgs, privateData) {
+    let obj = Object.create(DOMImplementation.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return obj;
+  },
+  createImpl(constructorArgs, privateData) {
+    let obj = Object.create(DOMImplementation.prototype);
+    obj = this.setup(obj, constructorArgs, privateData);
+    return utils.implForWrapper(obj);
+  },
+  _internalSetup(obj) {},
+  setup(obj, constructorArgs, privateData) {
+    if (!privateData) privateData = {};
+
+    privateData.wrapper = obj;
+
+    this._internalSetup(obj);
+    Object.defineProperty(obj, impl, {
+      value: new Impl.implementation(constructorArgs, privateData),
+      configurable: true
+    });
+
+    obj[impl][utils.wrapperSymbol] = obj;
+    if (Impl.init) {
+      Impl.init(obj[impl], privateData);
+    }
+    return obj;
+  },
+  interface: DOMImplementation,
+  expose: {
+    Window: { DOMImplementation }
+  }
+}; // iface
+module.exports = iface;
+
+const Impl = require(\\"../implementations/DOMImplementation.js\\");
+"
+`;
+
 exports[`Dictionary.webidl 1`] = `
 "\\"use strict\\";
 

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -6607,11 +6607,32 @@ class Unscopable {
 
     this[impl][\\"unscopableTest\\"] = V;
   }
+
+  get unscopableMixin() {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    return this[impl][\\"unscopableMixin\\"];
+  }
+
+  set unscopableMixin(V) {
+    if (!this || !module.exports.is(this)) {
+      throw new TypeError(\\"Illegal invocation\\");
+    }
+
+    V = conversions[\\"boolean\\"](V, {
+      context: \\"Failed to set the 'unscopableMixin' property on 'Unscopable': The provided value\\"
+    });
+
+    this[impl][\\"unscopableMixin\\"] = V;
+  }
 }
 Object.defineProperties(Unscopable.prototype, {
   unscopableTest: { enumerable: true },
+  unscopableMixin: { enumerable: true },
   [Symbol.toStringTag]: { value: \\"Unscopable\\", configurable: true },
-  [Symbol.unscopables]: { value: { unscopableTest: true }, configurable: true }
+  [Symbol.unscopables]: { value: { unscopableTest: true, unscopableMixin: true }, configurable: true }
 });
 const iface = {
   // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`

--- a/test/cases/DOMImplementation.webidl
+++ b/test/cases/DOMImplementation.webidl
@@ -1,0 +1,8 @@
+[Exposed=Window]
+interface DOMImplementation {
+  [NewObject] DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
+  [NewObject] XMLDocument createDocument(DOMString? namespace, [TreatNullAs=EmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
+  [NewObject] Document createHTMLDocument(optional DOMString title);
+
+  boolean hasFeature(); // useless; always returns true
+};

--- a/test/cases/MixedIn.webidl
+++ b/test/cases/MixedIn.webidl
@@ -4,3 +4,13 @@ interface MixedIn {
   const     byte      mixedInConst = 43;
 };
 MixedIn implements Mixin;
+MixedIn includes InterfaceMixin;
+
+partial interface mixin InterfaceMixin {
+  const       byte      ifaceMixinConst = 42;
+};
+
+interface mixin InterfaceMixin {
+              DOMString ifaceMixinOp();
+  attribute   DOMString ifaceMixinAttr;
+};

--- a/test/cases/Unscopable.webidl
+++ b/test/cases/Unscopable.webidl
@@ -1,3 +1,8 @@
 interface Unscopable {
   [Unscopable] attribute boolean unscopableTest;
 };
+Unscopable includes UnscopableMixin;
+
+interface mixin UnscopableMixin {
+  [Unscopable] attribute boolean unscopableMixin;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3489,9 +3489,9 @@ webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
-webidl2@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-9.0.0.tgz#82686b0ffab2dc94874a0bf162d9637be471cb7f"
+webidl2@^10.3.1:
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-10.3.1.tgz#4982fdb80847547b704396e009198efdc176fdd2"
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
~~Found that 10.3.0 doesn't break JSDOM while 10.3.1+ does.~~

Fixed the breakage faced in jsdom/jsdom#2443 so it's now safe to update to 10.3.1+.