### PR TITLE
Avoid using instanceof for BufferSource types

### DIFF
--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -69,7 +69,7 @@ function isArrayBuffer(value) {
   try {
     byteLengthGetter.call(value);
     return true;
-  } catch {
+  } catch (e) {
     return false;
   }
 }

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -63,6 +63,17 @@ function isArrayIndexPropName(P) {
   return true;
 }
 
+const byteLengthGetter =
+    Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "byteLength").get;
+function isArrayBuffer(value) {
+  try {
+    byteLengthGetter.call(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const supportsPropertyIndex = Symbol("supports property index");
 const supportedPropertyIndices = Symbol("supported property indices");
 const supportsPropertyName = Symbol("supports property name");
@@ -88,6 +99,7 @@ module.exports = exports = {
   tryImplForWrapper,
   iterInternalSymbol,
   IteratorPrototype,
+  isArrayBuffer,
   isArrayIndexPropName,
   supportsPropertyIndex,
   supportedPropertyIndices,

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -157,8 +157,7 @@ module.exports.generateOverloadConversions = function (ctx, typeOfOp, name, pare
         const arrayBuffers = S.filter(o => isOrIncludes(ctx, o.typeList[d], t => t.idlType === "ArrayBuffer"));
         if (arrayBuffers.length) {
           possibilities.push(`
-            if (curArg instanceof ArrayBuffer ||
-                typeof SharedArrayBuffer !== "undefined" && curArg instanceof SharedArrayBuffer) {
+            if (utils.isArrayBuffer(curArg)) {
               ${continued(arrayBuffers[0], i)}
             }
           `);

--- a/lib/types.js
+++ b/lib/types.js
@@ -195,13 +195,13 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
 
     // Do not convert buffer source types as the impl code can either "get a reference" or "get a copy" to the bytes.
     if (union.ArrayBuffer || union.object) {
-      output.push(`if (${name} instanceof ArrayBuffer) {}`);
+      output.push(`if (utils.isArrayBuffer(${name})) {}`);
     }
     if (union.ArrayBufferViews.size > 0 || union.object) {
       let condition = `ArrayBuffer.isView(${name})`;
       // Skip specific type check if all ArrayBufferView member types are allowed.
       if (union.ArrayBufferViews.size !== arrayBufferViewTypes.size) {
-        const exprs = [...union.ArrayBufferViews].map(a => `${name} instanceof ${a}`);
+        const exprs = [...union.ArrayBufferViews].map(a => `${name}.constructor.name === "${a}"`);
         condition += ` && (${exprs.join(" || ")})`;
       }
       output.push(`if (${condition}) {}`);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "pn": "^1.1.0",
     "prettier": "^1.19.1",
-    "webidl-conversions": "^4.0.0",
+    "webidl-conversions": "^5.0.0",
     "webidl2": "^23.10.1"
   },
   "devDependencies": {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,5 +1,273 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BufferSourceTypes.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const impl = utils.implSymbol;
+const ctorRegistry = utils.ctorRegistrySymbol;
+
+const iface = {
+  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+  // implementing this mixin interface.
+  _mixedIntoPredicates: [],
+  is(obj) {
+    if (obj) {
+      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+        return true;
+      }
+      for (const isMixedInto of module.exports._mixedIntoPredicates) {
+        if (isMixedInto(obj)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  isImpl(obj) {
+    if (obj) {
+      if (obj instanceof Impl.implementation) {
+        return true;
+      }
+
+      const wrapper = utils.wrapperForImpl(obj);
+      for (const isMixedInto of module.exports._mixedIntoPredicates) {
+        if (isMixedInto(wrapper)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  },
+  convert(obj, { context = \\"The provided value\\" } = {}) {
+    if (module.exports.is(obj)) {
+      return utils.implForWrapper(obj);
+    }
+    throw new TypeError(\`\${context} is not of type 'BufferSourceTypes'.\`);
+  },
+
+  create(globalObject, constructorArgs, privateData) {
+    if (globalObject[ctorRegistry] === undefined) {
+      throw new Error(\\"Internal error: invalid global object\\");
+    }
+
+    const ctor = globalObject[ctorRegistry][\\"BufferSourceTypes\\"];
+    if (ctor === undefined) {
+      throw new Error(\\"Internal error: constructor BufferSourceTypes is not installed on the passed global object\\");
+    }
+
+    let obj = Object.create(ctor.prototype);
+    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
+    return obj;
+  },
+  createImpl(globalObject, constructorArgs, privateData) {
+    const obj = iface.create(globalObject, constructorArgs, privateData);
+    return utils.implForWrapper(obj);
+  },
+  _internalSetup(obj) {},
+  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+    privateData.wrapper = obj;
+
+    iface._internalSetup(obj);
+    Object.defineProperty(obj, impl, {
+      value: new Impl.implementation(globalObject, constructorArgs, privateData),
+      configurable: true
+    });
+
+    obj[impl][utils.wrapperSymbol] = obj;
+    if (Impl.init) {
+      Impl.init(obj[impl], privateData);
+    }
+    return obj;
+  },
+
+  install(globalObject) {
+    class BufferSourceTypes {
+      constructor() {
+        throw new TypeError(\\"Illegal constructor\\");
+      }
+
+      bs(source) {
+        if (!this || !module.exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'bs' on 'BufferSourceTypes': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          if (utils.isArrayBuffer(curArg)) {
+          } else if (ArrayBuffer.isView(curArg)) {
+          } else {
+            throw new TypeError(
+              \\"Failed to execute 'bs' on 'BufferSourceTypes': parameter 1\\" + \\" is not of any supported type.\\"
+            );
+          }
+          args.push(curArg);
+        }
+        return this[impl].bs(...args);
+      }
+
+      ab(ab) {
+        if (!this || !module.exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'ab' on 'BufferSourceTypes': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          curArg = conversions[\\"ArrayBuffer\\"](curArg, {
+            context: \\"Failed to execute 'ab' on 'BufferSourceTypes': parameter 1\\"
+          });
+          args.push(curArg);
+        }
+        return this[impl].ab(...args);
+      }
+
+      abv(abv) {
+        if (!this || !module.exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'abv' on 'BufferSourceTypes': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          if (ArrayBuffer.isView(curArg)) {
+          } else {
+            throw new TypeError(
+              \\"Failed to execute 'abv' on 'BufferSourceTypes': parameter 1\\" + \\" is not of any supported type.\\"
+            );
+          }
+          args.push(curArg);
+        }
+        return this[impl].abv(...args);
+      }
+
+      u8a(u8) {
+        if (!this || !module.exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'u8a' on 'BufferSourceTypes': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          curArg = conversions[\\"Uint8Array\\"](curArg, {
+            context: \\"Failed to execute 'u8a' on 'BufferSourceTypes': parameter 1\\"
+          });
+          args.push(curArg);
+        }
+        return this[impl].u8a(...args);
+      }
+
+      abUnion(ab) {
+        if (!this || !module.exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'abUnion' on 'BufferSourceTypes': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          if (utils.isArrayBuffer(curArg)) {
+          } else {
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'abUnion' on 'BufferSourceTypes': parameter 1\\"
+            });
+          }
+          args.push(curArg);
+        }
+        return this[impl].abUnion(...args);
+      }
+
+      u8aUnion(ab) {
+        if (!this || !module.exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'u8aUnion' on 'BufferSourceTypes': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          if (ArrayBuffer.isView(curArg) && curArg.constructor.name === \\"Uint8Array\\") {
+          } else {
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'u8aUnion' on 'BufferSourceTypes': parameter 1\\"
+            });
+          }
+          args.push(curArg);
+        }
+        return this[impl].u8aUnion(...args);
+      }
+    }
+    Object.defineProperties(BufferSourceTypes.prototype, {
+      bs: { enumerable: true },
+      ab: { enumerable: true },
+      abv: { enumerable: true },
+      u8a: { enumerable: true },
+      abUnion: { enumerable: true },
+      u8aUnion: { enumerable: true },
+      [Symbol.toStringTag]: { value: \\"BufferSourceTypes\\", configurable: true }
+    });
+    if (globalObject[ctorRegistry] === undefined) {
+      globalObject[ctorRegistry] = Object.create(null);
+    }
+    globalObject[ctorRegistry][\\"BufferSourceTypes\\"] = BufferSourceTypes;
+
+    Object.defineProperty(globalObject, \\"BufferSourceTypes\\", {
+      configurable: true,
+      writable: true,
+      value: BufferSourceTypes
+    });
+  }
+}; // iface
+module.exports = iface;
+
+const Impl = require(\\"../implementations/BufferSourceTypes.js\\");
+"
+`;
+
 exports[`DOMImplementation.webidl 1`] = `
 "\\"use strict\\";
 
@@ -1400,13 +1668,10 @@ const iface = {
                   }
                   args.push(curArg);
                 }
-              } else if (
-                curArg instanceof ArrayBuffer ||
-                (typeof SharedArrayBuffer !== \\"undefined\\" && curArg instanceof SharedArrayBuffer)
-              ) {
+              } else if (utils.isArrayBuffer(curArg)) {
                 {
                   let curArg = arguments[1];
-                  if (curArg instanceof ArrayBuffer) {
+                  if (utils.isArrayBuffer(curArg)) {
                   } else if (ArrayBuffer.isView(curArg)) {
                   } else {
                     throw new TypeError(
@@ -1418,7 +1683,7 @@ const iface = {
               } else if (ArrayBuffer.isView(curArg)) {
                 {
                   let curArg = arguments[1];
-                  if (curArg instanceof ArrayBuffer) {
+                  if (utils.isArrayBuffer(curArg)) {
                   } else if (ArrayBuffer.isView(curArg)) {
                   } else {
                     throw new TypeError(
@@ -1460,7 +1725,7 @@ const iface = {
             }
             {
               let curArg = arguments[2];
-              if (curArg instanceof ArrayBuffer) {
+              if (utils.isArrayBuffer(curArg)) {
               } else if (ArrayBuffer.isView(curArg)) {
               } else {
                 throw new TypeError(
@@ -1471,7 +1736,7 @@ const iface = {
             }
             {
               let curArg = arguments[3];
-              if (curArg instanceof ArrayBuffer) {
+              if (utils.isArrayBuffer(curArg)) {
               } else if (ArrayBuffer.isView(curArg)) {
               } else {
                 throw new TypeError(
@@ -3660,7 +3925,7 @@ const iface = {
           let curArg = arguments[0];
           if (isURL(curArg)) {
             curArg = utils.implForWrapper(curArg);
-          } else if (curArg instanceof ArrayBuffer) {
+          } else if (utils.isArrayBuffer(curArg)) {
           } else if (ArrayBuffer.isView(curArg)) {
           } else {
             throw new TypeError(
@@ -3779,8 +4044,11 @@ const iface = {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        if (V instanceof ArrayBuffer) {
-        } else if (ArrayBuffer.isView(V) && (V instanceof Uint8Array || V instanceof Uint16Array)) {
+        if (utils.isArrayBuffer(V)) {
+        } else if (
+          ArrayBuffer.isView(V) &&
+          (V.constructor.name === \\"Uint8Array\\" || V.constructor.name === \\"Uint16Array\\")
+        ) {
         } else {
           throw new TypeError(
             \\"Failed to set the 'buf' property on 'TypedefsAndUnions': The provided value\\" +

--- a/test/cases/BufferSourceTypes.webidl
+++ b/test/cases/BufferSourceTypes.webidl
@@ -1,0 +1,10 @@
+[Exposed=Window]
+interface BufferSourceTypes {
+  void bs(BufferSource source);
+  void ab(ArrayBuffer ab);
+  void abv(ArrayBufferView abv);
+  void u8a(Uint8Array u8);
+
+  void abUnion((ArrayBuffer or DOMString) ab);
+  void u8aUnion((Uint8Array or DOMString) ab);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3814,10 +3814,15 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
+webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+webidl-conversions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
 
 webidl2@^23.10.1:
   version "23.10.1"


### PR DESCRIPTION
Given jsdom's move to separate the Node.js globals from the JSDOM globals, instanceof is no longer reliable in this fashion.

Helps with https://github.com/jsdom/jsdom/pull/2743.

---

Probably I should also fix webidl-conversions before pulling this.