### PR TITLE
Only reflect attributes without a namespace

### DIFF
--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -51,8 +51,8 @@ class Attribute {
         throw new Error("Unknown reflector type: " + this.idl.idlType.idlType);
       }
       const attrName = shouldReflect.rhs && shouldReflect.rhs.value.replace(/_/g, "-") || this.idl.name;
-      getterBody = reflector[this.idl.idlType.idlType].get(objName, attrName);
-      setterBody = reflector[this.idl.idlType.idlType].set(objName, attrName);
+      getterBody = reflector[this.idl.idlType.idlType].get(objName, attrName.toLowerCase());
+      setterBody = reflector[this.idl.idlType.idlType].set(objName, attrName.toLowerCase());
     }
 
     if (utils.getExtAttr(this.idl.extAttrs, "LenientThis")) {

--- a/lib/reflector.js
+++ b/lib/reflector.js
@@ -2,14 +2,14 @@
 
 module.exports.boolean = {
   get(objName, attrName) {
-    return `return this.hasAttribute("${attrName}");`;
+    return `return this.hasAttributeNS(null, "${attrName}");`;
   },
   set(objName, attrName) {
     return `
       if (V) {
-        this.setAttribute("${attrName}", "");
+        this.setAttributeNS(null, "${attrName}", "");
       } else {
-        this.removeAttribute("${attrName}");
+        this.removeAttributeNS(null, "${attrName}");
       }
     `;
   }
@@ -18,35 +18,35 @@ module.exports.boolean = {
 module.exports.DOMString = {
   get(objName, attrName) {
     return `
-      const value = this.getAttribute("${attrName}");
+      const value = this.getAttributeNS(null, "${attrName}");
       return value === null ? "" : value;
     `;
   },
   set(objName, attrName) {
-    return `this.setAttribute("${attrName}", V);`;
+    return `this.setAttributeNS(null, "${attrName}", V);`;
   }
 };
 
 module.exports.long = {
   get(objName, attrName) {
     return `
-      const value = parseInt(this.getAttribute("${attrName}"));
+      const value = parseInt(this.getAttributeNS(null, "${attrName}"));
       return isNaN(value) || value < -2147483648 || value > 2147483647 ? 0 : value
     `;
   },
   set(objName, attrName) {
-    return `this.setAttribute("${attrName}", String(V));`;
+    return `this.setAttributeNS(null, "${attrName}", String(V));`;
   }
 };
 
 module.exports["unsigned long"] = {
   get(objName, attrName) {
     return `
-      const value = parseInt(this.getAttribute("${attrName}"));
+      const value = parseInt(this.getAttributeNS(null, "${attrName}"));
       return isNaN(value) || value < 0 || value > 2147483647 ? 0 : value
     `;
   },
   set(objName, attrName) {
-    return `this.setAttribute("${attrName}", String(V > 2147483647 ? 0 : V));`;
+    return `this.setAttributeNS(null, "${attrName}", String(V > 2147483647 ? 0 : V));`;
   }
 };

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -2236,7 +2236,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    return this.hasAttribute(\\"ReflectedBoolean\\");
+    return this.hasAttributeNS(null, \\"reflectedboolean\\");
   }
 
   set ReflectedBoolean(V) {
@@ -2249,9 +2249,9 @@ class Reflect {
     });
 
     if (V) {
-      this.setAttribute(\\"ReflectedBoolean\\", \\"\\");
+      this.setAttributeNS(null, \\"reflectedboolean\\", \\"\\");
     } else {
-      this.removeAttribute(\\"ReflectedBoolean\\");
+      this.removeAttributeNS(null, \\"reflectedboolean\\");
     }
   }
 
@@ -2260,7 +2260,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    const value = this.getAttribute(\\"ReflectedDOMString\\");
+    const value = this.getAttributeNS(null, \\"reflecteddomstring\\");
     return value === null ? \\"\\" : value;
   }
 
@@ -2273,7 +2273,7 @@ class Reflect {
       context: \\"Failed to set the 'ReflectedDOMString' property on 'Reflect': The provided value\\"
     });
 
-    this.setAttribute(\\"ReflectedDOMString\\", V);
+    this.setAttributeNS(null, \\"reflecteddomstring\\", V);
   }
 
   get ReflectedLong() {
@@ -2281,7 +2281,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    const value = parseInt(this.getAttribute(\\"ReflectedLong\\"));
+    const value = parseInt(this.getAttributeNS(null, \\"reflectedlong\\"));
     return isNaN(value) || value < -2147483648 || value > 2147483647 ? 0 : value;
   }
 
@@ -2294,7 +2294,7 @@ class Reflect {
       context: \\"Failed to set the 'ReflectedLong' property on 'Reflect': The provided value\\"
     });
 
-    this.setAttribute(\\"ReflectedLong\\", String(V));
+    this.setAttributeNS(null, \\"reflectedlong\\", String(V));
   }
 
   get ReflectedUnsignedLong() {
@@ -2302,7 +2302,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    const value = parseInt(this.getAttribute(\\"ReflectedUnsignedLong\\"));
+    const value = parseInt(this.getAttributeNS(null, \\"reflectedunsignedlong\\"));
     return isNaN(value) || value < 0 || value > 2147483647 ? 0 : value;
   }
 
@@ -2315,7 +2315,7 @@ class Reflect {
       context: \\"Failed to set the 'ReflectedUnsignedLong' property on 'Reflect': The provided value\\"
     });
 
-    this.setAttribute(\\"ReflectedUnsignedLong\\", String(V > 2147483647 ? 0 : V));
+    this.setAttributeNS(null, \\"reflectedunsignedlong\\", String(V > 2147483647 ? 0 : V));
   }
 
   get ReflectionTest() {
@@ -2323,7 +2323,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    const value = this.getAttribute(\\"reflection\\");
+    const value = this.getAttributeNS(null, \\"reflection\\");
     return value === null ? \\"\\" : value;
   }
 
@@ -2336,7 +2336,7 @@ class Reflect {
       context: \\"Failed to set the 'ReflectionTest' property on 'Reflect': The provided value\\"
     });
 
-    this.setAttribute(\\"reflection\\", V);
+    this.setAttributeNS(null, \\"reflection\\", V);
   }
 
   get withUnderscore() {
@@ -2344,7 +2344,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    const value = this.getAttribute(\\"with-underscore\\");
+    const value = this.getAttributeNS(null, \\"with-underscore\\");
     return value === null ? \\"\\" : value;
   }
 
@@ -2357,7 +2357,7 @@ class Reflect {
       context: \\"Failed to set the 'withUnderscore' property on 'Reflect': The provided value\\"
     });
 
-    this.setAttribute(\\"with-underscore\\", V);
+    this.setAttributeNS(null, \\"with-underscore\\", V);
   }
 }
 Object.defineProperties(Reflect.prototype, {


### PR DESCRIPTION
Following the discussion in https://github.com/jsdom/jsdom/pull/2546. The change has been tested with jsdom.

The `getAttribute()`-method includes a step that lowercases the attribute name while `getAttributeNS()` does not, so it is now done explicitly here. This is necessary for all tests in jsdom to pass.