### PR TITLE
WIP upgrade webidl2

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This export is the wrapper class interface, suitable for example for putting on 
 
 #### `expose`
 
-This export contains information about where an interface is supposed to be exposed as a property. It takes into account the Web IDL extended attribute `[Expose]` to generate a data structure of the form:
+This export contains information about where an interface is supposed to be exposed as a property. It takes into account the Web IDL extended attribute `[Exposed]` to generate a data structure of the form:
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This export is the wrapper class interface, suitable for example for putting on 
 
 #### `expose`
 
-This export contains information about where an interface is supposed to be exposed as a property. It takes into account the Web IDL extended attributes `[Expose]` and `[NoInterfaceObject]` to generate a data structure of the form:
+This export contains information about where an interface is supposed to be exposed as a property. It takes into account the Web IDL extended attribute `[Expose]` to generate a data structure of the form:
 
 ```js
 {
@@ -346,7 +346,7 @@ webidl2js is implementing an ever-growing subset of the Web IDL specification. S
 - `[Clamp]`
 - `[Constructor]`
 - `[EnforceRange]`
-- `[Exposed]` and `[NoInterfaceObject]` (by exporting metadata on where/whether it is exposed)
+- `[Exposed]` (by exporting metadata on where/whether it is exposed)
 - `[LegacyArrayClass]`
 - `[LegacyUnenumerableNamedProperties]`
 - `[OverrideBuiltins]`

--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -11,7 +11,7 @@ class Attribute {
     this.ctx = ctx;
     this.interface = I;
     this.idl = idl;
-    this.static = idl.static;
+    this.static = idl.special === "static";
   }
 
   generate() {
@@ -109,7 +109,7 @@ class Attribute {
       `, "set", { configurable });
     }
 
-    if (!this.static && this.idl.stringifier) {
+    if (!this.static && this.idl.special === "stringifier") {
       addMethod("toString", [], `
         if (!this || !module.exports.is(this)) {
           throw new TypeError("Illegal invocation");

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -359,7 +359,7 @@ class Interface {
       }
     }
     for (const member of this.allMembers()) {
-      if (forbiddenMembers.has(member.name) || (member.name && member.name[0] === "_")) {
+      if (forbiddenMembers.has(member.name)) {
         let msg = `${member.name} is forbidden in interface ${this.name}`;
         if (member.definingInterface !== this.name) {
           msg += ` (defined in ${member.definingInterface})`;

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -100,7 +100,7 @@ class Interface {
 
     const global = utils.getExtAttr(this.idl.extAttrs, "Global");
     this.isGlobal = Boolean(global);
-    if (global && (!global.rhs || global.arguments)) {
+    if (global && !global.rhs) {
       throw new Error(`[Global] must take an identifier or an identifier list in interface ${this.name}`);
     }
   }
@@ -190,7 +190,7 @@ class Interface {
   _analyzeMembers() {
     const handleSpecialOperations = member => {
       if (member.type === "operation") {
-        if (member.getter) {
+        if (member.special === "getter") {
           let msg = `Invalid getter ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
           if (member.definingInterface !== this.name) {
             msg += ` (defined in ${member.definingInterface})`;
@@ -213,7 +213,7 @@ class Interface {
             throw new Error(msg + "getter is neither indexed nor named");
           }
         }
-        if (member.setter) {
+        if (member.special === "setter") {
           let msg = `Invalid setter ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
           if (member.definingInterface !== this.name) {
             msg += ` (defined in ${member.definingInterface})`;
@@ -237,7 +237,7 @@ class Interface {
             throw new Error(msg + "setter is neither indexed nor named");
           }
         }
-        if (member.deleter) {
+        if (member.special === "deleter") {
           let msg = `Invalid deleter ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
           if (member.definingInterface !== this.name) {
             msg += ` (defined in ${member.definingInterface})`;
@@ -264,7 +264,7 @@ class Interface {
       let key;
       switch (member.type) {
         case "operation":
-          key = member.static ? "staticOperations" : "operations";
+          key = member.special === "static" ? "staticOperations" : "operations";
           if (member.name) {
             if (!this[key].has(member.name)) {
               this[key].set(member.name, new Operation(this.ctx, this, member));
@@ -274,7 +274,7 @@ class Interface {
           }
           break;
         case "attribute":
-          key = member.static ? "staticAttributes" : "attributes";
+          key = member.special === "static" ? "staticAttributes" : "attributes";
           this[key].set(member.name, new Attribute(this.ctx, this, member));
           break;
         case "const":
@@ -294,7 +294,7 @@ class Interface {
 
       handleSpecialOperations(member);
 
-      if (member.stringifier) {
+      if (member.special === "stringifier") {
         let msg = `Invalid stringifier ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
         if (member.definingInterface !== this.name) {
           msg += ` (defined in ${member.definingInterface})`;
@@ -320,7 +320,7 @@ class Interface {
           op.name = "toString";
           this.operations.set("toString", op);
         } else if (member.type === "attribute") {
-          if (member.static) {
+          if (member.special === "static") {
             throw new Error(msg + "keyword cannot be placed on static attribute");
           }
           if (member.idlType.idlType !== "DOMString" && member.idlType.idlType !== "USVString" ||
@@ -588,7 +588,7 @@ class Interface {
         unsupportedValue = unsupportedValue.rhs.value;
       }
       if (unsupportedValue) {
-        const func = this.indexedGetter.name !== null ? `.${this.indexedGetter.name}` : "[utils.indexedGet]";
+        const func = this.indexedGetter.name ? `.${this.indexedGetter.name}` : "[utils.indexedGet]";
         const value = indexedValue || `${O}[impl]${func}(${index})`;
         return `${value} !== ${unsupportedValue}`;
       }
@@ -601,7 +601,7 @@ class Interface {
         unsupportedValue = unsupportedValue.rhs.value;
       }
       if (unsupportedValue) {
-        const func = this.namedGetter.name !== null ? `.${this.namedGetter.name}` : "[utils.namedGet]";
+        const func = this.namedGetter.name ? `.${this.namedGetter.name}` : "[utils.namedGet]";
         const value = namedValue || `${O}[impl]${func}(${P})`;
         return `${value} !== ${unsupportedValue}`;
       }
@@ -638,7 +638,7 @@ class Interface {
         ${conv.body}
       `;
 
-      if (this.indexedSetter.name === null) {
+      if (!this.indexedSetter.name) {
         str += `
           const creating = !(${supportsPropertyIndex(O, "index")});
           if (creating) {
@@ -669,7 +669,7 @@ class Interface {
         ${conv.body}
       `;
 
-      if (this.namedSetter.name === null) {
+      if (!this.namedSetter.name) {
         str += `
           const creating = !(${supportsPropertyName(O, P)});
           if (creating) {
@@ -779,7 +779,7 @@ class Interface {
             const index = P >>> 0;
       `;
 
-      const func = this.indexedGetter.name !== null ? `.${this.indexedGetter.name}` : "[utils.indexedGet]";
+      const func = this.indexedGetter.name ? `.${this.indexedGetter.name}` : "[utils.indexedGet]";
       let preamble = "";
       let condition;
       if (utils.getExtAttr(this.indexedGetter.extAttrs, "WebIDL2JSValueAsUnsupported")) {
@@ -805,7 +805,7 @@ class Interface {
       `;
     }
     if (this.supportsNamedProperties) {
-      const func = this.namedGetter.name !== null ? `.${this.namedGetter.name}` : "[utils.namedGet]";
+      const func = this.namedGetter.name ? `.${this.namedGetter.name}` : "[utils.namedGet]";
       const enumerable = !utils.getExtAttr(this.idl.extAttrs, "LegacyUnenumerableNamedProperties");
       let preamble = "";
       const conditions = [];
@@ -889,7 +889,7 @@ class Interface {
             const index = P >>> 0;
       `;
 
-      const func = this.indexedGetter.name !== null ? `.${this.indexedGetter.name}` : "[utils.indexedGet]";
+      const func = this.indexedGetter.name ? `.${this.indexedGetter.name}` : "[utils.indexedGet]";
       let preamble = "";
       let condition;
       if (utils.getExtAttr(this.indexedGetter.extAttrs, "WebIDL2JSValueAsUnsupported")) {
@@ -979,7 +979,7 @@ class Interface {
     if (this.supportsNamedProperties && !this.isGlobal) {
       const unforgeable = new Set();
       for (const m of this.allMembers()) {
-        if ((m.type === "attribute" || m.type === "operation") && !m.static &&
+        if ((m.type === "attribute" || m.type === "operation") && m.special !== "static" &&
             utils.getExtAttr(m.extAttrs, "Unforgeable")) {
           unforgeable.add(m.name);
         }
@@ -1059,7 +1059,7 @@ class Interface {
             return false;
         `;
       } else {
-        const func = this.namedDeleter.name !== null ? `.${this.namedDeleter.name}` : "[utils.namedDelete]";
+        const func = this.namedDeleter.name ? `.${this.namedDeleter.name}` : "[utils.namedDelete]";
         if (this.namedDeleter.idlType.idlType === "bool") {
           this.str += `
             return target[impl]${func}(P);
@@ -1093,25 +1093,24 @@ class Interface {
   }
 
   generateIface() {
-    const shouldExposeRoot = !utils.getExtAttr(this.idl.extAttrs, "NoInterfaceObject");
+    const exposedAttrs = this.idl.extAttrs
+      .filter(attr => attr.name === "Exposed");
+    if (exposedAttrs.length === 0) {
+      throw new Error(`Missing [Exposed] extended attribute on ${this.name}`);
+    }
+    if (exposedAttrs.length > 1) {
+      throw new Error(`Too many [Exposed] extended attributes on ${this.name}`);
+    }
+
+    const rhs = exposedAttrs[0].rhs.value;
+    const exposedOn = typeof rhs === "string" ? [rhs] : rhs.map(arg => arg.value);
 
     const exposedMap = {};
-    if (shouldExposeRoot) {
-      let exposedOn = ["Window"];
-      const exposedAttrs = this.idl.extAttrs
-        .filter(attr => attr.name === "Exposed");
-      if (exposedAttrs.length !== 0) {
-        if (typeof exposedAttrs[0].rhs.value === "string") {
-          exposedAttrs[0].rhs.value = [exposedAttrs[0].rhs.value];
-        }
-        exposedOn = exposedAttrs[0].rhs.value;
+    for (let i = 0; i < exposedOn.length; ++i) {
+      if (!exposedMap[exposedOn[i]]) {
+        exposedMap[exposedOn[i]] = [];
       }
-      for (let i = 0; i < exposedOn.length; ++i) {
-        if (!exposedMap[exposedOn[i]]) {
-          exposedMap[exposedOn[i]] = [];
-        }
-        exposedMap[exposedOn[i]].push(this.name);
-      }
+      exposedMap[exposedOn[i]].push(this.name);
     }
 
     const exposers = [];

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -12,7 +12,7 @@ class Operation {
     this.interface = I;
     this.idls = [idl];
     this.name = idl.name;
-    this.static = idl.static;
+    this.static = idl.special === "static";
   }
 
   isOnInstance() {

--- a/lib/types.js
+++ b/lib/types.js
@@ -56,7 +56,7 @@ function resolveType(ctx, idlType, stack = []) {
     idlType.idlType = types;
     return idlType;
   } else if (idlType.generic === "sequence" || idlType.generic === "FrozenArray" || idlType.generic === "Promise") {
-    idlType.idlType = resolveType(ctx, idlType.idlType, stack);
+    idlType.idlType = resolveType(ctx, idlType.idlType[0], stack);
     return idlType;
   } else if (idlType.generic === "record") {
     idlType.idlType = idlType.idlType.map(t => resolveType(ctx, t, stack));

--- a/lib/types.js
+++ b/lib/types.js
@@ -55,10 +55,7 @@ function resolveType(ctx, idlType, stack = []) {
     }
     idlType.idlType = types;
     return idlType;
-  } else if (idlType.generic === "sequence" || idlType.generic === "FrozenArray" || idlType.generic === "Promise") {
-    idlType.idlType = resolveType(ctx, idlType.idlType[0], stack);
-    return idlType;
-  } else if (idlType.generic === "record") {
+  } else if (idlType.generic) {
     idlType.idlType = idlType.idlType.map(t => resolveType(ctx, t, stack));
     return idlType;
   } else if (resolvedTypes.has(ctx.typeOf(idlType.idlType))) {
@@ -279,7 +276,7 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
   }
 
   function generateSequence() {
-    const conv = generateTypeConversion(ctx, "nextItem", idlType.idlType, [], parentName,
+    const conv = generateTypeConversion(ctx, "nextItem", idlType.idlType[0], [], parentName,
       `${errPrefix} + "'s element"`);
     requires.merge(conv.requires);
 
@@ -329,11 +326,11 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
 
   function generatePromise() {
     let handler;
-    if (idlType.idlType.idlType === "void") {
+    if (idlType.idlType[0].idlType === "void") {
       // Do nothing.
       handler = "";
     } else {
-      const conv = generateTypeConversion(ctx, "value", idlType.idlType, [], parentName,
+      const conv = generateTypeConversion(ctx, "value", idlType.idlType[0], [], parentName,
         `${errPrefix} + " promise value"`);
       requires.merge(conv.requires);
       handler = `

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,7 +33,7 @@ function isGlobal(idl) {
 }
 
 function isOnInstance(memberIDL, interfaceIDL) {
-  return !memberIDL.static && (getExtAttr(memberIDL.extAttrs, "Unforgeable") || isGlobal(interfaceIDL));
+  return memberIDL.special !== "static" && (getExtAttr(memberIDL.extAttrs, "Unforgeable") || isGlobal(interfaceIDL));
 }
 
 function stringifyPropertyName(propName) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pn": "^1.1.0",
     "prettier": "^1.18.2",
     "webidl-conversions": "^4.0.0",
-    "webidl2": "^23.10.0"
+    "webidl2": "^23.10.1"
   },
   "devDependencies": {
     "eslint": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pn": "^1.1.0",
     "prettier": "^1.18.2",
     "webidl-conversions": "^4.0.0",
-    "webidl2": "^10.3.3"
+    "webidl2": "^23.9.0"
   },
   "devDependencies": {
     "eslint": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pn": "^1.1.0",
     "prettier": "^1.18.2",
     "webidl-conversions": "^4.0.0",
-    "webidl2": "^23.9.0"
+    "webidl2": "^23.10.0"
   },
   "devDependencies": {
     "eslint": "^6.5.1",

--- a/test/cases/DictionaryConvert.webidl
+++ b/test/cases/DictionaryConvert.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface DictionaryConvert {
   // Test force-conversion of dictionary types.
   DOMString op(optional DOMString arg1, optional Dictionary arg2);

--- a/test/cases/Enum.webidl
+++ b/test/cases/Enum.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface Enum {
   void op(RequestDestination destination);
   attribute RequestDestination attr;

--- a/test/cases/Factory.webidl
+++ b/test/cases/Factory.webidl
@@ -1,4 +1,4 @@
-[WebIDL2JSFactory]
+[WebIDL2JSFactory,Exposed=Window]
 interface Factory {
   DOMString method();
   attribute double _attribute;

--- a/test/cases/Global.webidl
+++ b/test/cases/Global.webidl
@@ -1,4 +1,4 @@
-[Global=Global]
+[Global=Global,Exposed=Window]
 interface Global {
   void op();
   [Unforgeable] void unforgeableOp();

--- a/test/cases/LegacyArrayClass.webidl
+++ b/test/cases/LegacyArrayClass.webidl
@@ -1,4 +1,4 @@
-[LegacyArrayClass]
+[LegacyArrayClass,Exposed=Window]
 interface LegacyArrayClass {
   readonly attribute unsigned long length;
 };

--- a/test/cases/MixedIn.webidl
+++ b/test/cases/MixedIn.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface MixedIn {
   attribute DOMString mixedInAttr;
             DOMString mixedInOp();

--- a/test/cases/Overloads.webidl
+++ b/test/cases/Overloads.webidl
@@ -1,6 +1,7 @@
 [Constructor,
  Constructor(DOMString arg1),
- Constructor(URL arg1)]
+ Constructor(URL arg1),
+ Exposed=Window]
 interface Overloads {
   DOMString compatible(DOMString arg1);
   byte compatible(DOMString arg1, DOMString arg2);

--- a/test/cases/PromiseTypes.webidl
+++ b/test/cases/PromiseTypes.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface PromiseTypes {
   void voidPromiseConsumer(Promise<void> p);
   void promiseConsumer(Promise<double> p);

--- a/test/cases/Reflect.webidl
+++ b/test/cases/Reflect.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface Reflect {
   [Reflect] attribute boolean ReflectedBoolean;
   [FooBar, Reflect] attribute DOMString ReflectedDOMString;

--- a/test/cases/SeqAndRec.webidl
+++ b/test/cases/SeqAndRec.webidl
@@ -1,4 +1,4 @@
-[Constructor]
+[Constructor,Exposed=Window]
 interface SeqAndRec {
   void recordConsumer(record<USVString, double> rec);
   void recordConsumer2(record<USVString, URL> rec);

--- a/test/cases/Static.webidl
+++ b/test/cases/Static.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface Static {
   static attribute DOMString abc;
   attribute DOMString abc;

--- a/test/cases/Storage.webidl
+++ b/test/cases/Storage.webidl
@@ -1,4 +1,5 @@
 // https://html.spec.whatwg.org/multipage/webstorage.html#storage-2<Paste>
+[Exposed=Window]
 interface Storage {
   readonly attribute unsigned long length;
   DOMString? key(unsigned long index);

--- a/test/cases/StringifierAttribute.webidl
+++ b/test/cases/StringifierAttribute.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface StringifierAttribute {
   stringifier readonly attribute DOMString attr;
 };

--- a/test/cases/StringifierDefaultOperation.webidl
+++ b/test/cases/StringifierDefaultOperation.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface StringifierDefaultOperation {
   stringifier;
 };

--- a/test/cases/StringifierNamedOperation.webidl
+++ b/test/cases/StringifierNamedOperation.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface StringifierNamedOperation {
   stringifier DOMString operation();
 };

--- a/test/cases/StringifierOperation.webidl
+++ b/test/cases/StringifierOperation.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface StringifierOperation {
   stringifier DOMString ();
 };

--- a/test/cases/TypedefsAndUnions.webidl
+++ b/test/cases/TypedefsAndUnions.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface TypedefsAndUnions {
   void numOrStrConsumer(NumOrStr a);
   void numOrEnumConsumer((double or RequestDestination)? a);

--- a/test/cases/URLList.webidl
+++ b/test/cases/URLList.webidl
@@ -1,5 +1,6 @@
 // Adapted from NodeList
 // https://dom.spec.whatwg.org/#nodelist
+[Exposed=Window]
 interface URLList {
   getter URL? item(unsigned long index);
   readonly attribute unsigned long length;

--- a/test/cases/URLSearchParamsCollection2.webidl
+++ b/test/cases/URLSearchParamsCollection2.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface URLSearchParamsCollection2 : URLSearchParamsCollection {
   setter void (DOMString key, URL value);
 };

--- a/test/cases/UnderscoredProperties.webidl
+++ b/test/cases/UnderscoredProperties.webidl
@@ -1,4 +1,5 @@
 // https://heycam.github.io/webidl/#idl-names
+[Exposed=Window]
 interface _UnderscoredProperties {
   const byte _const = 42;
   attribute byte _attribute;

--- a/test/cases/Unforgeable.webidl
+++ b/test/cases/Unforgeable.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface Unforgeable {
   [Unforgeable] stringifier attribute USVString href;
   [Unforgeable] readonly attribute USVString origin;

--- a/test/cases/UnforgeableMap.webidl
+++ b/test/cases/UnforgeableMap.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface UnforgeableMap {
   [Unforgeable] readonly attribute DOMString a;
   getter DOMString (DOMString x);

--- a/test/cases/Unscopable.webidl
+++ b/test/cases/Unscopable.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface Unscopable {
   [Unscopable] attribute boolean unscopableTest;
 };

--- a/test/cases/Variadic.webidl
+++ b/test/cases/Variadic.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface Variadic {
   void simple1(DOMString... strings);
 

--- a/test/cases/ZeroArgConstructor.webidl
+++ b/test/cases/ZeroArgConstructor.webidl
@@ -1,2 +1,2 @@
-[Constructor]
+[Constructor,Exposed=Window]
 interface ZeroArgConstructor {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3822,10 +3822,10 @@ webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webidl2@^10.3.3:
-  version "10.3.3"
-  resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-10.3.3.tgz#9e6562df1ecd466dba0cdb713a0db073bbe1039a"
-  integrity sha512-C3rxCpkX2XQ9FW1EIllN0nW2zlN21S+PgE59xQ6ErI5awVaXYm3TTsDDsdCYIfwjVwNZZIpKjcW1xJF89ZlAew==
+webidl2@^23.9.0:
+  version "23.9.0"
+  resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-23.9.0.tgz#9dbbbb2560f21ed5b7227b429c20869564b1fc2c"
+  integrity sha512-a6d9Ej6g/agkg0OdfKAiUuwpaT0XFzgy+iDwe8vAgUboTuIHR3NsQ5RFyA4P922CMAH+PGWmuRVV65t/uRK/PA==
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3822,10 +3822,10 @@ webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webidl2@^23.10.0:
-  version "23.10.0"
-  resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-23.10.0.tgz#a1f04dcf369ed627cab39522118c8d5f6361609d"
-  integrity sha512-nO9P5byFfN5yv1k7J+Jynjme3AH+gvFGQoVmh0+OD8dlXbJjsFwxLc3kNWm7TmsVbT4CEb6Vrf/M8Rb03ciVog==
+webidl2@^23.10.1:
+  version "23.10.1"
+  resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-23.10.1.tgz#2d2786fdff7b72c6b4a9a43e70f1611ded8ec8e6"
+  integrity sha512-SK/KzMGgkPLN73HNqyU9tWPduireSzV6p/WAsmYYweI/ED19FC8+ymsi2InMX80+VjSvsfc3vA7UbMjXYWNPhA==
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3822,10 +3822,10 @@ webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webidl2@^23.9.0:
-  version "23.9.0"
-  resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-23.9.0.tgz#9dbbbb2560f21ed5b7227b429c20869564b1fc2c"
-  integrity sha512-a6d9Ej6g/agkg0OdfKAiUuwpaT0XFzgy+iDwe8vAgUboTuIHR3NsQ5RFyA4P922CMAH+PGWmuRVV65t/uRK/PA==
+webidl2@^23.10.0:
+  version "23.10.0"
+  resolved "https://registry.yarnpkg.com/webidl2/-/webidl2-23.10.0.tgz#a1f04dcf369ed627cab39522118c8d5f6361609d"
+  integrity sha512-nO9P5byFfN5yv1k7J+Jynjme3AH+gvFGQoVmh0+OD8dlXbJjsFwxLc3kNWm7TmsVbT4CEb6Vrf/M8Rb03ciVog==
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.5"


### PR DESCRIPTION
Fixes so far:

* Removed `[NoInterfaceObject]` support and made a single `[Exposed]` mandatory to align with ongoing/upcoming Web IDL spec changes. Fixed how `[Exposed]` arguments are processed as that changed in webidl2.
* Stopped checking for `.arguments` when checking `[Global]` validity; I'm not sure what that check was for and it doesn't seem to work anymore anyway.
* Updated to check the `.special` property instead of the `.getter`, `.setter`, `.deleter`, `.stringifier`, `.static` properties
* Changed to check for falsy `name` properties for indexed/named getters/setters, instead of `null`. webidl2 is now sometimes returning undefined and sometimes returning the empty string (I think via the prototype chain? There is no `name` own property.)

Tests still failing:

* Escaped (underscore-prefixed) name handling got changed in webidl2, causing various failures due to `_analyzeMembers (lib/constructs/interface.js:367:15)` which seems to prohibit any underscores from appearing. I'm unsure what the intent of the original code was, or the intent of the webidl2 changes, which seem likely to be those in https://github.com/w3c/webidl2.js/pull/229. This is causing lots of early failures which might mask other issues.
* `sequence<sequence<USVString>>` in `URLSearchParams.webidl` is being treated as something like `sequence<USVString>`. I fixed several similar failures, which were caused by webidl2 switching `idlType` from the inner type to an array containing the inner type. I'm unsure why this one remains.

Help very much appreciated from anyone who is able to figure these remaining things out.

/cc @saschanaz