### PR TITLE
Use async/await instead of co

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 8
   },
   "rules": {
     // Possible errors

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -2,7 +2,6 @@
 
 const path = require("path");
 
-const co = require("co");
 const fs = require("pn/fs");
 const webidl = require("webidl2");
 const prettier = require("prettier");
@@ -38,12 +37,12 @@ class Transformer {
     return this;
   }
 
-  * _collectSources() {
-    const stats = yield Promise.all(this.sources.map(src => fs.stat(src.idlPath)));
+  async _collectSources() {
+    const stats = await Promise.all(this.sources.map(src => fs.stat(src.idlPath)));
     const files = [];
     for (let i = 0; i < stats.length; ++i) {
       if (stats[i].isDirectory()) {
-        const folderContents = yield fs.readdir(this.sources[i].idlPath);
+        const folderContents = await fs.readdir(this.sources[i].idlPath);
         for (const file of folderContents) {
           if (file.endsWith(".webidl")) {
             files.push({
@@ -62,9 +61,9 @@ class Transformer {
     return files;
   }
 
-  * _readFiles(files) {
+  async _readFiles(files) {
     const zipped = [];
-    const fileContents = yield Promise.all(files.map(f => fs.readFile(f.idlPath, { encoding: "utf-8" })));
+    const fileContents = await Promise.all(files.map(f => fs.readFile(f.idlPath, { encoding: "utf-8" })));
     for (let i = 0; i < files.length; ++i) {
       zipped.push({
         idlContent: fileContents[i],
@@ -194,9 +193,9 @@ class Transformer {
     }
   }
 
-  * _writeFiles(outputDir) {
-    const utilsText = yield fs.readFile(path.resolve(__dirname, "output/utils.js"));
-    yield fs.writeFile(this.utilPath, utilsText);
+  async _writeFiles(outputDir) {
+    const utilsText = await fs.readFile(path.resolve(__dirname, "output/utils.js"));
+    await fs.writeFile(this.utilPath, utilsText);
 
     const { interfaces, dictionaries, enumerations } = this.ctx;
 
@@ -225,7 +224,7 @@ class Transformer {
 
       source = this._prettify(source);
 
-      yield fs.writeFile(path.join(outputDir, obj.name + ".js"), source);
+      await fs.writeFile(path.join(outputDir, obj.name + ".js"), source);
     }
 
     for (const obj of dictionaries.values()) {
@@ -246,7 +245,7 @@ class Transformer {
 
       source = this._prettify(source);
 
-      yield fs.writeFile(path.join(outputDir, obj.name + ".js"), source);
+      await fs.writeFile(path.join(outputDir, obj.name + ".js"), source);
     }
 
     for (const obj of enumerations.values()) {
@@ -255,7 +254,7 @@ class Transformer {
 
         ${obj.toString()}
       `);
-      yield fs.writeFile(path.join(outputDir, obj.name + ".js"), source);
+      await fs.writeFile(path.join(outputDir, obj.name + ".js"), source);
     }
   }
 
@@ -266,17 +265,15 @@ class Transformer {
     });
   }
 
-  generate(outputDir) {
+  async generate(outputDir) {
     if (!this.utilPath) {
       this.utilPath = path.join(outputDir, "utils.js");
     }
 
-    return co(function* () {
-      const sources = yield* this._collectSources();
-      const contents = yield* this._readFiles(sources);
-      this._parse(outputDir, contents);
-      yield* this._writeFiles(outputDir);
-    }.bind(this));
+    const sources = await this._collectSources();
+    const contents = await this._readFiles(sources);
+    this._parse(outputDir, contents);
+    await this._writeFiles(outputDir);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "lib/transformer.js",
   "repository": "github:jsdom/webidl2js",
   "dependencies": {
-    "co": "^4.6.0",
     "pn": "^1.1.0",
     "prettier": "^1.17.1",
     "webidl-conversions": "^4.0.0",


### PR DESCRIPTION
Now that we dropped support for node 6, we remove the dependency on [`co`](https://www.npmjs.com/package/co), in favor of async/await.

As a side-effect, I also bumped the `emcaVersion` field on the `.eslintrc.json` to enable the usage of such syntax in the project.