### PR TITLE
Using impl attribute method for [Reflect] properties

### DIFF
--- a/lib/reflector.js
+++ b/lib/reflector.js
@@ -2,14 +2,14 @@
 
 module.exports.boolean = {
   get(objName, attrName) {
-    return `return this.hasAttributeNS(null, "${attrName}");`;
+    return `return this[impl].hasAttributeNS(null, "${attrName}");`;
   },
   set(objName, attrName) {
     return `
       if (V) {
-        this.setAttributeNS(null, "${attrName}", "");
+        this[impl].setAttributeNS(null, "${attrName}", "");
       } else {
-        this.removeAttributeNS(null, "${attrName}");
+        this[impl].removeAttributeNS(null, "${attrName}");
       }
     `;
   }
@@ -18,35 +18,35 @@ module.exports.boolean = {
 module.exports.DOMString = {
   get(objName, attrName) {
     return `
-      const value = this.getAttributeNS(null, "${attrName}");
+      const value = this[impl].getAttributeNS(null, "${attrName}");
       return value === null ? "" : value;
     `;
   },
   set(objName, attrName) {
-    return `this.setAttributeNS(null, "${attrName}", V);`;
+    return `this[impl].setAttributeNS(null, "${attrName}", V);`;
   }
 };
 
 module.exports.long = {
   get(objName, attrName) {
     return `
-      const value = parseInt(this.getAttributeNS(null, "${attrName}"));
+      const value = parseInt(this[impl].getAttributeNS(null, "${attrName}"));
       return isNaN(value) || value < -2147483648 || value > 2147483647 ? 0 : value
     `;
   },
   set(objName, attrName) {
-    return `this.setAttributeNS(null, "${attrName}", String(V));`;
+    return `this[impl].setAttributeNS(null, "${attrName}", String(V));`;
   }
 };
 
 module.exports["unsigned long"] = {
   get(objName, attrName) {
     return `
-      const value = parseInt(this.getAttributeNS(null, "${attrName}"));
+      const value = parseInt(this[impl].getAttributeNS(null, "${attrName}"));
       return isNaN(value) || value < 0 || value > 2147483647 ? 0 : value
     `;
   },
   set(objName, attrName) {
-    return `this.setAttributeNS(null, "${attrName}", String(V > 2147483647 ? 0 : V));`;
+    return `this[impl].setAttributeNS(null, "${attrName}", String(V > 2147483647 ? 0 : V));`;
   }
 };

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -2236,7 +2236,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    return this.hasAttributeNS(null, \\"reflectedboolean\\");
+    return this[impl].hasAttributeNS(null, \\"reflectedboolean\\");
   }
 
   set ReflectedBoolean(V) {
@@ -2249,9 +2249,9 @@ class Reflect {
     });
 
     if (V) {
-      this.setAttributeNS(null, \\"reflectedboolean\\", \\"\\");
+      this[impl].setAttributeNS(null, \\"reflectedboolean\\", \\"\\");
     } else {
-      this.removeAttributeNS(null, \\"reflectedboolean\\");
+      this[impl].removeAttributeNS(null, \\"reflectedboolean\\");
     }
   }
 
@@ -2260,7 +2260,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    const value = this.getAttributeNS(null, \\"reflecteddomstring\\");
+    const value = this[impl].getAttributeNS(null, \\"reflecteddomstring\\");
     return value === null ? \\"\\" : value;
   }
 
@@ -2273,7 +2273,7 @@ class Reflect {
       context: \\"Failed to set the 'ReflectedDOMString' property on 'Reflect': The provided value\\"
     });
 
-    this.setAttributeNS(null, \\"reflecteddomstring\\", V);
+    this[impl].setAttributeNS(null, \\"reflecteddomstring\\", V);
   }
 
   get ReflectedLong() {
@@ -2281,7 +2281,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    const value = parseInt(this.getAttributeNS(null, \\"reflectedlong\\"));
+    const value = parseInt(this[impl].getAttributeNS(null, \\"reflectedlong\\"));
     return isNaN(value) || value < -2147483648 || value > 2147483647 ? 0 : value;
   }
 
@@ -2294,7 +2294,7 @@ class Reflect {
       context: \\"Failed to set the 'ReflectedLong' property on 'Reflect': The provided value\\"
     });
 
-    this.setAttributeNS(null, \\"reflectedlong\\", String(V));
+    this[impl].setAttributeNS(null, \\"reflectedlong\\", String(V));
   }
 
   get ReflectedUnsignedLong() {
@@ -2302,7 +2302,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    const value = parseInt(this.getAttributeNS(null, \\"reflectedunsignedlong\\"));
+    const value = parseInt(this[impl].getAttributeNS(null, \\"reflectedunsignedlong\\"));
     return isNaN(value) || value < 0 || value > 2147483647 ? 0 : value;
   }
 
@@ -2315,7 +2315,7 @@ class Reflect {
       context: \\"Failed to set the 'ReflectedUnsignedLong' property on 'Reflect': The provided value\\"
     });
 
-    this.setAttributeNS(null, \\"reflectedunsignedlong\\", String(V > 2147483647 ? 0 : V));
+    this[impl].setAttributeNS(null, \\"reflectedunsignedlong\\", String(V > 2147483647 ? 0 : V));
   }
 
   get ReflectionTest() {
@@ -2323,7 +2323,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    const value = this.getAttributeNS(null, \\"reflection\\");
+    const value = this[impl].getAttributeNS(null, \\"reflection\\");
     return value === null ? \\"\\" : value;
   }
 
@@ -2336,7 +2336,7 @@ class Reflect {
       context: \\"Failed to set the 'ReflectionTest' property on 'Reflect': The provided value\\"
     });
 
-    this.setAttributeNS(null, \\"reflection\\", V);
+    this[impl].setAttributeNS(null, \\"reflection\\", V);
   }
 
   get withUnderscore() {
@@ -2344,7 +2344,7 @@ class Reflect {
       throw new TypeError(\\"Illegal invocation\\");
     }
 
-    const value = this.getAttributeNS(null, \\"with-underscore\\");
+    const value = this[impl].getAttributeNS(null, \\"with-underscore\\");
     return value === null ? \\"\\" : value;
   }
 
@@ -2357,7 +2357,7 @@ class Reflect {
       context: \\"Failed to set the 'withUnderscore' property on 'Reflect': The provided value\\"
     });
 
-    this.setAttributeNS(null, \\"with-underscore\\", V);
+    this[impl].setAttributeNS(null, \\"with-underscore\\", V);
   }
 }
 Object.defineProperties(Reflect.prototype, {


### PR DESCRIPTION
This PR changes the way `[Reflect]` properties are generated. Instead of using the attribute methods on the wrapper, it uses the attributes methods on the impl.

More details here: https://github.com/jsdom/jsdom/issues/2158