### PR TITLE
perf(utils): Avoid allocating new exports object

### DIFF
--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -4,15 +4,22 @@
 function isObject(value) {
   return typeof value === "object" && value !== null || typeof value === "function";
 }
+exports.isObject = isObject;
 
 function hasOwn(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
+exports.hasOwn = hasOwn;
 
 const wrapperSymbol = Symbol("wrapper");
+exports.wrapperSymbol = wrapperSymbol;
+
 const implSymbol = Symbol("impl");
+exports.implSymbol = implSymbol;
+
 const sameObjectCaches = Symbol("SameObject caches");
 const ctorRegistrySymbol = Symbol.for("[webidl2js]  constructor registry");
+exports.ctorRegistrySymbol = ctorRegistrySymbol;
 
 function getSameObject(wrapper, prop, creator) {
   if (!wrapper[sameObjectCaches]) {
@@ -26,27 +33,35 @@ function getSameObject(wrapper, prop, creator) {
   wrapper[sameObjectCaches][prop] = creator();
   return wrapper[sameObjectCaches][prop];
 }
+exports.getSameObject = getSameObject;
 
 function wrapperForImpl(impl) {
   return impl ? impl[wrapperSymbol] : null;
 }
+exports.wrapperForImpl = wrapperForImpl;
 
 function implForWrapper(wrapper) {
   return wrapper ? wrapper[implSymbol] : null;
 }
+exports.implForWrapper = implForWrapper;
 
 function tryWrapperForImpl(impl) {
   const wrapper = wrapperForImpl(impl);
   return wrapper ? wrapper : impl;
 }
+exports.tryWrapperForImpl = tryWrapperForImpl;
 
 function tryImplForWrapper(wrapper) {
   const impl = implForWrapper(wrapper);
   return impl ? impl : wrapper;
 }
+exports.tryImplForWrapper = tryImplForWrapper;
 
 const iterInternalSymbol = Symbol("internal");
+exports.iterInternalSymbol = iterInternalSymbol;
+
 const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+exports.IteratorPrototype = IteratorPrototype;
 
 function isArrayIndexPropName(P) {
   if (typeof P !== "string") {
@@ -62,6 +77,7 @@ function isArrayIndexPropName(P) {
   }
   return true;
 }
+exports.isArrayIndexPropName = isArrayIndexPropName;
 
 const byteLengthGetter =
     Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "byteLength").get;
@@ -73,43 +89,37 @@ function isArrayBuffer(value) {
     return false;
   }
 }
+exports.isArrayBuffer = isArrayBuffer;
 
 const supportsPropertyIndex = Symbol("supports property index");
-const supportedPropertyIndices = Symbol("supported property indices");
-const supportsPropertyName = Symbol("supports property name");
-const supportedPropertyNames = Symbol("supported property names");
-const indexedGet = Symbol("indexed property get");
-const indexedSetNew = Symbol("indexed property set new");
-const indexedSetExisting = Symbol("indexed property set existing");
-const namedGet = Symbol("named property get");
-const namedSetNew = Symbol("named property set new");
-const namedSetExisting = Symbol("named property set existing");
-const namedDelete = Symbol("named property delete");
+exports.supportsPropertyIndex = supportsPropertyIndex;
 
-module.exports = exports = {
-  isObject,
-  hasOwn,
-  wrapperSymbol,
-  implSymbol,
-  getSameObject,
-  ctorRegistrySymbol,
-  wrapperForImpl,
-  implForWrapper,
-  tryWrapperForImpl,
-  tryImplForWrapper,
-  iterInternalSymbol,
-  IteratorPrototype,
-  isArrayBuffer,
-  isArrayIndexPropName,
-  supportsPropertyIndex,
-  supportedPropertyIndices,
-  supportsPropertyName,
-  supportedPropertyNames,
-  indexedGet,
-  indexedSetNew,
-  indexedSetExisting,
-  namedGet,
-  namedSetNew,
-  namedSetExisting,
-  namedDelete
-};
+const supportedPropertyIndices = Symbol("supported property indices");
+exports.supportedPropertyIndices = supportedPropertyIndices;
+
+const supportsPropertyName = Symbol("supports property name");
+exports.supportsPropertyName = supportsPropertyName;
+
+const supportedPropertyNames = Symbol("supported property names");
+exports.supportedPropertyNames = supportedPropertyNames;
+
+const indexedGet = Symbol("indexed property get");
+exports.indexedGet = indexedGet;
+
+const indexedSetNew = Symbol("indexed property set new");
+exports.indexedSetNew = indexedSetNew;
+
+const indexedSetExisting = Symbol("indexed property set existing");
+exports.indexedSetExisting = indexedSetExisting;
+
+const namedGet = Symbol("named property get");
+exports.namedGet = namedGet;
+
+const namedSetNew = Symbol("named property set new");
+exports.namedSetNew = namedSetNew;
+
+const namedSetExisting = Symbol("named property set existing");
+exports.namedSetExisting = namedSetExisting;
+
+const namedDelete = Symbol("named property delete");
+exports.namedDelete = namedDelete;


### PR DESCRIPTION
This&nbsp;avoids the&nbsp;overhead of&nbsp;allocating a&nbsp;new&nbsp;`module.exports`&nbsp;object.

I&nbsp;also put&nbsp;the&nbsp;`exports.*` right&nbsp;after each&nbsp;exported&nbsp;member, to&nbsp;make it&nbsp;clearer at&nbsp;a&nbsp;glance what&nbsp;is&nbsp;exported, and&nbsp;what&nbsp;isn’t, without&nbsp;needing to&nbsp;scroll all&nbsp;the&nbsp;way&nbsp;down, and&nbsp;then&nbsp;back&nbsp;up&nbsp;again.