### PR TITLE
fix: Don’t break on circular imports

### DIFF
--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -28,7 +28,7 @@ class Attribute {
       objName = `obj`;
     }
     let brandCheck = `
-      if (!this || !module.exports.is(this)) {
+      if (!this || !exports.is(this)) {
         throw new TypeError("Illegal invocation");
       }
     `;
@@ -111,7 +111,7 @@ class Attribute {
 
     if (!this.static && this.idl.special === "stringifier") {
       addMethod("toString", [], `
-        if (!this || !module.exports.is(this)) {
+        if (!this || !exports.is(this)) {
           throw new TypeError("Illegal invocation");
         }
         ${getterBody};

--- a/lib/constructs/dictionary.js
+++ b/lib/constructs/dictionary.js
@@ -70,8 +70,7 @@ class Dictionary {
 
   generate() {
     this.str += `
-      module.exports = {
-        convertInherit(obj, ret, { context = "The provided value" } = {}) {
+      exports.convertInherit = function convertInherit(obj, ret, { context = "The provided value" } = {}) {
     `;
 
     if (this.idl.inheritance) {
@@ -82,9 +81,9 @@ class Dictionary {
 
     this.str += `
           ${this._generateConversions()}
-        },
+        };
 
-        convert(obj, { context = "The provided value" } = {}) {
+        exports.convert = function convert(obj, { context = "The provided value" } = {}) {
           if (obj !== undefined && typeof obj !== "object" && typeof obj !== "function") {
             throw new TypeError(\`\${context} is not an object.\`);
           }
@@ -92,8 +91,7 @@ class Dictionary {
           const ret = Object.create(null);
           module.exports.convertInherit(obj, ret, { context });
           return ret;
-        }
-      };
+        };
     `;
 
     if (this.idl.inheritance) {

--- a/lib/constructs/enumeration.js
+++ b/lib/constructs/enumeration.js
@@ -16,15 +16,14 @@ class Enumeration {
 
     this.str += `
       const enumerationValues = new Set(${JSON.stringify([...values])});
-      module.exports = {
-        enumerationValues,
-        convert(value, { context = "The provided value" } = {}) {
-          const string = \`\${value}\`;
-          if (!enumerationValues.has(value)) {
-            throw new TypeError(\`\${context} '\${value}' is not a valid enumeration value for ${this.name}\`);
-          }
-          return string;
+      exports.enumerationValues = enumerationValues;
+
+      exports.convert = function convert(value, { context = "The provided value" } = {}) {
+        const string = \`\${value}\`;
+        if (!enumerationValues.has(value)) {
+          throw new TypeError(\`\${context} '\${value}' is not a valid enumeration value for ${this.name}\`);
         }
+        return string;
       };
     `;
   }

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -519,63 +519,65 @@ class Interface {
   generateMixins() {
     for (const iface of this.consequentialInterfaces()) {
       this.str += `
-        ${iface}._mixedIntoPredicates.push(module.exports.is);
+        ${iface}._mixedIntoPredicates.push(exports.is);
       `;
     }
   }
 
   generateExport() {
     this.str += `
-      // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-      // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-      // implementing this mixin interface.
-      _mixedIntoPredicates: [],
-      is(obj) {
+      /**
+       * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+       * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+       * implementing this mixin interface.
+       */
+      exports._mixedIntoPredicates = [];
+      exports.is = function is(obj) {
         if (obj) {
           if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
             return true;
           }
-          for (const isMixedInto of module.exports._mixedIntoPredicates) {
+          for (const isMixedInto of exports._mixedIntoPredicates) {
             if (isMixedInto(obj)) {
               return true;
             }
           }
         }
         return false;
-      },
-      isImpl(obj) {
+      };
+      exports.isImpl = function isImpl(obj) {
         if (obj) {
           if (obj instanceof Impl.implementation) {
             return true;
           }
 
           const wrapper = utils.wrapperForImpl(obj);
-          for (const isMixedInto of module.exports._mixedIntoPredicates) {
+          for (const isMixedInto of exports._mixedIntoPredicates) {
             if (isMixedInto(wrapper)) {
               return true;
             }
           }
         }
         return false;
-      },
-      convert(obj, { context = "The provided value" } = {}) {
-        if (module.exports.is(obj)) {
+      };
+      exports.convert = function convert(obj, { context = "The provided value" } = {}) {
+        if (exports.is(obj)) {
           return utils.implForWrapper(obj);
         }
         throw new TypeError(\`\${context} is not of type '${this.name}'.\`);
-      },
+      };
     `;
 
     if (this.iterable && this.iterable.isPair) {
       this.str += `
-        createDefaultIterator(target, kind) {
+        exports.createDefaultIterator = function createDefaultIterator(target, kind) {
           const iterator = Object.create(IteratorPrototype);
           Object.defineProperty(iterator, utils.iterInternalSymbol, {
             value: { target, kind, index: 0 },
             configurable: true
           });
           return iterator;
-        },
+        };
       `;
     }
   }
@@ -1098,7 +1100,7 @@ class Interface {
 
   generateIface() {
     this.str += `
-      create(globalObject, constructorArgs, privateData) {
+      exports.create = function create(globalObject, constructorArgs, privateData) {
         if (globalObject[ctorRegistry] === undefined) {
           throw new Error('Internal error: invalid global object');
         }
@@ -1109,14 +1111,14 @@ class Interface {
         }
 
         let obj = Object.create(ctor.prototype);
-        obj = iface.setup(obj, globalObject, constructorArgs, privateData);
+        obj = exports.setup(obj, globalObject, constructorArgs, privateData);
         return obj;
-      },
-      createImpl(globalObject, constructorArgs, privateData) {
-        const obj = iface.create(globalObject, constructorArgs, privateData);
+      };
+      exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+        const obj = exports.create(globalObject, constructorArgs, privateData);
         return utils.implForWrapper(obj);
-      },
-      _internalSetup(obj) {
+      };
+      exports._internalSetup = function _internalSetup(obj) {
     `;
 
     if (this.idl.inheritance) {
@@ -1128,11 +1130,11 @@ class Interface {
     this.generateOnInstance();
 
     this.str += `
-      },
-      setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+      };
+      exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
         privateData.wrapper = obj;
 
-        iface._internalSetup(obj);
+        exports._internalSetup(obj);
         Object.defineProperty(obj, impl, {
           value: new Impl.implementation(globalObject, constructorArgs, privateData),
           configurable: true
@@ -1149,7 +1151,7 @@ class Interface {
           Impl.init(obj[impl], privateData);
         }
         return obj;
-      },
+      };
     `;
   }
 
@@ -1180,7 +1182,7 @@ class Interface {
 
       body = `
         ${conversions.body}
-        return iface.setup(${formatArgs(setupArgs)});
+        return exports.setup(${formatArgs(setupArgs)});
       `;
     } else {
       body = `
@@ -1414,7 +1416,7 @@ class Interface {
     const { idl, name } = this;
 
     this.str += `
-      install(globalObject) {
+      exports.install = function install(globalObject) {
     `;
 
     if (idl.inheritance) {
@@ -1444,25 +1446,16 @@ class Interface {
           writable: true,
           value: ${name}
         });
-      },
+      };
     `;
   }
 
   generate() {
     this.generateIterator();
 
-    this.str += `
-      const iface = {
-    `;
-
     this.generateExport();
     this.generateIface();
     this.generateInstall();
-
-    this.str += `
-      }; // iface
-      module.exports = iface;
-    `;
 
     this.generateMixins();
     this.generateRequires();

--- a/lib/constructs/iterable.js
+++ b/lib/constructs/iterable.js
@@ -20,10 +20,10 @@ class Iterable {
 
   generateFunction(key, kind) {
     this.interface.addMethod(this.interface.defaultWhence, key, [], `
-      if (!this || !module.exports.is(this)) {
+      if (!this || !exports.is(this)) {
         throw new TypeError("Illegal invocation");
       }
-      return module.exports.createDefaultIterator(this, "${kind}");
+      return exports.createDefaultIterator(this, "${kind}");
     `);
   }
 
@@ -35,7 +35,7 @@ class Iterable {
       this.generateFunction("entries", "key+value");
       this.interface.addProperty(whence, Symbol.iterator, `${this.interface.name}.prototype.entries`);
       this.interface.addMethod(whence, "forEach", ["callback"], `
-        if (!this || !module.exports.is(this)) {
+        if (!this || !exports.is(this)) {
           throw new TypeError("Illegal invocation");
         }
         if (arguments.length < 1) {

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -61,7 +61,7 @@ class Operation {
 
     if (!this.static) {
       str += `
-        if (!this || !module.exports.is(this)) {
+        if (!this || !exports.is(this)) {
           throw new TypeError("Illegal invocation");
         }
       `;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -9,260 +9,259 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'BufferSourceTypes'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"BufferSourceTypes\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor BufferSourceTypes is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class BufferSourceTypes {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      bs(source) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'bs' on 'BufferSourceTypes': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (utils.isArrayBuffer(curArg)) {
-          } else if (ArrayBuffer.isView(curArg)) {
-          } else {
-            throw new TypeError(
-              \\"Failed to execute 'bs' on 'BufferSourceTypes': parameter 1\\" + \\" is not of any supported type.\\"
-            );
-          }
-          args.push(curArg);
-        }
-        return this[impl].bs(...args);
-      }
-
-      ab(ab) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'ab' on 'BufferSourceTypes': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"ArrayBuffer\\"](curArg, {
-            context: \\"Failed to execute 'ab' on 'BufferSourceTypes': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].ab(...args);
-      }
-
-      abv(abv) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'abv' on 'BufferSourceTypes': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (ArrayBuffer.isView(curArg)) {
-          } else {
-            throw new TypeError(
-              \\"Failed to execute 'abv' on 'BufferSourceTypes': parameter 1\\" + \\" is not of any supported type.\\"
-            );
-          }
-          args.push(curArg);
-        }
-        return this[impl].abv(...args);
-      }
-
-      u8a(u8) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'u8a' on 'BufferSourceTypes': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"Uint8Array\\"](curArg, {
-            context: \\"Failed to execute 'u8a' on 'BufferSourceTypes': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].u8a(...args);
-      }
-
-      abUnion(ab) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'abUnion' on 'BufferSourceTypes': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (utils.isArrayBuffer(curArg)) {
-          } else {
-            curArg = conversions[\\"DOMString\\"](curArg, {
-              context: \\"Failed to execute 'abUnion' on 'BufferSourceTypes': parameter 1\\"
-            });
-          }
-          args.push(curArg);
-        }
-        return this[impl].abUnion(...args);
-      }
-
-      u8aUnion(ab) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'u8aUnion' on 'BufferSourceTypes': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (ArrayBuffer.isView(curArg) && curArg.constructor.name === \\"Uint8Array\\") {
-          } else {
-            curArg = conversions[\\"DOMString\\"](curArg, {
-              context: \\"Failed to execute 'u8aUnion' on 'BufferSourceTypes': parameter 1\\"
-            });
-          }
-          args.push(curArg);
-        }
-        return this[impl].u8aUnion(...args);
-      }
-    }
-    Object.defineProperties(BufferSourceTypes.prototype, {
-      bs: { enumerable: true },
-      ab: { enumerable: true },
-      abv: { enumerable: true },
-      u8a: { enumerable: true },
-      abUnion: { enumerable: true },
-      u8aUnion: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"BufferSourceTypes\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"BufferSourceTypes\\"] = BufferSourceTypes;
-
-    Object.defineProperty(globalObject, \\"BufferSourceTypes\\", {
-      configurable: true,
-      writable: true,
-      value: BufferSourceTypes
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'BufferSourceTypes'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"BufferSourceTypes\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor BufferSourceTypes is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class BufferSourceTypes {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    bs(source) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'bs' on 'BufferSourceTypes': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else {
+          throw new TypeError(
+            \\"Failed to execute 'bs' on 'BufferSourceTypes': parameter 1\\" + \\" is not of any supported type.\\"
+          );
+        }
+        args.push(curArg);
+      }
+      return this[impl].bs(...args);
+    }
+
+    ab(ab) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'ab' on 'BufferSourceTypes': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"ArrayBuffer\\"](curArg, {
+          context: \\"Failed to execute 'ab' on 'BufferSourceTypes': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return this[impl].ab(...args);
+    }
+
+    abv(abv) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'abv' on 'BufferSourceTypes': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (ArrayBuffer.isView(curArg)) {
+        } else {
+          throw new TypeError(
+            \\"Failed to execute 'abv' on 'BufferSourceTypes': parameter 1\\" + \\" is not of any supported type.\\"
+          );
+        }
+        args.push(curArg);
+      }
+      return this[impl].abv(...args);
+    }
+
+    u8a(u8) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'u8a' on 'BufferSourceTypes': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"Uint8Array\\"](curArg, {
+          context: \\"Failed to execute 'u8a' on 'BufferSourceTypes': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return this[impl].u8a(...args);
+    }
+
+    abUnion(ab) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'abUnion' on 'BufferSourceTypes': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isArrayBuffer(curArg)) {
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'abUnion' on 'BufferSourceTypes': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return this[impl].abUnion(...args);
+    }
+
+    u8aUnion(ab) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'u8aUnion' on 'BufferSourceTypes': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (ArrayBuffer.isView(curArg) && curArg.constructor.name === \\"Uint8Array\\") {
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'u8aUnion' on 'BufferSourceTypes': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return this[impl].u8aUnion(...args);
+    }
+  }
+  Object.defineProperties(BufferSourceTypes.prototype, {
+    bs: { enumerable: true },
+    ab: { enumerable: true },
+    abv: { enumerable: true },
+    u8a: { enumerable: true },
+    abUnion: { enumerable: true },
+    u8aUnion: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"BufferSourceTypes\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"BufferSourceTypes\\"] = BufferSourceTypes;
+
+  Object.defineProperty(globalObject, \\"BufferSourceTypes\\", {
+    configurable: true,
+    writable: true,
+    value: BufferSourceTypes
+  });
+};
 
 const Impl = require(\\"../implementations/BufferSourceTypes.js\\");
 "
@@ -277,217 +276,216 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
+  }
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
         return true;
       }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'DOMImplementation'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"DOMImplementation\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor DOMImplementation is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
     return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
+  }
+  throw new TypeError(\`\${context} is not of type 'DOMImplementation'.\`);
+};
 
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
 
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
+  const ctor = globalObject[ctorRegistry][\\"DOMImplementation\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor DOMImplementation is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class DOMImplementation {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
     }
-    return obj;
-  },
 
-  install(globalObject) {
-    class DOMImplementation {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
+    createDocumentType(qualifiedName, publicId, systemId) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      createDocumentType(qualifiedName, publicId, systemId) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      if (arguments.length < 3) {
+        throw new TypeError(
+          \\"Failed to execute 'createDocumentType' on 'DOMImplementation': 3 arguments required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'createDocumentType' on 'DOMImplementation': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      {
+        let curArg = arguments[1];
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'createDocumentType' on 'DOMImplementation': parameter 2\\"
+        });
+        args.push(curArg);
+      }
+      {
+        let curArg = arguments[2];
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'createDocumentType' on 'DOMImplementation': parameter 3\\"
+        });
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(this[impl].createDocumentType(...args));
+    }
 
-        if (arguments.length < 3) {
-          throw new TypeError(
-            \\"Failed to execute 'createDocumentType' on 'DOMImplementation': 3 arguments required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'createDocumentType' on 'DOMImplementation': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        {
-          let curArg = arguments[1];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'createDocumentType' on 'DOMImplementation': parameter 2\\"
-          });
-          args.push(curArg);
-        }
-        {
-          let curArg = arguments[2];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'createDocumentType' on 'DOMImplementation': parameter 3\\"
-          });
-          args.push(curArg);
-        }
-        return utils.tryWrapperForImpl(this[impl].createDocumentType(...args));
+    createDocument(namespace, qualifiedName) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      createDocument(namespace, qualifiedName) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
+      if (arguments.length < 2) {
+        throw new TypeError(
+          \\"Failed to execute 'createDocument' on 'DOMImplementation': 2 arguments required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (curArg === null || curArg === undefined) {
+          curArg = null;
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'createDocument' on 'DOMImplementation': parameter 1\\"
+          });
         }
-
-        if (arguments.length < 2) {
-          throw new TypeError(
-            \\"Failed to execute 'createDocument' on 'DOMImplementation': 2 arguments required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
+        args.push(curArg);
+      }
+      {
+        let curArg = arguments[1];
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'createDocument' on 'DOMImplementation': parameter 2\\",
+          treatNullAsEmptyString: true
+        });
+        args.push(curArg);
+      }
+      {
+        let curArg = arguments[2];
+        if (curArg !== undefined) {
           if (curArg === null || curArg === undefined) {
             curArg = null;
           } else {
-            curArg = conversions[\\"DOMString\\"](curArg, {
-              context: \\"Failed to execute 'createDocument' on 'DOMImplementation': parameter 1\\"
-            });
+            curArg = utils.tryImplForWrapper(curArg);
           }
-          args.push(curArg);
+        } else {
+          curArg = null;
         }
-        {
-          let curArg = arguments[1];
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(this[impl].createDocument(...args));
+    }
+
+    createHTMLDocument() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (curArg !== undefined) {
           curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'createDocument' on 'DOMImplementation': parameter 2\\",
-            treatNullAsEmptyString: true
+            context: \\"Failed to execute 'createHTMLDocument' on 'DOMImplementation': parameter 1\\"
           });
-          args.push(curArg);
         }
-        {
-          let curArg = arguments[2];
-          if (curArg !== undefined) {
-            if (curArg === null || curArg === undefined) {
-              curArg = null;
-            } else {
-              curArg = utils.tryImplForWrapper(curArg);
-            }
-          } else {
-            curArg = null;
-          }
-          args.push(curArg);
-        }
-        return utils.tryWrapperForImpl(this[impl].createDocument(...args));
+        args.push(curArg);
       }
-
-      createHTMLDocument() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (curArg !== undefined) {
-            curArg = conversions[\\"DOMString\\"](curArg, {
-              context: \\"Failed to execute 'createHTMLDocument' on 'DOMImplementation': parameter 1\\"
-            });
-          }
-          args.push(curArg);
-        }
-        return utils.tryWrapperForImpl(this[impl].createHTMLDocument(...args));
-      }
-
-      hasFeature() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].hasFeature();
-      }
+      return utils.tryWrapperForImpl(this[impl].createHTMLDocument(...args));
     }
-    Object.defineProperties(DOMImplementation.prototype, {
-      createDocumentType: { enumerable: true },
-      createDocument: { enumerable: true },
-      createHTMLDocument: { enumerable: true },
-      hasFeature: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"DOMImplementation\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"DOMImplementation\\"] = DOMImplementation;
 
-    Object.defineProperty(globalObject, \\"DOMImplementation\\", {
-      configurable: true,
-      writable: true,
-      value: DOMImplementation
-    });
+    hasFeature() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].hasFeature();
+    }
   }
-}; // iface
-module.exports = iface;
+  Object.defineProperties(DOMImplementation.prototype, {
+    createDocumentType: { enumerable: true },
+    createDocument: { enumerable: true },
+    createHTMLDocument: { enumerable: true },
+    hasFeature: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"DOMImplementation\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"DOMImplementation\\"] = DOMImplementation;
+
+  Object.defineProperty(globalObject, \\"DOMImplementation\\", {
+    configurable: true,
+    writable: true,
+    value: DOMImplementation
+  });
+};
 
 const Impl = require(\\"../implementations/DOMImplementation.js\\");
 "
@@ -502,73 +500,71 @@ const utils = require(\\"./utils.js\\");
 const convertURL = require(\\"./URL.js\\").convert;
 const convertURLSearchParams = require(\\"./URLSearchParams.js\\").convert;
 
-module.exports = {
-  convertInherit(obj, ret, { context = \\"The provided value\\" } = {}) {
-    {
-      const key = \\"boolWithDefault\\";
-      let value = obj === undefined || obj === null ? undefined : obj[key];
-      if (value !== undefined) {
-        value = conversions[\\"boolean\\"](value, { context: context + \\" has member boolWithDefault that\\" });
+exports.convertInherit = function convertInherit(obj, ret, { context = \\"The provided value\\" } = {}) {
+  {
+    const key = \\"boolWithDefault\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = conversions[\\"boolean\\"](value, { context: context + \\" has member boolWithDefault that\\" });
 
-        ret[key] = value;
-      } else {
-        ret[key] = false;
-      }
+      ret[key] = value;
+    } else {
+      ret[key] = false;
     }
-
-    {
-      const key = \\"requiredInterface\\";
-      let value = obj === undefined || obj === null ? undefined : obj[key];
-      if (value !== undefined) {
-        value = convertURL(value, { context: context + \\" has member requiredInterface that\\" });
-
-        ret[key] = value;
-      } else {
-        throw new TypeError(\\"requiredInterface is required in 'Dictionary'\\");
-      }
-    }
-
-    {
-      const key = \\"seq\\";
-      let value = obj === undefined || obj === null ? undefined : obj[key];
-      if (value !== undefined) {
-        if (!utils.isObject(value)) {
-          throw new TypeError(context + \\" has member seq that\\" + \\" is not an iterable object.\\");
-        } else {
-          const V = [];
-          const tmp = value;
-          for (let nextItem of tmp) {
-            nextItem = convertURLSearchParams(nextItem, { context: context + \\" has member seq that\\" + \\"'s element\\" });
-
-            V.push(nextItem);
-          }
-          value = V;
-        }
-
-        ret[key] = value;
-      }
-    }
-
-    {
-      const key = \\"vanillaString\\";
-      let value = obj === undefined || obj === null ? undefined : obj[key];
-      if (value !== undefined) {
-        value = conversions[\\"DOMString\\"](value, { context: context + \\" has member vanillaString that\\" });
-
-        ret[key] = value;
-      }
-    }
-  },
-
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (obj !== undefined && typeof obj !== \\"object\\" && typeof obj !== \\"function\\") {
-      throw new TypeError(\`\${context} is not an object.\`);
-    }
-
-    const ret = Object.create(null);
-    module.exports.convertInherit(obj, ret, { context });
-    return ret;
   }
+
+  {
+    const key = \\"requiredInterface\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = convertURL(value, { context: context + \\" has member requiredInterface that\\" });
+
+      ret[key] = value;
+    } else {
+      throw new TypeError(\\"requiredInterface is required in 'Dictionary'\\");
+    }
+  }
+
+  {
+    const key = \\"seq\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      if (!utils.isObject(value)) {
+        throw new TypeError(context + \\" has member seq that\\" + \\" is not an iterable object.\\");
+      } else {
+        const V = [];
+        const tmp = value;
+        for (let nextItem of tmp) {
+          nextItem = convertURLSearchParams(nextItem, { context: context + \\" has member seq that\\" + \\"'s element\\" });
+
+          V.push(nextItem);
+        }
+        value = V;
+      }
+
+      ret[key] = value;
+    }
+  }
+
+  {
+    const key = \\"vanillaString\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = conversions[\\"DOMString\\"](value, { context: context + \\" has member vanillaString that\\" });
+
+      ret[key] = value;
+    }
+  }
+};
+
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (obj !== undefined && typeof obj !== \\"object\\" && typeof obj !== \\"function\\") {
+    throw new TypeError(\`\${context} is not an object.\`);
+  }
+
+  const ret = Object.create(null);
+  module.exports.convertInherit(obj, ret, { context });
+  return ret;
 };
 "
 `;
@@ -583,126 +579,125 @@ const convertDictionary = require(\\"./Dictionary.js\\").convert;
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'DictionaryConvert'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"DictionaryConvert\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor DictionaryConvert is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class DictionaryConvert {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      op() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (curArg !== undefined) {
-            curArg = conversions[\\"DOMString\\"](curArg, {
-              context: \\"Failed to execute 'op' on 'DictionaryConvert': parameter 1\\"
-            });
-          }
-          args.push(curArg);
-        }
-        {
-          let curArg = arguments[1];
-          curArg = convertDictionary(curArg, { context: \\"Failed to execute 'op' on 'DictionaryConvert': parameter 2\\" });
-          args.push(curArg);
-        }
-        return this[impl].op(...args);
-      }
-    }
-    Object.defineProperties(DictionaryConvert.prototype, {
-      op: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"DictionaryConvert\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"DictionaryConvert\\"] = DictionaryConvert;
-
-    Object.defineProperty(globalObject, \\"DictionaryConvert\\", {
-      configurable: true,
-      writable: true,
-      value: DictionaryConvert
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'DictionaryConvert'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"DictionaryConvert\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor DictionaryConvert is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class DictionaryConvert {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    op() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (curArg !== undefined) {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'op' on 'DictionaryConvert': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      {
+        let curArg = arguments[1];
+        curArg = convertDictionary(curArg, { context: \\"Failed to execute 'op' on 'DictionaryConvert': parameter 2\\" });
+        args.push(curArg);
+      }
+      return this[impl].op(...args);
+    }
+  }
+  Object.defineProperties(DictionaryConvert.prototype, {
+    op: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"DictionaryConvert\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"DictionaryConvert\\"] = DictionaryConvert;
+
+  Object.defineProperty(globalObject, \\"DictionaryConvert\\", {
+    configurable: true,
+    writable: true,
+    value: DictionaryConvert
+  });
+};
 
 const Impl = require(\\"../implementations/DictionaryConvert.js\\");
 "
@@ -719,145 +714,144 @@ const RequestDestination = require(\\"./RequestDestination.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'Enum'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"Enum\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor Enum is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class Enum {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      op(destination) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'op' on 'Enum': 1 argument required, but only \\" + arguments.length + \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = convertRequestDestination(curArg, { context: \\"Failed to execute 'op' on 'Enum': parameter 1\\" });
-          args.push(curArg);
-        }
-        return this[impl].op(...args);
-      }
-
-      get attr() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return utils.tryWrapperForImpl(this[impl][\\"attr\\"]);
-      }
-
-      set attr(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = \`\${V}\`;
-        if (!RequestDestination.enumerationValues.has(V)) {
-          return;
-        }
-
-        this[impl][\\"attr\\"] = V;
-      }
-    }
-    Object.defineProperties(Enum.prototype, {
-      op: { enumerable: true },
-      attr: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"Enum\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"Enum\\"] = Enum;
-
-    Object.defineProperty(globalObject, \\"Enum\\", {
-      configurable: true,
-      writable: true,
-      value: Enum
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'Enum'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"Enum\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Enum is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class Enum {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    op(destination) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'op' on 'Enum': 1 argument required, but only \\" + arguments.length + \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = convertRequestDestination(curArg, { context: \\"Failed to execute 'op' on 'Enum': parameter 1\\" });
+        args.push(curArg);
+      }
+      return this[impl].op(...args);
+    }
+
+    get attr() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return utils.tryWrapperForImpl(this[impl][\\"attr\\"]);
+    }
+
+    set attr(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = \`\${V}\`;
+      if (!RequestDestination.enumerationValues.has(V)) {
+        return;
+      }
+
+      this[impl][\\"attr\\"] = V;
+    }
+  }
+  Object.defineProperties(Enum.prototype, {
+    op: { enumerable: true },
+    attr: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"Enum\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"Enum\\"] = Enum;
+
+  Object.defineProperty(globalObject, \\"Enum\\", {
+    configurable: true,
+    writable: true,
+    value: Enum
+  });
+};
 
 const Impl = require(\\"../implementations/Enum.js\\");
 "
@@ -872,186 +866,185 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'Global'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"Global\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor Global is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {
-    Object.defineProperties(
-      obj,
-      Object.getOwnPropertyDescriptors({
-        op() {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          return this[impl].op();
-        },
-        unforgeableOp() {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          return this[impl].unforgeableOp();
-        },
-        get attr() {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          return obj[impl][\\"attr\\"];
-        },
-        set attr(V) {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          V = conversions[\\"DOMString\\"](V, {
-            context: \\"Failed to set the 'attr' property on 'Global': The provided value\\"
-          });
-
-          obj[impl][\\"attr\\"] = V;
-        },
-        get unforgeableAttr() {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          return obj[impl][\\"unforgeableAttr\\"];
-        },
-        set unforgeableAttr(V) {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          V = conversions[\\"DOMString\\"](V, {
-            context: \\"Failed to set the 'unforgeableAttr' property on 'Global': The provided value\\"
-          });
-
-          obj[impl][\\"unforgeableAttr\\"] = V;
-        },
-        get length() {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          return obj[impl][\\"length\\"];
-        },
-        set length(V) {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          V = conversions[\\"unsigned long\\"](V, {
-            context: \\"Failed to set the 'length' property on 'Global': The provided value\\"
-          });
-
-          obj[impl][\\"length\\"] = V;
-        },
-        [Symbol.iterator]: Array.prototype[Symbol.iterator],
-        keys: Array.prototype.keys,
-        values: Array.prototype[Symbol.iterator],
-        entries: Array.prototype.entries,
-        forEach: Array.prototype.forEach
-      })
-    );
-
-    Object.defineProperties(obj, {
-      unforgeableOp: { configurable: false, writable: false },
-      unforgeableAttr: { configurable: false },
-      [Symbol.iterator]: { enumerable: false }
-    });
-  },
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class Global {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-    }
-    Object.defineProperties(Global.prototype, { [Symbol.toStringTag]: { value: \\"Global\\", configurable: true } });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"Global\\"] = Global;
-
-    Object.defineProperty(globalObject, \\"Global\\", {
-      configurable: true,
-      writable: true,
-      value: Global
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'Global'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"Global\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Global is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {
+  Object.defineProperties(
+    obj,
+    Object.getOwnPropertyDescriptors({
+      op() {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return this[impl].op();
+      },
+      unforgeableOp() {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return this[impl].unforgeableOp();
+      },
+      get attr() {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return obj[impl][\\"attr\\"];
+      },
+      set attr(V) {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        V = conversions[\\"DOMString\\"](V, {
+          context: \\"Failed to set the 'attr' property on 'Global': The provided value\\"
+        });
+
+        obj[impl][\\"attr\\"] = V;
+      },
+      get unforgeableAttr() {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return obj[impl][\\"unforgeableAttr\\"];
+      },
+      set unforgeableAttr(V) {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        V = conversions[\\"DOMString\\"](V, {
+          context: \\"Failed to set the 'unforgeableAttr' property on 'Global': The provided value\\"
+        });
+
+        obj[impl][\\"unforgeableAttr\\"] = V;
+      },
+      get length() {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return obj[impl][\\"length\\"];
+      },
+      set length(V) {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        V = conversions[\\"unsigned long\\"](V, {
+          context: \\"Failed to set the 'length' property on 'Global': The provided value\\"
+        });
+
+        obj[impl][\\"length\\"] = V;
+      },
+      [Symbol.iterator]: Array.prototype[Symbol.iterator],
+      keys: Array.prototype.keys,
+      values: Array.prototype[Symbol.iterator],
+      entries: Array.prototype.entries,
+      forEach: Array.prototype.forEach
+    })
+  );
+
+  Object.defineProperties(obj, {
+    unforgeableOp: { configurable: false, writable: false },
+    unforgeableAttr: { configurable: false },
+    [Symbol.iterator]: { enumerable: false }
+  });
+};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class Global {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+  }
+  Object.defineProperties(Global.prototype, { [Symbol.toStringTag]: { value: \\"Global\\", configurable: true } });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"Global\\"] = Global;
+
+  Object.defineProperty(globalObject, \\"Global\\", {
+    configurable: true,
+    writable: true,
+    value: Global
+  });
+};
 
 const Impl = require(\\"../implementations/Global.js\\");
 "
@@ -1066,113 +1059,112 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'LegacyArrayClass'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"LegacyArrayClass\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor LegacyArrayClass is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class LegacyArrayClass {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      get length() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"length\\"];
-      }
-    }
-    Object.setPrototypeOf(LegacyArrayClass.prototype, Array.prototype);
-    Object.defineProperties(LegacyArrayClass.prototype, {
-      length: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"LegacyArrayClass\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"LegacyArrayClass\\"] = LegacyArrayClass;
-
-    Object.defineProperty(globalObject, \\"LegacyArrayClass\\", {
-      configurable: true,
-      writable: true,
-      value: LegacyArrayClass
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'LegacyArrayClass'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"LegacyArrayClass\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor LegacyArrayClass is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class LegacyArrayClass {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    get length() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"length\\"];
+    }
+  }
+  Object.setPrototypeOf(LegacyArrayClass.prototype, Array.prototype);
+  Object.defineProperties(LegacyArrayClass.prototype, {
+    length: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"LegacyArrayClass\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"LegacyArrayClass\\"] = LegacyArrayClass;
+
+  Object.defineProperty(globalObject, \\"LegacyArrayClass\\", {
+    configurable: true,
+    writable: true,
+    value: LegacyArrayClass
+  });
+};
 
 const Impl = require(\\"../implementations/LegacyArrayClass.js\\");
 "
@@ -1187,169 +1179,168 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'MixedIn'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"MixedIn\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor MixedIn is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class MixedIn {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      mixedInOp() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].mixedInOp();
-      }
-
-      ifaceMixinOp() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].ifaceMixinOp();
-      }
-
-      get mixedInAttr() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"mixedInAttr\\"];
-      }
-
-      set mixedInAttr(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"DOMString\\"](V, {
-          context: \\"Failed to set the 'mixedInAttr' property on 'MixedIn': The provided value\\"
-        });
-
-        this[impl][\\"mixedInAttr\\"] = V;
-      }
-
-      get ifaceMixinAttr() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"ifaceMixinAttr\\"];
-      }
-
-      set ifaceMixinAttr(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"DOMString\\"](V, {
-          context: \\"Failed to set the 'ifaceMixinAttr' property on 'MixedIn': The provided value\\"
-        });
-
-        this[impl][\\"ifaceMixinAttr\\"] = V;
-      }
-    }
-    Object.defineProperties(MixedIn.prototype, {
-      mixedInOp: { enumerable: true },
-      ifaceMixinOp: { enumerable: true },
-      mixedInAttr: { enumerable: true },
-      ifaceMixinAttr: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"MixedIn\\", configurable: true },
-      mixedInConst: { value: 43, enumerable: true },
-      ifaceMixinConst: { value: 42, enumerable: true }
-    });
-    Object.defineProperties(MixedIn, {
-      mixedInConst: { value: 43, enumerable: true },
-      ifaceMixinConst: { value: 42, enumerable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"MixedIn\\"] = MixedIn;
-
-    Object.defineProperty(globalObject, \\"MixedIn\\", {
-      configurable: true,
-      writable: true,
-      value: MixedIn
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'MixedIn'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"MixedIn\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor MixedIn is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class MixedIn {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    mixedInOp() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].mixedInOp();
+    }
+
+    ifaceMixinOp() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].ifaceMixinOp();
+    }
+
+    get mixedInAttr() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"mixedInAttr\\"];
+    }
+
+    set mixedInAttr(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"DOMString\\"](V, {
+        context: \\"Failed to set the 'mixedInAttr' property on 'MixedIn': The provided value\\"
+      });
+
+      this[impl][\\"mixedInAttr\\"] = V;
+    }
+
+    get ifaceMixinAttr() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"ifaceMixinAttr\\"];
+    }
+
+    set ifaceMixinAttr(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"DOMString\\"](V, {
+        context: \\"Failed to set the 'ifaceMixinAttr' property on 'MixedIn': The provided value\\"
+      });
+
+      this[impl][\\"ifaceMixinAttr\\"] = V;
+    }
+  }
+  Object.defineProperties(MixedIn.prototype, {
+    mixedInOp: { enumerable: true },
+    ifaceMixinOp: { enumerable: true },
+    mixedInAttr: { enumerable: true },
+    ifaceMixinAttr: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"MixedIn\\", configurable: true },
+    mixedInConst: { value: 43, enumerable: true },
+    ifaceMixinConst: { value: 42, enumerable: true }
+  });
+  Object.defineProperties(MixedIn, {
+    mixedInConst: { value: 43, enumerable: true },
+    ifaceMixinConst: { value: 42, enumerable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"MixedIn\\"] = MixedIn;
+
+  Object.defineProperty(globalObject, \\"MixedIn\\", {
+    configurable: true,
+    writable: true,
+    value: MixedIn
+  });
+};
 
 const Impl = require(\\"../implementations/MixedIn.js\\");
 "
@@ -1366,409 +1357,408 @@ const convertURL = require(\\"./URL.js\\").convert;
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
+  }
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
         return true;
       }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'Overloads'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"Overloads\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor Overloads is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
     return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
+  }
+  throw new TypeError(\`\${context} is not of type 'Overloads'.\`);
+};
 
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
 
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
+  const ctor = globalObject[ctorRegistry][\\"Overloads\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Overloads is not installed on the passed global object\\");
+  }
 
-  install(globalObject) {
-    class Overloads {
-      constructor() {
-        const args = [];
-        switch (arguments.length) {
-          case 0:
-            break;
-          default: {
-            let curArg = arguments[0];
-            if (isURL(curArg)) {
-              {
-                let curArg = arguments[0];
-                curArg = convertURL(curArg, { context: \\"Failed to construct 'Overloads': parameter 1\\" });
-                args.push(curArg);
-              }
-            } else {
-              {
-                let curArg = arguments[0];
-                curArg = conversions[\\"DOMString\\"](curArg, { context: \\"Failed to construct 'Overloads': parameter 1\\" });
-                args.push(curArg);
-              }
-            }
-          }
-        }
-        return iface.setup(Object.create(new.target.prototype), globalObject, args);
-      }
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
 
-      compatible(arg1) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
 
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'compatible' on 'Overloads': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        switch (arguments.length) {
-          case 1:
-            {
-              let curArg = arguments[0];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'compatible' on 'Overloads': parameter 1\\"
-              });
-              args.push(curArg);
-            }
-            break;
-          case 2:
-            {
-              let curArg = arguments[0];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'compatible' on 'Overloads': parameter 1\\"
-              });
-              args.push(curArg);
-            }
-            {
-              let curArg = arguments[1];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'compatible' on 'Overloads': parameter 2\\"
-              });
-              args.push(curArg);
-            }
-            break;
-          default:
-            {
-              let curArg = arguments[0];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'compatible' on 'Overloads': parameter 1\\"
-              });
-              args.push(curArg);
-            }
-            {
-              let curArg = arguments[1];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'compatible' on 'Overloads': parameter 2\\"
-              });
-              args.push(curArg);
-            }
-            {
-              let curArg = arguments[2];
-              if (curArg !== undefined) {
-                curArg = conversions[\\"long\\"](curArg, {
-                  context: \\"Failed to execute 'compatible' on 'Overloads': parameter 3\\"
-                });
-              } else {
-                curArg = 0;
-              }
-              args.push(curArg);
-            }
-        }
-        return utils.tryWrapperForImpl(this[impl].compatible(...args));
-      }
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
 
-      incompatible1(arg1) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'incompatible1' on 'Overloads': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
+exports.install = function install(globalObject) {
+  class Overloads {
+    constructor() {
+      const args = [];
+      switch (arguments.length) {
+        case 0:
+          break;
+        default: {
           let curArg = arguments[0];
-          if (typeof curArg === \\"number\\") {
+          if (isURL(curArg)) {
             {
               let curArg = arguments[0];
-              curArg = conversions[\\"long\\"](curArg, {
-                context: \\"Failed to execute 'incompatible1' on 'Overloads': parameter 1\\"
-              });
+              curArg = convertURL(curArg, { context: \\"Failed to construct 'Overloads': parameter 1\\" });
               args.push(curArg);
             }
           } else {
             {
               let curArg = arguments[0];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'incompatible1' on 'Overloads': parameter 1\\"
-              });
+              curArg = conversions[\\"DOMString\\"](curArg, { context: \\"Failed to construct 'Overloads': parameter 1\\" });
               args.push(curArg);
             }
           }
         }
-        return this[impl].incompatible1(...args);
+      }
+      return exports.setup(Object.create(new.target.prototype), globalObject, args);
+    }
+
+    compatible(arg1) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      incompatible2(arg1) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'compatible' on 'Overloads': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      switch (arguments.length) {
+        case 1:
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'compatible' on 'Overloads': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+          break;
+        case 2:
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'compatible' on 'Overloads': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+          {
+            let curArg = arguments[1];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'compatible' on 'Overloads': parameter 2\\"
+            });
+            args.push(curArg);
+          }
+          break;
+        default:
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'compatible' on 'Overloads': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+          {
+            let curArg = arguments[1];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'compatible' on 'Overloads': parameter 2\\"
+            });
+            args.push(curArg);
+          }
+          {
+            let curArg = arguments[2];
+            if (curArg !== undefined) {
+              curArg = conversions[\\"long\\"](curArg, {
+                context: \\"Failed to execute 'compatible' on 'Overloads': parameter 3\\"
+              });
+            } else {
+              curArg = 0;
+            }
+            args.push(curArg);
+          }
+      }
+      return utils.tryWrapperForImpl(this[impl].compatible(...args));
+    }
 
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'incompatible2' on 'Overloads': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        switch (arguments.length) {
-          case 1:
-            {
-              let curArg = arguments[0];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'incompatible2' on 'Overloads': parameter 1\\"
-              });
-              args.push(curArg);
-            }
-            break;
-          default:
-            {
-              let curArg = arguments[0];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'incompatible2' on 'Overloads': parameter 1\\"
-              });
-              args.push(curArg);
-            }
-            {
-              let curArg = arguments[1];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'incompatible2' on 'Overloads': parameter 2\\"
-              });
-              args.push(curArg);
-            }
-        }
-        return this[impl].incompatible2(...args);
+    incompatible1(arg1) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      incompatible3(arg1) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'incompatible1' on 'Overloads': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'incompatible1' on 'Overloads': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'incompatible1' on 'Overloads': parameter 1\\"
+            });
+            args.push(curArg);
+          }
         }
+      }
+      return this[impl].incompatible1(...args);
+    }
 
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'incompatible3' on 'Overloads': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        switch (arguments.length) {
-          case 1:
-            {
-              let curArg = arguments[0];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 1\\"
-              });
-              args.push(curArg);
-            }
-            break;
-          case 2:
-            {
-              let curArg = arguments[0];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 1\\"
-              });
-              args.push(curArg);
-            }
-            {
-              let curArg = arguments[1];
-              if (curArg === undefined) {
-                {
-                  let curArg = arguments[1];
-                  if (curArg !== undefined) {
-                    curArg = convertURL(curArg, {
-                      context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
-                    });
-                  }
-                  args.push(curArg);
-                }
-              } else if (isURL(curArg)) {
-                {
-                  let curArg = arguments[1];
-                  if (curArg !== undefined) {
-                    curArg = convertURL(curArg, {
-                      context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
-                    });
-                  }
-                  args.push(curArg);
-                }
-              } else if (utils.isArrayBuffer(curArg)) {
-                {
-                  let curArg = arguments[1];
-                  if (utils.isArrayBuffer(curArg)) {
-                  } else if (ArrayBuffer.isView(curArg)) {
-                  } else {
-                    throw new TypeError(
-                      \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\" + \\" is not of any supported type.\\"
-                    );
-                  }
-                  args.push(curArg);
-                }
-              } else if (ArrayBuffer.isView(curArg)) {
-                {
-                  let curArg = arguments[1];
-                  if (utils.isArrayBuffer(curArg)) {
-                  } else if (ArrayBuffer.isView(curArg)) {
-                  } else {
-                    throw new TypeError(
-                      \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\" + \\" is not of any supported type.\\"
-                    );
-                  }
-                  args.push(curArg);
-                }
-              } else {
-                {
-                  let curArg = arguments[1];
-                  curArg = conversions[\\"DOMString\\"](curArg, {
+    incompatible2(arg1) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'incompatible2' on 'Overloads': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      switch (arguments.length) {
+        case 1:
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'incompatible2' on 'Overloads': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+          break;
+        default:
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'incompatible2' on 'Overloads': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+          {
+            let curArg = arguments[1];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'incompatible2' on 'Overloads': parameter 2\\"
+            });
+            args.push(curArg);
+          }
+      }
+      return this[impl].incompatible2(...args);
+    }
+
+    incompatible3(arg1) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'incompatible3' on 'Overloads': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      switch (arguments.length) {
+        case 1:
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+          break;
+        case 2:
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+          {
+            let curArg = arguments[1];
+            if (curArg === undefined) {
+              {
+                let curArg = arguments[1];
+                if (curArg !== undefined) {
+                  curArg = convertURL(curArg, {
                     context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
                   });
-                  args.push(curArg);
                 }
+                args.push(curArg);
+              }
+            } else if (isURL(curArg)) {
+              {
+                let curArg = arguments[1];
+                if (curArg !== undefined) {
+                  curArg = convertURL(curArg, {
+                    context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
+                  });
+                }
+                args.push(curArg);
+              }
+            } else if (utils.isArrayBuffer(curArg)) {
+              {
+                let curArg = arguments[1];
+                if (utils.isArrayBuffer(curArg)) {
+                } else if (ArrayBuffer.isView(curArg)) {
+                } else {
+                  throw new TypeError(
+                    \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\" + \\" is not of any supported type.\\"
+                  );
+                }
+                args.push(curArg);
+              }
+            } else if (ArrayBuffer.isView(curArg)) {
+              {
+                let curArg = arguments[1];
+                if (utils.isArrayBuffer(curArg)) {
+                } else if (ArrayBuffer.isView(curArg)) {
+                } else {
+                  throw new TypeError(
+                    \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\" + \\" is not of any supported type.\\"
+                  );
+                }
+                args.push(curArg);
+              }
+            } else {
+              {
+                let curArg = arguments[1];
+                curArg = conversions[\\"DOMString\\"](curArg, {
+                  context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
+                });
+                args.push(curArg);
               }
             }
-            break;
-          case 3:
-            throw new TypeError(
-              \\"Failed to execute 'incompatible3' on 'Overloads': only \\" + arguments.length + \\" arguments present.\\"
-            );
-            break;
-          default:
-            {
-              let curArg = arguments[0];
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 1\\"
-              });
-              args.push(curArg);
+          }
+          break;
+        case 3:
+          throw new TypeError(
+            \\"Failed to execute 'incompatible3' on 'Overloads': only \\" + arguments.length + \\" arguments present.\\"
+          );
+          break;
+        default:
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+          {
+            let curArg = arguments[1];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
+            });
+            args.push(curArg);
+          }
+          {
+            let curArg = arguments[2];
+            if (utils.isArrayBuffer(curArg)) {
+            } else if (ArrayBuffer.isView(curArg)) {
+            } else {
+              throw new TypeError(
+                \\"Failed to execute 'incompatible3' on 'Overloads': parameter 3\\" + \\" is not of any supported type.\\"
+              );
             }
-            {
-              let curArg = arguments[1];
-              curArg = conversions[\\"long\\"](curArg, {
-                context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
-              });
-              args.push(curArg);
+            args.push(curArg);
+          }
+          {
+            let curArg = arguments[3];
+            if (utils.isArrayBuffer(curArg)) {
+            } else if (ArrayBuffer.isView(curArg)) {
+            } else {
+              throw new TypeError(
+                \\"Failed to execute 'incompatible3' on 'Overloads': parameter 4\\" + \\" is not of any supported type.\\"
+              );
             }
-            {
-              let curArg = arguments[2];
-              if (utils.isArrayBuffer(curArg)) {
-              } else if (ArrayBuffer.isView(curArg)) {
-              } else {
-                throw new TypeError(
-                  \\"Failed to execute 'incompatible3' on 'Overloads': parameter 3\\" + \\" is not of any supported type.\\"
-                );
-              }
-              args.push(curArg);
-            }
-            {
-              let curArg = arguments[3];
-              if (utils.isArrayBuffer(curArg)) {
-              } else if (ArrayBuffer.isView(curArg)) {
-              } else {
-                throw new TypeError(
-                  \\"Failed to execute 'incompatible3' on 'Overloads': parameter 4\\" + \\" is not of any supported type.\\"
-                );
-              }
-              args.push(curArg);
-            }
-        }
-        return this[impl].incompatible3(...args);
+            args.push(curArg);
+          }
       }
+      return this[impl].incompatible3(...args);
     }
-    Object.defineProperties(Overloads.prototype, {
-      compatible: { enumerable: true },
-      incompatible1: { enumerable: true },
-      incompatible2: { enumerable: true },
-      incompatible3: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"Overloads\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"Overloads\\"] = Overloads;
-
-    Object.defineProperty(globalObject, \\"Overloads\\", {
-      configurable: true,
-      writable: true,
-      value: Overloads
-    });
   }
-}; // iface
-module.exports = iface;
+  Object.defineProperties(Overloads.prototype, {
+    compatible: { enumerable: true },
+    incompatible1: { enumerable: true },
+    incompatible2: { enumerable: true },
+    incompatible3: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"Overloads\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"Overloads\\"] = Overloads;
+
+  Object.defineProperty(globalObject, \\"Overloads\\", {
+    configurable: true,
+    writable: true,
+    value: Overloads
+  });
+};
 
 const Impl = require(\\"../implementations/Overloads.js\\");
 "
@@ -1783,159 +1773,158 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'PromiseTypes'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"PromiseTypes\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor PromiseTypes is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class PromiseTypes {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      voidPromiseConsumer(p) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'voidPromiseConsumer' on 'PromiseTypes': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = Promise.resolve(curArg).then(
-            value => {},
-            reason => reason
-          );
-          args.push(curArg);
-        }
-        return this[impl].voidPromiseConsumer(...args);
-      }
-
-      promiseConsumer(p) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = Promise.resolve(curArg).then(
-            value => {
-              value = conversions[\\"double\\"](value, {
-                context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-              });
-
-              return value;
-            },
-            reason => reason
-          );
-          args.push(curArg);
-        }
-        return this[impl].promiseConsumer(...args);
-      }
-    }
-    Object.defineProperties(PromiseTypes.prototype, {
-      voidPromiseConsumer: { enumerable: true },
-      promiseConsumer: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"PromiseTypes\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"PromiseTypes\\"] = PromiseTypes;
-
-    Object.defineProperty(globalObject, \\"PromiseTypes\\", {
-      configurable: true,
-      writable: true,
-      value: PromiseTypes
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'PromiseTypes'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"PromiseTypes\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor PromiseTypes is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class PromiseTypes {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    voidPromiseConsumer(p) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'voidPromiseConsumer' on 'PromiseTypes': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = Promise.resolve(curArg).then(
+          value => {},
+          reason => reason
+        );
+        args.push(curArg);
+      }
+      return this[impl].voidPromiseConsumer(...args);
+    }
+
+    promiseConsumer(p) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = Promise.resolve(curArg).then(
+          value => {
+            value = conversions[\\"double\\"](value, {
+              context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
+            });
+
+            return value;
+          },
+          reason => reason
+        );
+        args.push(curArg);
+      }
+      return this[impl].promiseConsumer(...args);
+    }
+  }
+  Object.defineProperties(PromiseTypes.prototype, {
+    voidPromiseConsumer: { enumerable: true },
+    promiseConsumer: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"PromiseTypes\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"PromiseTypes\\"] = PromiseTypes;
+
+  Object.defineProperty(globalObject, \\"PromiseTypes\\", {
+    configurable: true,
+    writable: true,
+    value: PromiseTypes
+  });
+};
 
 const Impl = require(\\"../implementations/PromiseTypes.js\\");
 "
@@ -1950,238 +1939,237 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'Reflect'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"Reflect\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor Reflect is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class Reflect {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      get ReflectedBoolean() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].hasAttributeNS(null, \\"reflectedboolean\\");
-      }
-
-      set ReflectedBoolean(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"boolean\\"](V, {
-          context: \\"Failed to set the 'ReflectedBoolean' property on 'Reflect': The provided value\\"
-        });
-
-        if (V) {
-          this[impl].setAttributeNS(null, \\"reflectedboolean\\", \\"\\");
-        } else {
-          this[impl].removeAttributeNS(null, \\"reflectedboolean\\");
-        }
-      }
-
-      get ReflectedDOMString() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        const value = this[impl].getAttributeNS(null, \\"reflecteddomstring\\");
-        return value === null ? \\"\\" : value;
-      }
-
-      set ReflectedDOMString(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"DOMString\\"](V, {
-          context: \\"Failed to set the 'ReflectedDOMString' property on 'Reflect': The provided value\\"
-        });
-
-        this[impl].setAttributeNS(null, \\"reflecteddomstring\\", V);
-      }
-
-      get ReflectedLong() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        const value = parseInt(this[impl].getAttributeNS(null, \\"reflectedlong\\"));
-        return isNaN(value) || value < -2147483648 || value > 2147483647 ? 0 : value;
-      }
-
-      set ReflectedLong(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"long\\"](V, {
-          context: \\"Failed to set the 'ReflectedLong' property on 'Reflect': The provided value\\"
-        });
-
-        this[impl].setAttributeNS(null, \\"reflectedlong\\", String(V));
-      }
-
-      get ReflectedUnsignedLong() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        const value = parseInt(this[impl].getAttributeNS(null, \\"reflectedunsignedlong\\"));
-        return isNaN(value) || value < 0 || value > 2147483647 ? 0 : value;
-      }
-
-      set ReflectedUnsignedLong(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"unsigned long\\"](V, {
-          context: \\"Failed to set the 'ReflectedUnsignedLong' property on 'Reflect': The provided value\\"
-        });
-
-        this[impl].setAttributeNS(null, \\"reflectedunsignedlong\\", String(V > 2147483647 ? 0 : V));
-      }
-
-      get ReflectionTest() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        const value = this[impl].getAttributeNS(null, \\"reflection\\");
-        return value === null ? \\"\\" : value;
-      }
-
-      set ReflectionTest(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"DOMString\\"](V, {
-          context: \\"Failed to set the 'ReflectionTest' property on 'Reflect': The provided value\\"
-        });
-
-        this[impl].setAttributeNS(null, \\"reflection\\", V);
-      }
-
-      get withUnderscore() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        const value = this[impl].getAttributeNS(null, \\"with-underscore\\");
-        return value === null ? \\"\\" : value;
-      }
-
-      set withUnderscore(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"DOMString\\"](V, {
-          context: \\"Failed to set the 'withUnderscore' property on 'Reflect': The provided value\\"
-        });
-
-        this[impl].setAttributeNS(null, \\"with-underscore\\", V);
-      }
-    }
-    Object.defineProperties(Reflect.prototype, {
-      ReflectedBoolean: { enumerable: true },
-      ReflectedDOMString: { enumerable: true },
-      ReflectedLong: { enumerable: true },
-      ReflectedUnsignedLong: { enumerable: true },
-      ReflectionTest: { enumerable: true },
-      withUnderscore: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"Reflect\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"Reflect\\"] = Reflect;
-
-    Object.defineProperty(globalObject, \\"Reflect\\", {
-      configurable: true,
-      writable: true,
-      value: Reflect
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'Reflect'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"Reflect\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Reflect is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class Reflect {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    get ReflectedBoolean() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].hasAttributeNS(null, \\"reflectedboolean\\");
+    }
+
+    set ReflectedBoolean(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"boolean\\"](V, {
+        context: \\"Failed to set the 'ReflectedBoolean' property on 'Reflect': The provided value\\"
+      });
+
+      if (V) {
+        this[impl].setAttributeNS(null, \\"reflectedboolean\\", \\"\\");
+      } else {
+        this[impl].removeAttributeNS(null, \\"reflectedboolean\\");
+      }
+    }
+
+    get ReflectedDOMString() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      const value = this[impl].getAttributeNS(null, \\"reflecteddomstring\\");
+      return value === null ? \\"\\" : value;
+    }
+
+    set ReflectedDOMString(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"DOMString\\"](V, {
+        context: \\"Failed to set the 'ReflectedDOMString' property on 'Reflect': The provided value\\"
+      });
+
+      this[impl].setAttributeNS(null, \\"reflecteddomstring\\", V);
+    }
+
+    get ReflectedLong() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      const value = parseInt(this[impl].getAttributeNS(null, \\"reflectedlong\\"));
+      return isNaN(value) || value < -2147483648 || value > 2147483647 ? 0 : value;
+    }
+
+    set ReflectedLong(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"long\\"](V, {
+        context: \\"Failed to set the 'ReflectedLong' property on 'Reflect': The provided value\\"
+      });
+
+      this[impl].setAttributeNS(null, \\"reflectedlong\\", String(V));
+    }
+
+    get ReflectedUnsignedLong() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      const value = parseInt(this[impl].getAttributeNS(null, \\"reflectedunsignedlong\\"));
+      return isNaN(value) || value < 0 || value > 2147483647 ? 0 : value;
+    }
+
+    set ReflectedUnsignedLong(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"unsigned long\\"](V, {
+        context: \\"Failed to set the 'ReflectedUnsignedLong' property on 'Reflect': The provided value\\"
+      });
+
+      this[impl].setAttributeNS(null, \\"reflectedunsignedlong\\", String(V > 2147483647 ? 0 : V));
+    }
+
+    get ReflectionTest() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      const value = this[impl].getAttributeNS(null, \\"reflection\\");
+      return value === null ? \\"\\" : value;
+    }
+
+    set ReflectionTest(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"DOMString\\"](V, {
+        context: \\"Failed to set the 'ReflectionTest' property on 'Reflect': The provided value\\"
+      });
+
+      this[impl].setAttributeNS(null, \\"reflection\\", V);
+    }
+
+    get withUnderscore() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      const value = this[impl].getAttributeNS(null, \\"with-underscore\\");
+      return value === null ? \\"\\" : value;
+    }
+
+    set withUnderscore(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"DOMString\\"](V, {
+        context: \\"Failed to set the 'withUnderscore' property on 'Reflect': The provided value\\"
+      });
+
+      this[impl].setAttributeNS(null, \\"with-underscore\\", V);
+    }
+  }
+  Object.defineProperties(Reflect.prototype, {
+    ReflectedBoolean: { enumerable: true },
+    ReflectedDOMString: { enumerable: true },
+    ReflectedLong: { enumerable: true },
+    ReflectedUnsignedLong: { enumerable: true },
+    ReflectionTest: { enumerable: true },
+    withUnderscore: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"Reflect\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"Reflect\\"] = Reflect;
+
+  Object.defineProperty(globalObject, \\"Reflect\\", {
+    configurable: true,
+    writable: true,
+    value: Reflect
+  });
+};
 
 const Impl = require(\\"../implementations/Reflect.js\\");
 "
@@ -2208,15 +2196,14 @@ const enumerationValues = new Set([
   \\"worker\\",
   \\"xslt\\"
 ]);
-module.exports = {
-  enumerationValues,
-  convert(value, { context = \\"The provided value\\" } = {}) {
-    const string = \`\${value}\`;
-    if (!enumerationValues.has(value)) {
-      throw new TypeError(\`\${context} '\${value}' is not a valid enumeration value for RequestDestination\`);
-    }
-    return string;
+exports.enumerationValues = enumerationValues;
+
+exports.convert = function convert(value, { context = \\"The provided value\\" } = {}) {
+  const string = \`\${value}\`;
+  if (!enumerationValues.has(value)) {
+    throw new TypeError(\`\${context} '\${value}' is not a valid enumeration value for RequestDestination\`);
   }
+  return string;
 };
 "
 `;
@@ -2231,307 +2218,302 @@ const convertURL = require(\\"./URL.js\\").convert;
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'SeqAndRec'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"SeqAndRec\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor SeqAndRec is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class SeqAndRec {
-      constructor() {
-        return iface.setup(Object.create(new.target.prototype), globalObject, undefined);
-      }
-
-      recordConsumer(rec) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'recordConsumer' on 'SeqAndRec': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (!utils.isObject(curArg)) {
-            throw new TypeError(
-              \\"Failed to execute 'recordConsumer' on 'SeqAndRec': parameter 1\\" + \\" is not an object.\\"
-            );
-          } else {
-            const result = Object.create(null);
-            for (const key of Reflect.ownKeys(curArg)) {
-              const desc = Object.getOwnPropertyDescriptor(curArg, key);
-              if (desc && desc.enumerable) {
-                let typedKey = key;
-
-                typedKey = conversions[\\"USVString\\"](typedKey, {
-                  context: \\"Failed to execute 'recordConsumer' on 'SeqAndRec': parameter 1\\" + \\"'s key\\"
-                });
-
-                let typedValue = curArg[key];
-
-                typedValue = conversions[\\"double\\"](typedValue, {
-                  context: \\"Failed to execute 'recordConsumer' on 'SeqAndRec': parameter 1\\" + \\"'s value\\"
-                });
-
-                result[typedKey] = typedValue;
-              }
-            }
-            curArg = result;
-          }
-          args.push(curArg);
-        }
-        return this[impl].recordConsumer(...args);
-      }
-
-      recordConsumer2(rec) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (!utils.isObject(curArg)) {
-            throw new TypeError(
-              \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': parameter 1\\" + \\" is not an object.\\"
-            );
-          } else {
-            const result = Object.create(null);
-            for (const key of Reflect.ownKeys(curArg)) {
-              const desc = Object.getOwnPropertyDescriptor(curArg, key);
-              if (desc && desc.enumerable) {
-                let typedKey = key;
-
-                typedKey = conversions[\\"USVString\\"](typedKey, {
-                  context: \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': parameter 1\\" + \\"'s key\\"
-                });
-
-                let typedValue = curArg[key];
-
-                typedValue = convertURL(typedValue, {
-                  context: \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': parameter 1\\" + \\"'s value\\"
-                });
-
-                result[typedKey] = typedValue;
-              }
-            }
-            curArg = result;
-          }
-          args.push(curArg);
-        }
-        return this[impl].recordConsumer2(...args);
-      }
-
-      sequenceConsumer(seq) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'sequenceConsumer' on 'SeqAndRec': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (!utils.isObject(curArg)) {
-            throw new TypeError(
-              \\"Failed to execute 'sequenceConsumer' on 'SeqAndRec': parameter 1\\" + \\" is not an iterable object.\\"
-            );
-          } else {
-            const V = [];
-            const tmp = curArg;
-            for (let nextItem of tmp) {
-              nextItem = conversions[\\"USVString\\"](nextItem, {
-                context: \\"Failed to execute 'sequenceConsumer' on 'SeqAndRec': parameter 1\\" + \\"'s element\\"
-              });
-
-              V.push(nextItem);
-            }
-            curArg = V;
-          }
-          args.push(curArg);
-        }
-        return this[impl].sequenceConsumer(...args);
-      }
-
-      sequenceConsumer2(seq) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'sequenceConsumer2' on 'SeqAndRec': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (!utils.isObject(curArg)) {
-            throw new TypeError(
-              \\"Failed to execute 'sequenceConsumer2' on 'SeqAndRec': parameter 1\\" + \\" is not an iterable object.\\"
-            );
-          } else {
-            const V = [];
-            const tmp = curArg;
-            for (let nextItem of tmp) {
-              nextItem = utils.tryImplForWrapper(nextItem);
-
-              V.push(nextItem);
-            }
-            curArg = V;
-          }
-          args.push(curArg);
-        }
-        return this[impl].sequenceConsumer2(...args);
-      }
-
-      frozenArrayConsumer(arr) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'frozenArrayConsumer' on 'SeqAndRec': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (!utils.isObject(curArg)) {
-            throw new TypeError(
-              \\"Failed to execute 'frozenArrayConsumer' on 'SeqAndRec': parameter 1\\" + \\" is not an iterable object.\\"
-            );
-          } else {
-            const V = [];
-            const tmp = curArg;
-            for (let nextItem of tmp) {
-              nextItem = conversions[\\"double\\"](nextItem, {
-                context: \\"Failed to execute 'frozenArrayConsumer' on 'SeqAndRec': parameter 1\\" + \\"'s element\\"
-              });
-
-              V.push(nextItem);
-            }
-            curArg = V;
-          }
-          curArg = Object.freeze(curArg);
-          args.push(curArg);
-        }
-        return this[impl].frozenArrayConsumer(...args);
-      }
-    }
-    Object.defineProperties(SeqAndRec.prototype, {
-      recordConsumer: { enumerable: true },
-      recordConsumer2: { enumerable: true },
-      sequenceConsumer: { enumerable: true },
-      sequenceConsumer2: { enumerable: true },
-      frozenArrayConsumer: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"SeqAndRec\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"SeqAndRec\\"] = SeqAndRec;
-
-    Object.defineProperty(globalObject, \\"SeqAndRec\\", {
-      configurable: true,
-      writable: true,
-      value: SeqAndRec
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'SeqAndRec'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"SeqAndRec\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor SeqAndRec is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class SeqAndRec {
+    constructor() {
+      return exports.setup(Object.create(new.target.prototype), globalObject, undefined);
+    }
+
+    recordConsumer(rec) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'recordConsumer' on 'SeqAndRec': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (!utils.isObject(curArg)) {
+          throw new TypeError(\\"Failed to execute 'recordConsumer' on 'SeqAndRec': parameter 1\\" + \\" is not an object.\\");
+        } else {
+          const result = Object.create(null);
+          for (const key of Reflect.ownKeys(curArg)) {
+            const desc = Object.getOwnPropertyDescriptor(curArg, key);
+            if (desc && desc.enumerable) {
+              let typedKey = key;
+
+              typedKey = conversions[\\"USVString\\"](typedKey, {
+                context: \\"Failed to execute 'recordConsumer' on 'SeqAndRec': parameter 1\\" + \\"'s key\\"
+              });
+
+              let typedValue = curArg[key];
+
+              typedValue = conversions[\\"double\\"](typedValue, {
+                context: \\"Failed to execute 'recordConsumer' on 'SeqAndRec': parameter 1\\" + \\"'s value\\"
+              });
+
+              result[typedKey] = typedValue;
+            }
+          }
+          curArg = result;
+        }
+        args.push(curArg);
+      }
+      return this[impl].recordConsumer(...args);
+    }
+
+    recordConsumer2(rec) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (!utils.isObject(curArg)) {
+          throw new TypeError(\\"Failed to execute 'recordConsumer2' on 'SeqAndRec': parameter 1\\" + \\" is not an object.\\");
+        } else {
+          const result = Object.create(null);
+          for (const key of Reflect.ownKeys(curArg)) {
+            const desc = Object.getOwnPropertyDescriptor(curArg, key);
+            if (desc && desc.enumerable) {
+              let typedKey = key;
+
+              typedKey = conversions[\\"USVString\\"](typedKey, {
+                context: \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': parameter 1\\" + \\"'s key\\"
+              });
+
+              let typedValue = curArg[key];
+
+              typedValue = convertURL(typedValue, {
+                context: \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': parameter 1\\" + \\"'s value\\"
+              });
+
+              result[typedKey] = typedValue;
+            }
+          }
+          curArg = result;
+        }
+        args.push(curArg);
+      }
+      return this[impl].recordConsumer2(...args);
+    }
+
+    sequenceConsumer(seq) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'sequenceConsumer' on 'SeqAndRec': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (!utils.isObject(curArg)) {
+          throw new TypeError(
+            \\"Failed to execute 'sequenceConsumer' on 'SeqAndRec': parameter 1\\" + \\" is not an iterable object.\\"
+          );
+        } else {
+          const V = [];
+          const tmp = curArg;
+          for (let nextItem of tmp) {
+            nextItem = conversions[\\"USVString\\"](nextItem, {
+              context: \\"Failed to execute 'sequenceConsumer' on 'SeqAndRec': parameter 1\\" + \\"'s element\\"
+            });
+
+            V.push(nextItem);
+          }
+          curArg = V;
+        }
+        args.push(curArg);
+      }
+      return this[impl].sequenceConsumer(...args);
+    }
+
+    sequenceConsumer2(seq) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'sequenceConsumer2' on 'SeqAndRec': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (!utils.isObject(curArg)) {
+          throw new TypeError(
+            \\"Failed to execute 'sequenceConsumer2' on 'SeqAndRec': parameter 1\\" + \\" is not an iterable object.\\"
+          );
+        } else {
+          const V = [];
+          const tmp = curArg;
+          for (let nextItem of tmp) {
+            nextItem = utils.tryImplForWrapper(nextItem);
+
+            V.push(nextItem);
+          }
+          curArg = V;
+        }
+        args.push(curArg);
+      }
+      return this[impl].sequenceConsumer2(...args);
+    }
+
+    frozenArrayConsumer(arr) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'frozenArrayConsumer' on 'SeqAndRec': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (!utils.isObject(curArg)) {
+          throw new TypeError(
+            \\"Failed to execute 'frozenArrayConsumer' on 'SeqAndRec': parameter 1\\" + \\" is not an iterable object.\\"
+          );
+        } else {
+          const V = [];
+          const tmp = curArg;
+          for (let nextItem of tmp) {
+            nextItem = conversions[\\"double\\"](nextItem, {
+              context: \\"Failed to execute 'frozenArrayConsumer' on 'SeqAndRec': parameter 1\\" + \\"'s element\\"
+            });
+
+            V.push(nextItem);
+          }
+          curArg = V;
+        }
+        curArg = Object.freeze(curArg);
+        args.push(curArg);
+      }
+      return this[impl].frozenArrayConsumer(...args);
+    }
+  }
+  Object.defineProperties(SeqAndRec.prototype, {
+    recordConsumer: { enumerable: true },
+    recordConsumer2: { enumerable: true },
+    sequenceConsumer: { enumerable: true },
+    sequenceConsumer2: { enumerable: true },
+    frozenArrayConsumer: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"SeqAndRec\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"SeqAndRec\\"] = SeqAndRec;
+
+  Object.defineProperty(globalObject, \\"SeqAndRec\\", {
+    configurable: true,
+    writable: true,
+    value: SeqAndRec
+  });
+};
 
 const Impl = require(\\"../implementations/SeqAndRec.js\\");
 "
@@ -2546,146 +2528,143 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'Static'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"Static\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor Static is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class Static {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      def() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].def();
-      }
-
-      get abc() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"abc\\"];
-      }
-
-      set abc(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"DOMString\\"](V, {
-          context: \\"Failed to set the 'abc' property on 'Static': The provided value\\"
-        });
-
-        this[impl][\\"abc\\"] = V;
-      }
-
-      static def() {
-        return Impl.implementation.def();
-      }
-
-      static get abc() {
-        return Impl.implementation[\\"abc\\"];
-      }
-
-      static set abc(V) {
-        return Impl.implementation[\\"abc\\"];
-      }
-    }
-    Object.defineProperties(Static.prototype, {
-      def: { enumerable: true },
-      abc: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"Static\\", configurable: true }
-    });
-    Object.defineProperties(Static, { def: { enumerable: true }, abc: { enumerable: true } });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"Static\\"] = Static;
-
-    Object.defineProperty(globalObject, \\"Static\\", {
-      configurable: true,
-      writable: true,
-      value: Static
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'Static'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"Static\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Static is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class Static {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    def() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].def();
+    }
+
+    get abc() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"abc\\"];
+    }
+
+    set abc(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"DOMString\\"](V, { context: \\"Failed to set the 'abc' property on 'Static': The provided value\\" });
+
+      this[impl][\\"abc\\"] = V;
+    }
+
+    static def() {
+      return Impl.implementation.def();
+    }
+
+    static get abc() {
+      return Impl.implementation[\\"abc\\"];
+    }
+
+    static set abc(V) {
+      return Impl.implementation[\\"abc\\"];
+    }
+  }
+  Object.defineProperties(Static.prototype, {
+    def: { enumerable: true },
+    abc: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"Static\\", configurable: true }
+  });
+  Object.defineProperties(Static, { def: { enumerable: true }, abc: { enumerable: true } });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"Static\\"] = Static;
+
+  Object.defineProperty(globalObject, \\"Static\\", {
+    configurable: true,
+    writable: true,
+    value: Static
+  });
+};
 
 const Impl = require(\\"../implementations/Static.js\\");
 "
@@ -2700,208 +2679,155 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
+  }
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
         return true;
       }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'Storage'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"Storage\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor Storage is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
     return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
+  }
+  throw new TypeError(\`\${context} is not of type 'Storage'.\`);
+};
 
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
 
-    obj = new Proxy(obj, {
-      get(target, P, receiver) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.get(target, P, receiver);
-        }
-        const desc = this.getOwnPropertyDescriptor(target, P);
-        if (desc === undefined) {
-          const parent = Object.getPrototypeOf(target);
-          if (parent === null) {
-            return undefined;
-          }
-          return Reflect.get(target, P, receiver);
-        }
-        if (!desc.get && !desc.set) {
-          return desc.value;
-        }
-        const getter = desc.get;
-        if (getter === undefined) {
+  const ctor = globalObject[ctorRegistry][\\"Storage\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Storage is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj = new Proxy(obj, {
+    get(target, P, receiver) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.get(target, P, receiver);
+      }
+      const desc = this.getOwnPropertyDescriptor(target, P);
+      if (desc === undefined) {
+        const parent = Object.getPrototypeOf(target);
+        if (parent === null) {
           return undefined;
         }
-        return Reflect.apply(getter, receiver, []);
-      },
+        return Reflect.get(target, P, receiver);
+      }
+      if (!desc.get && !desc.set) {
+        return desc.value;
+      }
+      const getter = desc.get;
+      if (getter === undefined) {
+        return undefined;
+      }
+      return Reflect.apply(getter, receiver, []);
+    },
 
-      has(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.has(target, P);
+    has(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.has(target, P);
+      }
+      const desc = this.getOwnPropertyDescriptor(target, P);
+      if (desc !== undefined) {
+        return true;
+      }
+      const parent = Object.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.has(parent, P);
+      }
+      return false;
+    },
+
+    ownKeys(target) {
+      const keys = new Set();
+
+      for (const key of target[impl][utils.supportedPropertyNames]) {
+        if (!(key in target)) {
+          keys.add(\`\${key}\`);
         }
-        const desc = this.getOwnPropertyDescriptor(target, P);
-        if (desc !== undefined) {
-          return true;
-        }
-        const parent = Object.getPrototypeOf(target);
-        if (parent !== null) {
-          return Reflect.has(parent, P);
-        }
-        return false;
-      },
+      }
 
-      ownKeys(target) {
-        const keys = new Set();
+      for (const key of Reflect.ownKeys(target)) {
+        keys.add(key);
+      }
+      return [...keys];
+    },
 
-        for (const key of target[impl][utils.supportedPropertyNames]) {
-          if (!(key in target)) {
-            keys.add(\`\${key}\`);
-          }
-        }
-
-        for (const key of Reflect.ownKeys(target)) {
-          keys.add(key);
-        }
-        return [...keys];
-      },
-
-      getOwnPropertyDescriptor(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.getOwnPropertyDescriptor(target, P);
-        }
-        let ignoreNamedProps = false;
-
-        if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-          const namedValue = target[impl].getItem(P);
-
-          return {
-            writable: true,
-            enumerable: true,
-            configurable: true,
-            value: utils.tryWrapperForImpl(namedValue)
-          };
-        }
-
+    getOwnPropertyDescriptor(target, P) {
+      if (typeof P === \\"symbol\\") {
         return Reflect.getOwnPropertyDescriptor(target, P);
-      },
+      }
+      let ignoreNamedProps = false;
 
-      set(target, P, V, receiver) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.set(target, P, V, receiver);
-        }
-        if (target === receiver) {
-          if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
-            let namedValue = V;
+      if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+        const namedValue = target[impl].getItem(P);
 
-            namedValue = conversions[\\"DOMString\\"](namedValue, {
-              context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
-            });
+        return {
+          writable: true,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
 
-            target[impl].setItem(P, namedValue);
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    },
 
-            return true;
-          }
-        }
-        let ownDesc;
-
-        if (ownDesc === undefined) {
-          ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-        }
-        if (ownDesc === undefined) {
-          const parent = Reflect.getPrototypeOf(target);
-          if (parent !== null) {
-            return Reflect.set(parent, P, V, receiver);
-          }
-          ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-        }
-        if (!ownDesc.writable) {
-          return false;
-        }
-        if (!utils.isObject(receiver)) {
-          return false;
-        }
-        const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-        let valueDesc;
-        if (existingDesc !== undefined) {
-          if (existingDesc.get || existingDesc.set) {
-            return false;
-          }
-          if (!existingDesc.writable) {
-            return false;
-          }
-          valueDesc = { value: V };
-        } else {
-          valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-        }
-        return Reflect.defineProperty(receiver, P, valueDesc);
-      },
-
-      defineProperty(target, P, desc) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.defineProperty(target, P, desc);
-        }
-        if (!utils.hasOwn(target, P)) {
-          if (desc.get || desc.set) {
-            return false;
-          }
-
-          let namedValue = desc.value;
+    set(target, P, V, receiver) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.set(target, P, V, receiver);
+      }
+      if (target === receiver) {
+        if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
+          let namedValue = V;
 
           namedValue = conversions[\\"DOMString\\"](namedValue, {
             context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
@@ -2911,171 +2837,213 @@ const iface = {
 
           return true;
         }
-        return Reflect.defineProperty(target, P, desc);
-      },
+      }
+      let ownDesc;
 
-      deleteProperty(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.deleteProperty(target, P);
+      if (ownDesc === undefined) {
+        ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+      }
+      if (ownDesc === undefined) {
+        const parent = Reflect.getPrototypeOf(target);
+        if (parent !== null) {
+          return Reflect.set(parent, P, V, receiver);
         }
-
-        if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
-          target[impl].removeItem(P);
-          return true;
-        }
-
-        return Reflect.deleteProperty(target, P);
-      },
-
-      preventExtensions() {
+        ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+      }
+      if (!ownDesc.writable) {
         return false;
       }
-    });
+      if (!utils.isObject(receiver)) {
+        return false;
+      }
+      const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+      let valueDesc;
+      if (existingDesc !== undefined) {
+        if (existingDesc.get || existingDesc.set) {
+          return false;
+        }
+        if (!existingDesc.writable) {
+          return false;
+        }
+        valueDesc = { value: V };
+      } else {
+        valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+      }
+      return Reflect.defineProperty(receiver, P, valueDesc);
+    },
 
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
+    defineProperty(target, P, desc) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.defineProperty(target, P, desc);
+      }
+      if (!utils.hasOwn(target, P)) {
+        if (desc.get || desc.set) {
+          return false;
+        }
+
+        let namedValue = desc.value;
+
+        namedValue = conversions[\\"DOMString\\"](namedValue, {
+          context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
+        });
+
+        target[impl].setItem(P, namedValue);
+
+        return true;
+      }
+      return Reflect.defineProperty(target, P, desc);
+    },
+
+    deleteProperty(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.deleteProperty(target, P);
+      }
+
+      if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
+        target[impl].removeItem(P);
+        return true;
+      }
+
+      return Reflect.deleteProperty(target, P);
+    },
+
+    preventExtensions() {
+      return false;
     }
-    return obj;
-  },
+  });
 
-  install(globalObject) {
-    class Storage {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      key(index) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'key' on 'Storage': 1 argument required, but only \\" + arguments.length + \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"unsigned long\\"](curArg, {
-            context: \\"Failed to execute 'key' on 'Storage': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].key(...args);
-      }
-
-      getItem(key) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'getItem' on 'Storage': 1 argument required, but only \\" + arguments.length + \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'getItem' on 'Storage': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].getItem(...args);
-      }
-
-      setItem(key, value) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 2) {
-          throw new TypeError(
-            \\"Failed to execute 'setItem' on 'Storage': 2 arguments required, but only \\" + arguments.length + \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'setItem' on 'Storage': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        {
-          let curArg = arguments[1];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'setItem' on 'Storage': parameter 2\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].setItem(...args);
-      }
-
-      removeItem(key) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'removeItem' on 'Storage': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'removeItem' on 'Storage': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].removeItem(...args);
-      }
-
-      clear() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].clear();
-      }
-
-      get length() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"length\\"];
-      }
-    }
-    Object.defineProperties(Storage.prototype, {
-      key: { enumerable: true },
-      getItem: { enumerable: true },
-      setItem: { enumerable: true },
-      removeItem: { enumerable: true },
-      clear: { enumerable: true },
-      length: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"Storage\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"Storage\\"] = Storage;
-
-    Object.defineProperty(globalObject, \\"Storage\\", {
-      configurable: true,
-      writable: true,
-      value: Storage
-    });
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
   }
-}; // iface
-module.exports = iface;
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class Storage {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    key(index) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'key' on 'Storage': 1 argument required, but only \\" + arguments.length + \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"unsigned long\\"](curArg, { context: \\"Failed to execute 'key' on 'Storage': parameter 1\\" });
+        args.push(curArg);
+      }
+      return this[impl].key(...args);
+    }
+
+    getItem(key) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'getItem' on 'Storage': 1 argument required, but only \\" + arguments.length + \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"DOMString\\"](curArg, { context: \\"Failed to execute 'getItem' on 'Storage': parameter 1\\" });
+        args.push(curArg);
+      }
+      return this[impl].getItem(...args);
+    }
+
+    setItem(key, value) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 2) {
+        throw new TypeError(
+          \\"Failed to execute 'setItem' on 'Storage': 2 arguments required, but only \\" + arguments.length + \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"DOMString\\"](curArg, { context: \\"Failed to execute 'setItem' on 'Storage': parameter 1\\" });
+        args.push(curArg);
+      }
+      {
+        let curArg = arguments[1];
+        curArg = conversions[\\"DOMString\\"](curArg, { context: \\"Failed to execute 'setItem' on 'Storage': parameter 2\\" });
+        args.push(curArg);
+      }
+      return this[impl].setItem(...args);
+    }
+
+    removeItem(key) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'removeItem' on 'Storage': 1 argument required, but only \\" + arguments.length + \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'removeItem' on 'Storage': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return this[impl].removeItem(...args);
+    }
+
+    clear() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].clear();
+    }
+
+    get length() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"length\\"];
+    }
+  }
+  Object.defineProperties(Storage.prototype, {
+    key: { enumerable: true },
+    getItem: { enumerable: true },
+    setItem: { enumerable: true },
+    removeItem: { enumerable: true },
+    clear: { enumerable: true },
+    length: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"Storage\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"Storage\\"] = Storage;
+
+  Object.defineProperty(globalObject, \\"Storage\\", {
+    configurable: true,
+    writable: true,
+    value: Storage
+  });
+};
 
 const Impl = require(\\"../implementations/Storage.js\\");
 "
@@ -3090,120 +3058,119 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'StringifierAttribute'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"StringifierAttribute\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor StringifierAttribute is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class StringifierAttribute {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      get attr() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"attr\\"];
-      }
-
-      toString() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-        return this[impl][\\"attr\\"];
-      }
-    }
-    Object.defineProperties(StringifierAttribute.prototype, {
-      attr: { enumerable: true },
-      toString: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"StringifierAttribute\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"StringifierAttribute\\"] = StringifierAttribute;
-
-    Object.defineProperty(globalObject, \\"StringifierAttribute\\", {
-      configurable: true,
-      writable: true,
-      value: StringifierAttribute
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'StringifierAttribute'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"StringifierAttribute\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor StringifierAttribute is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class StringifierAttribute {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    get attr() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"attr\\"];
+    }
+
+    toString() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+      return this[impl][\\"attr\\"];
+    }
+  }
+  Object.defineProperties(StringifierAttribute.prototype, {
+    attr: { enumerable: true },
+    toString: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"StringifierAttribute\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"StringifierAttribute\\"] = StringifierAttribute;
+
+  Object.defineProperty(globalObject, \\"StringifierAttribute\\", {
+    configurable: true,
+    writable: true,
+    value: StringifierAttribute
+  });
+};
 
 const Impl = require(\\"../implementations/StringifierAttribute.js\\");
 "
@@ -3218,114 +3185,113 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'StringifierDefaultOperation'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"StringifierDefaultOperation\\"];
-    if (ctor === undefined) {
-      throw new Error(
-        \\"Internal error: constructor StringifierDefaultOperation is not installed on the passed global object\\"
-      );
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class StringifierDefaultOperation {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      toString() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].toString();
-      }
-    }
-    Object.defineProperties(StringifierDefaultOperation.prototype, {
-      toString: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"StringifierDefaultOperation\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"StringifierDefaultOperation\\"] = StringifierDefaultOperation;
-
-    Object.defineProperty(globalObject, \\"StringifierDefaultOperation\\", {
-      configurable: true,
-      writable: true,
-      value: StringifierDefaultOperation
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'StringifierDefaultOperation'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"StringifierDefaultOperation\\"];
+  if (ctor === undefined) {
+    throw new Error(
+      \\"Internal error: constructor StringifierDefaultOperation is not installed on the passed global object\\"
+    );
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class StringifierDefaultOperation {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    toString() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].toString();
+    }
+  }
+  Object.defineProperties(StringifierDefaultOperation.prototype, {
+    toString: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"StringifierDefaultOperation\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"StringifierDefaultOperation\\"] = StringifierDefaultOperation;
+
+  Object.defineProperty(globalObject, \\"StringifierDefaultOperation\\", {
+    configurable: true,
+    writable: true,
+    value: StringifierDefaultOperation
+  });
+};
 
 const Impl = require(\\"../implementations/StringifierDefaultOperation.js\\");
 "
@@ -3340,123 +3306,122 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'StringifierNamedOperation'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"StringifierNamedOperation\\"];
-    if (ctor === undefined) {
-      throw new Error(
-        \\"Internal error: constructor StringifierNamedOperation is not installed on the passed global object\\"
-      );
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class StringifierNamedOperation {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      operation() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].operation();
-      }
-
-      toString() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].operation();
-      }
-    }
-    Object.defineProperties(StringifierNamedOperation.prototype, {
-      operation: { enumerable: true },
-      toString: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"StringifierNamedOperation\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"StringifierNamedOperation\\"] = StringifierNamedOperation;
-
-    Object.defineProperty(globalObject, \\"StringifierNamedOperation\\", {
-      configurable: true,
-      writable: true,
-      value: StringifierNamedOperation
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'StringifierNamedOperation'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"StringifierNamedOperation\\"];
+  if (ctor === undefined) {
+    throw new Error(
+      \\"Internal error: constructor StringifierNamedOperation is not installed on the passed global object\\"
+    );
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class StringifierNamedOperation {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    operation() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].operation();
+    }
+
+    toString() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].operation();
+    }
+  }
+  Object.defineProperties(StringifierNamedOperation.prototype, {
+    operation: { enumerable: true },
+    toString: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"StringifierNamedOperation\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"StringifierNamedOperation\\"] = StringifierNamedOperation;
+
+  Object.defineProperty(globalObject, \\"StringifierNamedOperation\\", {
+    configurable: true,
+    writable: true,
+    value: StringifierNamedOperation
+  });
+};
 
 const Impl = require(\\"../implementations/StringifierNamedOperation.js\\");
 "
@@ -3471,112 +3436,111 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'StringifierOperation'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"StringifierOperation\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor StringifierOperation is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class StringifierOperation {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      toString() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].toString();
-      }
-    }
-    Object.defineProperties(StringifierOperation.prototype, {
-      toString: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"StringifierOperation\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"StringifierOperation\\"] = StringifierOperation;
-
-    Object.defineProperty(globalObject, \\"StringifierOperation\\", {
-      configurable: true,
-      writable: true,
-      value: StringifierOperation
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'StringifierOperation'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"StringifierOperation\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor StringifierOperation is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class StringifierOperation {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    toString() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].toString();
+    }
+  }
+  Object.defineProperties(StringifierOperation.prototype, {
+    toString: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"StringifierOperation\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"StringifierOperation\\"] = StringifierOperation;
+
+  Object.defineProperty(globalObject, \\"StringifierOperation\\", {
+    configurable: true,
+    writable: true,
+    value: StringifierOperation
+  });
+};
 
 const Impl = require(\\"../implementations/StringifierOperation.js\\");
 "
@@ -3594,242 +3558,292 @@ const convertURL = require(\\"./URL.js\\").convert;
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
+  }
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
         return true;
       }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'TypedefsAndUnions'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"TypedefsAndUnions\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor TypedefsAndUnions is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
     return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
+  }
+  throw new TypeError(\`\${context} is not of type 'TypedefsAndUnions'.\`);
+};
 
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
 
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
+  const ctor = globalObject[ctorRegistry][\\"TypedefsAndUnions\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor TypedefsAndUnions is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class TypedefsAndUnions {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
     }
-    return obj;
-  },
 
-  install(globalObject) {
-    class TypedefsAndUnions {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
+    numOrStrConsumer(a) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      numOrStrConsumer(a) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'numOrStrConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"double\\"](curArg, {
+            context: \\"Failed to execute 'numOrStrConsumer' on 'TypedefsAndUnions': parameter 1\\",
+            clamp: true
+          });
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'numOrStrConsumer' on 'TypedefsAndUnions': parameter 1\\"
+          });
         }
+        args.push(curArg);
+      }
+      return this[impl].numOrStrConsumer(...args);
+    }
 
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'numOrStrConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
+    numOrEnumConsumer(a) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'numOrEnumConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (curArg === null || curArg === undefined) {
+          curArg = null;
+        } else {
           if (typeof curArg === \\"number\\") {
             curArg = conversions[\\"double\\"](curArg, {
-              context: \\"Failed to execute 'numOrStrConsumer' on 'TypedefsAndUnions': parameter 1\\",
-              clamp: true
+              context: \\"Failed to execute 'numOrEnumConsumer' on 'TypedefsAndUnions': parameter 1\\"
+            });
+          } else {
+            curArg = convertRequestDestination(curArg, {
+              context: \\"Failed to execute 'numOrEnumConsumer' on 'TypedefsAndUnions': parameter 1\\"
+            });
+          }
+        }
+        args.push(curArg);
+      }
+      return this[impl].numOrEnumConsumer(...args);
+    }
+
+    numOrStrOrNullConsumer(a) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'numOrStrOrNullConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (curArg === null || curArg === undefined) {
+          curArg = null;
+        } else {
+          if (typeof curArg === \\"number\\") {
+            curArg = conversions[\\"double\\"](curArg, {
+              context: \\"Failed to execute 'numOrStrOrNullConsumer' on 'TypedefsAndUnions': parameter 1\\",
+              clamp: true,
+              enforceRange: true
             });
           } else {
             curArg = conversions[\\"DOMString\\"](curArg, {
-              context: \\"Failed to execute 'numOrStrConsumer' on 'TypedefsAndUnions': parameter 1\\"
+              context: \\"Failed to execute 'numOrStrOrNullConsumer' on 'TypedefsAndUnions': parameter 1\\",
+              enforceRange: true
             });
           }
-          args.push(curArg);
         }
-        return this[impl].numOrStrConsumer(...args);
+        args.push(curArg);
+      }
+      return this[impl].numOrStrOrNullConsumer(...args);
+    }
+
+    numOrStrOrURLOrNullConsumer(a) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      numOrEnumConsumer(a) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'numOrEnumConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (curArg === null || curArg === undefined) {
-            curArg = null;
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'numOrStrOrURLOrNullConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (curArg === null || curArg === undefined) {
+          curArg = null;
+        } else {
+          if (isURL(curArg)) {
+            curArg = utils.implForWrapper(curArg);
+          } else if (typeof curArg === \\"number\\") {
+            curArg = conversions[\\"double\\"](curArg, {
+              context: \\"Failed to execute 'numOrStrOrURLOrNullConsumer' on 'TypedefsAndUnions': parameter 1\\",
+              clamp: true,
+              enforceRange: true
+            });
           } else {
-            if (typeof curArg === \\"number\\") {
-              curArg = conversions[\\"double\\"](curArg, {
-                context: \\"Failed to execute 'numOrEnumConsumer' on 'TypedefsAndUnions': parameter 1\\"
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'numOrStrOrURLOrNullConsumer' on 'TypedefsAndUnions': parameter 1\\",
+              enforceRange: true
+            });
+          }
+        }
+        args.push(curArg);
+      }
+      return this[impl].numOrStrOrURLOrNullConsumer(...args);
+    }
+
+    urlMapInnerConsumer(a) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (!utils.isObject(curArg)) {
+          throw new TypeError(
+            \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\" is not an object.\\"
+          );
+        } else {
+          const result = Object.create(null);
+          for (const key of Reflect.ownKeys(curArg)) {
+            const desc = Object.getOwnPropertyDescriptor(curArg, key);
+            if (desc && desc.enumerable) {
+              let typedKey = key;
+
+              typedKey = conversions[\\"USVString\\"](typedKey, {
+                context: \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s key\\"
               });
-            } else {
-              curArg = convertRequestDestination(curArg, {
-                context: \\"Failed to execute 'numOrEnumConsumer' on 'TypedefsAndUnions': parameter 1\\"
+
+              let typedValue = curArg[key];
+
+              typedValue = convertURL(typedValue, {
+                context: \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s value\\"
               });
+
+              result[typedKey] = typedValue;
             }
           }
-          args.push(curArg);
+          curArg = result;
         }
-        return this[impl].numOrEnumConsumer(...args);
+        args.push(curArg);
+      }
+      return this[impl].urlMapInnerConsumer(...args);
+    }
+
+    urlMapConsumer(a) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      numOrStrOrNullConsumer(a) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'numOrStrOrNullConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (curArg === null || curArg === undefined) {
-            curArg = null;
-          } else {
-            if (typeof curArg === \\"number\\") {
-              curArg = conversions[\\"double\\"](curArg, {
-                context: \\"Failed to execute 'numOrStrOrNullConsumer' on 'TypedefsAndUnions': parameter 1\\",
-                clamp: true,
-                enforceRange: true
-              });
-            } else {
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'numOrStrOrNullConsumer' on 'TypedefsAndUnions': parameter 1\\",
-                enforceRange: true
-              });
-            }
-          }
-          args.push(curArg);
-        }
-        return this[impl].numOrStrOrNullConsumer(...args);
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
       }
-
-      numOrStrOrURLOrNullConsumer(a) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'numOrStrOrURLOrNullConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (curArg === null || curArg === undefined) {
-            curArg = null;
-          } else {
-            if (isURL(curArg)) {
-              curArg = utils.implForWrapper(curArg);
-            } else if (typeof curArg === \\"number\\") {
-              curArg = conversions[\\"double\\"](curArg, {
-                context: \\"Failed to execute 'numOrStrOrURLOrNullConsumer' on 'TypedefsAndUnions': parameter 1\\",
-                clamp: true,
-                enforceRange: true
-              });
-            } else {
-              curArg = conversions[\\"DOMString\\"](curArg, {
-                context: \\"Failed to execute 'numOrStrOrURLOrNullConsumer' on 'TypedefsAndUnions': parameter 1\\",
-                enforceRange: true
-              });
-            }
-          }
-          args.push(curArg);
-        }
-        return this[impl].numOrStrOrURLOrNullConsumer(...args);
-      }
-
-      urlMapInnerConsumer(a) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (curArg === null || curArg === undefined) {
+          curArg = null;
+        } else {
           if (!utils.isObject(curArg)) {
             throw new TypeError(
-              \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\" is not an object.\\"
+              \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\" is not an object.\\"
             );
           } else {
             const result = Object.create(null);
@@ -3839,13 +3853,13 @@ const iface = {
                 let typedKey = key;
 
                 typedKey = conversions[\\"USVString\\"](typedKey, {
-                  context: \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s key\\"
+                  context: \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s key\\"
                 });
 
                 let typedValue = curArg[key];
 
                 typedValue = convertURL(typedValue, {
-                  context: \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s value\\"
+                  context: \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s value\\"
                 });
 
                 result[typedKey] = typedValue;
@@ -3853,32 +3867,67 @@ const iface = {
             }
             curArg = result;
           }
-          args.push(curArg);
         }
-        return this[impl].urlMapInnerConsumer(...args);
+        args.push(curArg);
+      }
+      return this[impl].urlMapConsumer(...args);
+    }
+
+    bufferSourceOrURLConsumer(b) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      urlMapConsumer(a) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'bufferSourceOrURLConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (isURL(curArg)) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else {
           throw new TypeError(
-            \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
+            \\"Failed to execute 'bufferSourceOrURLConsumer' on 'TypedefsAndUnions': parameter 1\\" +
+              \\" is not of any supported type.\\"
           );
         }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (curArg === null || curArg === undefined) {
-            curArg = null;
-          } else {
+        args.push(curArg);
+      }
+      return this[impl].bufferSourceOrURLConsumer(...args);
+    }
+
+    arrayBufferViewOrURLMapConsumer(b) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (curArg === null || curArg === undefined) {
+          curArg = null;
+        } else {
+          if (ArrayBuffer.isView(curArg)) {
+          } else if (utils.isObject(curArg)) {
             if (!utils.isObject(curArg)) {
               throw new TypeError(
-                \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\" is not an object.\\"
+                \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': parameter 1\\" +
+                  \\" record\\" +
+                  \\" is not an object.\\"
               );
             } else {
               const result = Object.create(null);
@@ -3888,13 +3937,19 @@ const iface = {
                   let typedKey = key;
 
                   typedKey = conversions[\\"USVString\\"](typedKey, {
-                    context: \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s key\\"
+                    context:
+                      \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': parameter 1\\" +
+                      \\" record\\" +
+                      \\"'s key\\"
                   });
 
                   let typedValue = curArg[key];
 
                   typedValue = convertURL(typedValue, {
-                    context: \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s value\\"
+                    context:
+                      \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': parameter 1\\" +
+                      \\" record\\" +
+                      \\"'s value\\"
                   });
 
                   result[typedKey] = typedValue;
@@ -3902,209 +3957,117 @@ const iface = {
               }
               curArg = result;
             }
-          }
-          args.push(curArg);
-        }
-        return this[impl].urlMapConsumer(...args);
-      }
-
-      bufferSourceOrURLConsumer(b) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'bufferSourceOrURLConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (isURL(curArg)) {
-            curArg = utils.implForWrapper(curArg);
-          } else if (utils.isArrayBuffer(curArg)) {
-          } else if (ArrayBuffer.isView(curArg)) {
           } else {
             throw new TypeError(
-              \\"Failed to execute 'bufferSourceOrURLConsumer' on 'TypedefsAndUnions': parameter 1\\" +
+              \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': parameter 1\\" +
                 \\" is not of any supported type.\\"
             );
           }
-          args.push(curArg);
         }
-        return this[impl].bufferSourceOrURLConsumer(...args);
+        args.push(curArg);
+      }
+      return this[impl].arrayBufferViewOrURLMapConsumer(...args);
+    }
+
+    arrayBufferViewDupConsumer(b) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      arrayBufferViewOrURLMapConsumer(b) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (curArg === null || curArg === undefined) {
-            curArg = null;
-          } else {
-            if (ArrayBuffer.isView(curArg)) {
-            } else if (utils.isObject(curArg)) {
-              if (!utils.isObject(curArg)) {
-                throw new TypeError(
-                  \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': parameter 1\\" +
-                    \\" record\\" +
-                    \\" is not an object.\\"
-                );
-              } else {
-                const result = Object.create(null);
-                for (const key of Reflect.ownKeys(curArg)) {
-                  const desc = Object.getOwnPropertyDescriptor(curArg, key);
-                  if (desc && desc.enumerable) {
-                    let typedKey = key;
-
-                    typedKey = conversions[\\"USVString\\"](typedKey, {
-                      context:
-                        \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': parameter 1\\" +
-                        \\" record\\" +
-                        \\"'s key\\"
-                    });
-
-                    let typedValue = curArg[key];
-
-                    typedValue = convertURL(typedValue, {
-                      context:
-                        \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': parameter 1\\" +
-                        \\" record\\" +
-                        \\"'s value\\"
-                    });
-
-                    result[typedKey] = typedValue;
-                  }
-                }
-                curArg = result;
-              }
-            } else {
-              throw new TypeError(
-                \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': parameter 1\\" +
-                  \\" is not of any supported type.\\"
-              );
-            }
-          }
-          args.push(curArg);
-        }
-        return this[impl].arrayBufferViewOrURLMapConsumer(...args);
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'arrayBufferViewDupConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
       }
-
-      arrayBufferViewDupConsumer(b) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'arrayBufferViewDupConsumer' on 'TypedefsAndUnions': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (ArrayBuffer.isView(curArg)) {
-          } else {
-            throw new TypeError(
-              \\"Failed to execute 'arrayBufferViewDupConsumer' on 'TypedefsAndUnions': parameter 1\\" +
-                \\" is not of any supported type.\\"
-            );
-          }
-          args.push(curArg);
-        }
-        return this[impl].arrayBufferViewDupConsumer(...args);
-      }
-
-      get buf() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return utils.tryWrapperForImpl(this[impl][\\"buf\\"]);
-      }
-
-      set buf(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (utils.isArrayBuffer(V)) {
-        } else if (
-          ArrayBuffer.isView(V) &&
-          (V.constructor.name === \\"Uint8Array\\" || V.constructor.name === \\"Uint16Array\\")
-        ) {
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (ArrayBuffer.isView(curArg)) {
         } else {
           throw new TypeError(
-            \\"Failed to set the 'buf' property on 'TypedefsAndUnions': The provided value\\" +
+            \\"Failed to execute 'arrayBufferViewDupConsumer' on 'TypedefsAndUnions': parameter 1\\" +
               \\" is not of any supported type.\\"
           );
         }
-        this[impl][\\"buf\\"] = V;
+        args.push(curArg);
       }
-
-      get time() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"time\\"];
-      }
-
-      set time(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"unsigned long long\\"](V, {
-          context: \\"Failed to set the 'time' property on 'TypedefsAndUnions': The provided value\\"
-        });
-
-        this[impl][\\"time\\"] = V;
-      }
+      return this[impl].arrayBufferViewDupConsumer(...args);
     }
-    Object.defineProperties(TypedefsAndUnions.prototype, {
-      numOrStrConsumer: { enumerable: true },
-      numOrEnumConsumer: { enumerable: true },
-      numOrStrOrNullConsumer: { enumerable: true },
-      numOrStrOrURLOrNullConsumer: { enumerable: true },
-      urlMapInnerConsumer: { enumerable: true },
-      urlMapConsumer: { enumerable: true },
-      bufferSourceOrURLConsumer: { enumerable: true },
-      arrayBufferViewOrURLMapConsumer: { enumerable: true },
-      arrayBufferViewDupConsumer: { enumerable: true },
-      buf: { enumerable: true },
-      time: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"TypedefsAndUnions\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"TypedefsAndUnions\\"] = TypedefsAndUnions;
 
-    Object.defineProperty(globalObject, \\"TypedefsAndUnions\\", {
-      configurable: true,
-      writable: true,
-      value: TypedefsAndUnions
-    });
+    get buf() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return utils.tryWrapperForImpl(this[impl][\\"buf\\"]);
+    }
+
+    set buf(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (utils.isArrayBuffer(V)) {
+      } else if (
+        ArrayBuffer.isView(V) &&
+        (V.constructor.name === \\"Uint8Array\\" || V.constructor.name === \\"Uint16Array\\")
+      ) {
+      } else {
+        throw new TypeError(
+          \\"Failed to set the 'buf' property on 'TypedefsAndUnions': The provided value\\" +
+            \\" is not of any supported type.\\"
+        );
+      }
+      this[impl][\\"buf\\"] = V;
+    }
+
+    get time() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"time\\"];
+    }
+
+    set time(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"unsigned long long\\"](V, {
+        context: \\"Failed to set the 'time' property on 'TypedefsAndUnions': The provided value\\"
+      });
+
+      this[impl][\\"time\\"] = V;
+    }
   }
-}; // iface
-module.exports = iface;
+  Object.defineProperties(TypedefsAndUnions.prototype, {
+    numOrStrConsumer: { enumerable: true },
+    numOrEnumConsumer: { enumerable: true },
+    numOrStrOrNullConsumer: { enumerable: true },
+    numOrStrOrURLOrNullConsumer: { enumerable: true },
+    urlMapInnerConsumer: { enumerable: true },
+    urlMapConsumer: { enumerable: true },
+    bufferSourceOrURLConsumer: { enumerable: true },
+    arrayBufferViewOrURLMapConsumer: { enumerable: true },
+    arrayBufferViewDupConsumer: { enumerable: true },
+    buf: { enumerable: true },
+    time: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"TypedefsAndUnions\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"TypedefsAndUnions\\"] = TypedefsAndUnions;
+
+  Object.defineProperty(globalObject, \\"TypedefsAndUnions\\", {
+    configurable: true,
+    writable: true,
+    value: TypedefsAndUnions
+  });
+};
 
 const Impl = require(\\"../implementations/TypedefsAndUnions.js\\");
 "
@@ -4119,360 +4082,357 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'URL'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"URL\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor URL is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class URL {
-      constructor(url) {
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to construct 'URL': 1 argument required, but only \\" + arguments.length + \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, { context: \\"Failed to construct 'URL': parameter 1\\" });
-          args.push(curArg);
-        }
-        {
-          let curArg = arguments[1];
-          if (curArg !== undefined) {
-            curArg = conversions[\\"USVString\\"](curArg, { context: \\"Failed to construct 'URL': parameter 2\\" });
-          }
-          args.push(curArg);
-        }
-        return iface.setup(Object.create(new.target.prototype), globalObject, args);
-      }
-
-      toJSON() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl].toJSON();
-      }
-
-      get href() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"href\\"];
-      }
-
-      set href(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'href' property on 'URL': The provided value\\" });
-
-        this[impl][\\"href\\"] = V;
-      }
-
-      toString() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-        return this[impl][\\"href\\"];
-      }
-
-      get origin() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"origin\\"];
-      }
-
-      get protocol() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"protocol\\"];
-      }
-
-      set protocol(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'protocol' property on 'URL': The provided value\\"
-        });
-
-        this[impl][\\"protocol\\"] = V;
-      }
-
-      get username() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"username\\"];
-      }
-
-      set username(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'username' property on 'URL': The provided value\\"
-        });
-
-        this[impl][\\"username\\"] = V;
-      }
-
-      get password() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"password\\"];
-      }
-
-      set password(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'password' property on 'URL': The provided value\\"
-        });
-
-        this[impl][\\"password\\"] = V;
-      }
-
-      get host() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"host\\"];
-      }
-
-      set host(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'host' property on 'URL': The provided value\\" });
-
-        this[impl][\\"host\\"] = V;
-      }
-
-      get hostname() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"hostname\\"];
-      }
-
-      set hostname(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'hostname' property on 'URL': The provided value\\"
-        });
-
-        this[impl][\\"hostname\\"] = V;
-      }
-
-      get port() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"port\\"];
-      }
-
-      set port(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'port' property on 'URL': The provided value\\" });
-
-        this[impl][\\"port\\"] = V;
-      }
-
-      get pathname() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"pathname\\"];
-      }
-
-      set pathname(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'pathname' property on 'URL': The provided value\\"
-        });
-
-        this[impl][\\"pathname\\"] = V;
-      }
-
-      get search() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"search\\"];
-      }
-
-      set search(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'search' property on 'URL': The provided value\\"
-        });
-
-        this[impl][\\"search\\"] = V;
-      }
-
-      get searchParams() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return utils.getSameObject(this, \\"searchParams\\", () => {
-          return utils.tryWrapperForImpl(this[impl][\\"searchParams\\"]);
-        });
-      }
-
-      get hash() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"hash\\"];
-      }
-
-      set hash(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'hash' property on 'URL': The provided value\\" });
-
-        this[impl][\\"hash\\"] = V;
-      }
-    }
-    Object.defineProperties(URL.prototype, {
-      toJSON: { enumerable: true },
-      href: { enumerable: true },
-      toString: { enumerable: true },
-      origin: { enumerable: true },
-      protocol: { enumerable: true },
-      username: { enumerable: true },
-      password: { enumerable: true },
-      host: { enumerable: true },
-      hostname: { enumerable: true },
-      port: { enumerable: true },
-      pathname: { enumerable: true },
-      search: { enumerable: true },
-      searchParams: { enumerable: true },
-      hash: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"URL\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"URL\\"] = URL;
-
-    Object.defineProperty(globalObject, \\"URL\\", {
-      configurable: true,
-      writable: true,
-      value: URL
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'URL'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"URL\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor URL is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class URL {
+    constructor(url) {
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to construct 'URL': 1 argument required, but only \\" + arguments.length + \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"USVString\\"](curArg, { context: \\"Failed to construct 'URL': parameter 1\\" });
+        args.push(curArg);
+      }
+      {
+        let curArg = arguments[1];
+        if (curArg !== undefined) {
+          curArg = conversions[\\"USVString\\"](curArg, { context: \\"Failed to construct 'URL': parameter 2\\" });
+        }
+        args.push(curArg);
+      }
+      return exports.setup(Object.create(new.target.prototype), globalObject, args);
+    }
+
+    toJSON() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl].toJSON();
+    }
+
+    get href() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"href\\"];
+    }
+
+    set href(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'href' property on 'URL': The provided value\\" });
+
+      this[impl][\\"href\\"] = V;
+    }
+
+    toString() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+      return this[impl][\\"href\\"];
+    }
+
+    get origin() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"origin\\"];
+    }
+
+    get protocol() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"protocol\\"];
+    }
+
+    set protocol(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"USVString\\"](V, {
+        context: \\"Failed to set the 'protocol' property on 'URL': The provided value\\"
+      });
+
+      this[impl][\\"protocol\\"] = V;
+    }
+
+    get username() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"username\\"];
+    }
+
+    set username(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"USVString\\"](V, {
+        context: \\"Failed to set the 'username' property on 'URL': The provided value\\"
+      });
+
+      this[impl][\\"username\\"] = V;
+    }
+
+    get password() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"password\\"];
+    }
+
+    set password(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"USVString\\"](V, {
+        context: \\"Failed to set the 'password' property on 'URL': The provided value\\"
+      });
+
+      this[impl][\\"password\\"] = V;
+    }
+
+    get host() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"host\\"];
+    }
+
+    set host(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'host' property on 'URL': The provided value\\" });
+
+      this[impl][\\"host\\"] = V;
+    }
+
+    get hostname() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"hostname\\"];
+    }
+
+    set hostname(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"USVString\\"](V, {
+        context: \\"Failed to set the 'hostname' property on 'URL': The provided value\\"
+      });
+
+      this[impl][\\"hostname\\"] = V;
+    }
+
+    get port() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"port\\"];
+    }
+
+    set port(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'port' property on 'URL': The provided value\\" });
+
+      this[impl][\\"port\\"] = V;
+    }
+
+    get pathname() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"pathname\\"];
+    }
+
+    set pathname(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"USVString\\"](V, {
+        context: \\"Failed to set the 'pathname' property on 'URL': The provided value\\"
+      });
+
+      this[impl][\\"pathname\\"] = V;
+    }
+
+    get search() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"search\\"];
+    }
+
+    set search(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'search' property on 'URL': The provided value\\" });
+
+      this[impl][\\"search\\"] = V;
+    }
+
+    get searchParams() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return utils.getSameObject(this, \\"searchParams\\", () => {
+        return utils.tryWrapperForImpl(this[impl][\\"searchParams\\"]);
+      });
+    }
+
+    get hash() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"hash\\"];
+    }
+
+    set hash(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'hash' property on 'URL': The provided value\\" });
+
+      this[impl][\\"hash\\"] = V;
+    }
+  }
+  Object.defineProperties(URL.prototype, {
+    toJSON: { enumerable: true },
+    href: { enumerable: true },
+    toString: { enumerable: true },
+    origin: { enumerable: true },
+    protocol: { enumerable: true },
+    username: { enumerable: true },
+    password: { enumerable: true },
+    host: { enumerable: true },
+    hostname: { enumerable: true },
+    port: { enumerable: true },
+    pathname: { enumerable: true },
+    search: { enumerable: true },
+    searchParams: { enumerable: true },
+    hash: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"URL\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"URL\\"] = URL;
+
+  Object.defineProperty(globalObject, \\"URL\\", {
+    configurable: true,
+    writable: true,
+    value: URL
+  });
+};
 
 const Impl = require(\\"../implementations/URL.js\\");
 "
@@ -4487,299 +4447,298 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
+  }
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
         return true;
       }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'URLList'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"URLList\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor URLList is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
     return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
+  }
+  throw new TypeError(\`\${context} is not of type 'URLList'.\`);
+};
 
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
 
-    obj = new Proxy(obj, {
-      get(target, P, receiver) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.get(target, P, receiver);
-        }
-        const desc = this.getOwnPropertyDescriptor(target, P);
-        if (desc === undefined) {
-          const parent = Object.getPrototypeOf(target);
-          if (parent === null) {
-            return undefined;
-          }
-          return Reflect.get(target, P, receiver);
-        }
-        if (!desc.get && !desc.set) {
-          return desc.value;
-        }
-        const getter = desc.get;
-        if (getter === undefined) {
+  const ctor = globalObject[ctorRegistry][\\"URLList\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor URLList is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj = new Proxy(obj, {
+    get(target, P, receiver) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.get(target, P, receiver);
+      }
+      const desc = this.getOwnPropertyDescriptor(target, P);
+      if (desc === undefined) {
+        const parent = Object.getPrototypeOf(target);
+        if (parent === null) {
           return undefined;
         }
-        return Reflect.apply(getter, receiver, []);
-      },
+        return Reflect.get(target, P, receiver);
+      }
+      if (!desc.get && !desc.set) {
+        return desc.value;
+      }
+      const getter = desc.get;
+      if (getter === undefined) {
+        return undefined;
+      }
+      return Reflect.apply(getter, receiver, []);
+    },
 
-      has(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.has(target, P);
-        }
-        const desc = this.getOwnPropertyDescriptor(target, P);
-        if (desc !== undefined) {
-          return true;
-        }
-        const parent = Object.getPrototypeOf(target);
-        if (parent !== null) {
-          return Reflect.has(parent, P);
-        }
-        return false;
-      },
+    has(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.has(target, P);
+      }
+      const desc = this.getOwnPropertyDescriptor(target, P);
+      if (desc !== undefined) {
+        return true;
+      }
+      const parent = Object.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.has(parent, P);
+      }
+      return false;
+    },
 
-      ownKeys(target) {
-        const keys = new Set();
+    ownKeys(target) {
+      const keys = new Set();
 
-        for (const key of target[impl][utils.supportedPropertyIndices]) {
-          keys.add(\`\${key}\`);
-        }
+      for (const key of target[impl][utils.supportedPropertyIndices]) {
+        keys.add(\`\${key}\`);
+      }
 
-        for (const key of Reflect.ownKeys(target)) {
-          keys.add(key);
-        }
-        return [...keys];
-      },
+      for (const key of Reflect.ownKeys(target)) {
+        keys.add(key);
+      }
+      return [...keys];
+    },
 
-      getOwnPropertyDescriptor(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.getOwnPropertyDescriptor(target, P);
-        }
-        let ignoreNamedProps = false;
-
-        if (utils.isArrayIndexPropName(P)) {
-          const index = P >>> 0;
-
-          if (target[impl][utils.supportsPropertyIndex](index)) {
-            const indexedValue = target[impl].item(index);
-            return {
-              writable: false,
-              enumerable: true,
-              configurable: true,
-              value: utils.tryWrapperForImpl(indexedValue)
-            };
-          }
-          ignoreNamedProps = true;
-        }
-
+    getOwnPropertyDescriptor(target, P) {
+      if (typeof P === \\"symbol\\") {
         return Reflect.getOwnPropertyDescriptor(target, P);
-      },
+      }
+      let ignoreNamedProps = false;
 
-      set(target, P, V, receiver) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.set(target, P, V, receiver);
-        }
-        if (target === receiver) {
-          utils.isArrayIndexPropName(P);
-        }
-        let ownDesc;
+      if (utils.isArrayIndexPropName(P)) {
+        const index = P >>> 0;
 
-        if (utils.isArrayIndexPropName(P)) {
-          const index = P >>> 0;
+        if (target[impl][utils.supportsPropertyIndex](index)) {
+          const indexedValue = target[impl].item(index);
+          return {
+            writable: false,
+            enumerable: true,
+            configurable: true,
+            value: utils.tryWrapperForImpl(indexedValue)
+          };
+        }
+        ignoreNamedProps = true;
+      }
 
-          if (target[impl][utils.supportsPropertyIndex](index)) {
-            const indexedValue = target[impl].item(index);
-            ownDesc = {
-              writable: false,
-              enumerable: true,
-              configurable: true,
-              value: utils.tryWrapperForImpl(indexedValue)
-            };
-          }
-        }
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    },
 
-        if (ownDesc === undefined) {
-          ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-        }
-        if (ownDesc === undefined) {
-          const parent = Reflect.getPrototypeOf(target);
-          if (parent !== null) {
-            return Reflect.set(parent, P, V, receiver);
-          }
-          ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-        }
-        if (!ownDesc.writable) {
-          return false;
-        }
-        if (!utils.isObject(receiver)) {
-          return false;
-        }
-        const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-        let valueDesc;
-        if (existingDesc !== undefined) {
-          if (existingDesc.get || existingDesc.set) {
-            return false;
-          }
-          if (!existingDesc.writable) {
-            return false;
-          }
-          valueDesc = { value: V };
-        } else {
-          valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-        }
-        return Reflect.defineProperty(receiver, P, valueDesc);
-      },
+    set(target, P, V, receiver) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.set(target, P, V, receiver);
+      }
+      if (target === receiver) {
+        utils.isArrayIndexPropName(P);
+      }
+      let ownDesc;
 
-      defineProperty(target, P, desc) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.defineProperty(target, P, desc);
+      if (utils.isArrayIndexPropName(P)) {
+        const index = P >>> 0;
+
+        if (target[impl][utils.supportsPropertyIndex](index)) {
+          const indexedValue = target[impl].item(index);
+          ownDesc = {
+            writable: false,
+            enumerable: true,
+            configurable: true,
+            value: utils.tryWrapperForImpl(indexedValue)
+          };
         }
+      }
 
-        if (utils.isArrayIndexPropName(P)) {
-          return false;
+      if (ownDesc === undefined) {
+        ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+      }
+      if (ownDesc === undefined) {
+        const parent = Reflect.getPrototypeOf(target);
+        if (parent !== null) {
+          return Reflect.set(parent, P, V, receiver);
         }
-
-        return Reflect.defineProperty(target, P, desc);
-      },
-
-      deleteProperty(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.deleteProperty(target, P);
-        }
-
-        if (utils.isArrayIndexPropName(P)) {
-          const index = P >>> 0;
-          return !target[impl][utils.supportsPropertyIndex](index);
-        }
-
-        return Reflect.deleteProperty(target, P);
-      },
-
-      preventExtensions() {
+        ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+      }
+      if (!ownDesc.writable) {
         return false;
       }
-    });
+      if (!utils.isObject(receiver)) {
+        return false;
+      }
+      const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+      let valueDesc;
+      if (existingDesc !== undefined) {
+        if (existingDesc.get || existingDesc.set) {
+          return false;
+        }
+        if (!existingDesc.writable) {
+          return false;
+        }
+        valueDesc = { value: V };
+      } else {
+        valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+      }
+      return Reflect.defineProperty(receiver, P, valueDesc);
+    },
 
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class URLList {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
+    defineProperty(target, P, desc) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.defineProperty(target, P, desc);
       }
 
-      item(index) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'item' on 'URLList': 1 argument required, but only \\" + arguments.length + \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"unsigned long\\"](curArg, {
-            context: \\"Failed to execute 'item' on 'URLList': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return utils.tryWrapperForImpl(this[impl].item(...args));
+      if (utils.isArrayIndexPropName(P)) {
+        return false;
       }
 
-      get length() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      return Reflect.defineProperty(target, P, desc);
+    },
 
-        return this[impl][\\"length\\"];
+    deleteProperty(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.deleteProperty(target, P);
       }
-    }
-    Object.defineProperties(URLList.prototype, {
-      item: { enumerable: true },
-      length: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"URLList\\", configurable: true },
-      [Symbol.iterator]: { value: Array.prototype[Symbol.iterator], configurable: true, writable: true },
-      keys: { value: Array.prototype.keys, configurable: true, enumerable: true, writable: true },
-      values: { value: Array.prototype[Symbol.iterator], configurable: true, enumerable: true, writable: true },
-      entries: { value: Array.prototype.entries, configurable: true, enumerable: true, writable: true },
-      forEach: { value: Array.prototype.forEach, configurable: true, enumerable: true, writable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"URLList\\"] = URLList;
 
-    Object.defineProperty(globalObject, \\"URLList\\", {
-      configurable: true,
-      writable: true,
-      value: URLList
-    });
+      if (utils.isArrayIndexPropName(P)) {
+        const index = P >>> 0;
+        return !target[impl][utils.supportsPropertyIndex](index);
+      }
+
+      return Reflect.deleteProperty(target, P);
+    },
+
+    preventExtensions() {
+      return false;
+    }
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
   }
-}; // iface
-module.exports = iface;
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class URLList {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    item(index) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'item' on 'URLList': 1 argument required, but only \\" + arguments.length + \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"unsigned long\\"](curArg, {
+          context: \\"Failed to execute 'item' on 'URLList': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(this[impl].item(...args));
+    }
+
+    get length() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"length\\"];
+    }
+  }
+  Object.defineProperties(URLList.prototype, {
+    item: { enumerable: true },
+    length: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"URLList\\", configurable: true },
+    [Symbol.iterator]: { value: Array.prototype[Symbol.iterator], configurable: true, writable: true },
+    keys: { value: Array.prototype.keys, configurable: true, enumerable: true, writable: true },
+    values: { value: Array.prototype[Symbol.iterator], configurable: true, enumerable: true, writable: true },
+    entries: { value: Array.prototype.entries, configurable: true, enumerable: true, writable: true },
+    forEach: { value: Array.prototype.forEach, configurable: true, enumerable: true, writable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"URLList\\"] = URLList;
+
+  Object.defineProperty(globalObject, \\"URLList\\", {
+    configurable: true,
+    writable: true,
+    value: URLList
+  });
+};
 
 const Impl = require(\\"../implementations/URLList.js\\");
 "
@@ -4833,419 +4792,416 @@ const IteratorPrototype = Object.create(utils.IteratorPrototype, {
   }
 });
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
+  }
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
         return true;
       }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'URLSearchParams'.\`);
-  },
-
-  createDefaultIterator(target, kind) {
-    const iterator = Object.create(IteratorPrototype);
-    Object.defineProperty(iterator, utils.iterInternalSymbol, {
-      value: { target, kind, index: 0 },
-      configurable: true
-    });
-    return iterator;
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"URLSearchParams\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor URLSearchParams is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
     return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
+  }
+  throw new TypeError(\`\${context} is not of type 'URLSearchParams'.\`);
+};
 
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
+exports.createDefaultIterator = function createDefaultIterator(target, kind) {
+  const iterator = Object.create(IteratorPrototype);
+  Object.defineProperty(iterator, utils.iterInternalSymbol, {
+    value: { target, kind, index: 0 },
+    configurable: true
+  });
+  return iterator;
+};
 
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
 
-  install(globalObject) {
-    class URLSearchParams {
-      constructor() {
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (curArg !== undefined) {
-            if (utils.isObject(curArg)) {
-              if (curArg[Symbol.iterator] !== undefined) {
-                if (!utils.isObject(curArg)) {
-                  throw new TypeError(
-                    \\"Failed to construct 'URLSearchParams': parameter 1\\" + \\" sequence\\" + \\" is not an iterable object.\\"
-                  );
-                } else {
-                  const V = [];
-                  const tmp = curArg;
-                  for (let nextItem of tmp) {
-                    if (!utils.isObject(nextItem)) {
-                      throw new TypeError(
-                        \\"Failed to construct 'URLSearchParams': parameter 1\\" +
+  const ctor = globalObject[ctorRegistry][\\"URLSearchParams\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor URLSearchParams is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class URLSearchParams {
+    constructor() {
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (curArg !== undefined) {
+          if (utils.isObject(curArg)) {
+            if (curArg[Symbol.iterator] !== undefined) {
+              if (!utils.isObject(curArg)) {
+                throw new TypeError(
+                  \\"Failed to construct 'URLSearchParams': parameter 1\\" + \\" sequence\\" + \\" is not an iterable object.\\"
+                );
+              } else {
+                const V = [];
+                const tmp = curArg;
+                for (let nextItem of tmp) {
+                  if (!utils.isObject(nextItem)) {
+                    throw new TypeError(
+                      \\"Failed to construct 'URLSearchParams': parameter 1\\" +
+                        \\" sequence\\" +
+                        \\"'s element\\" +
+                        \\" is not an iterable object.\\"
+                    );
+                  } else {
+                    const V = [];
+                    const tmp = nextItem;
+                    for (let nextItem of tmp) {
+                      nextItem = conversions[\\"USVString\\"](nextItem, {
+                        context:
+                          \\"Failed to construct 'URLSearchParams': parameter 1\\" +
                           \\" sequence\\" +
                           \\"'s element\\" +
-                          \\" is not an iterable object.\\"
-                      );
-                    } else {
-                      const V = [];
-                      const tmp = nextItem;
-                      for (let nextItem of tmp) {
-                        nextItem = conversions[\\"USVString\\"](nextItem, {
-                          context:
-                            \\"Failed to construct 'URLSearchParams': parameter 1\\" +
-                            \\" sequence\\" +
-                            \\"'s element\\" +
-                            \\"'s element\\"
-                        });
-
-                        V.push(nextItem);
-                      }
-                      nextItem = V;
-                    }
-
-                    V.push(nextItem);
-                  }
-                  curArg = V;
-                }
-              } else {
-                if (!utils.isObject(curArg)) {
-                  throw new TypeError(
-                    \\"Failed to construct 'URLSearchParams': parameter 1\\" + \\" record\\" + \\" is not an object.\\"
-                  );
-                } else {
-                  const result = Object.create(null);
-                  for (const key of Reflect.ownKeys(curArg)) {
-                    const desc = Object.getOwnPropertyDescriptor(curArg, key);
-                    if (desc && desc.enumerable) {
-                      let typedKey = key;
-
-                      typedKey = conversions[\\"USVString\\"](typedKey, {
-                        context: \\"Failed to construct 'URLSearchParams': parameter 1\\" + \\" record\\" + \\"'s key\\"
+                          \\"'s element\\"
                       });
 
-                      let typedValue = curArg[key];
-
-                      typedValue = conversions[\\"USVString\\"](typedValue, {
-                        context: \\"Failed to construct 'URLSearchParams': parameter 1\\" + \\" record\\" + \\"'s value\\"
-                      });
-
-                      result[typedKey] = typedValue;
+                      V.push(nextItem);
                     }
+                    nextItem = V;
                   }
-                  curArg = result;
+
+                  V.push(nextItem);
                 }
+                curArg = V;
               }
             } else {
-              curArg = conversions[\\"USVString\\"](curArg, {
-                context: \\"Failed to construct 'URLSearchParams': parameter 1\\"
-              });
+              if (!utils.isObject(curArg)) {
+                throw new TypeError(
+                  \\"Failed to construct 'URLSearchParams': parameter 1\\" + \\" record\\" + \\" is not an object.\\"
+                );
+              } else {
+                const result = Object.create(null);
+                for (const key of Reflect.ownKeys(curArg)) {
+                  const desc = Object.getOwnPropertyDescriptor(curArg, key);
+                  if (desc && desc.enumerable) {
+                    let typedKey = key;
+
+                    typedKey = conversions[\\"USVString\\"](typedKey, {
+                      context: \\"Failed to construct 'URLSearchParams': parameter 1\\" + \\" record\\" + \\"'s key\\"
+                    });
+
+                    let typedValue = curArg[key];
+
+                    typedValue = conversions[\\"USVString\\"](typedValue, {
+                      context: \\"Failed to construct 'URLSearchParams': parameter 1\\" + \\" record\\" + \\"'s value\\"
+                    });
+
+                    result[typedKey] = typedValue;
+                  }
+                }
+                curArg = result;
+              }
             }
           } else {
-            curArg = \\"\\";
+            curArg = conversions[\\"USVString\\"](curArg, {
+              context: \\"Failed to construct 'URLSearchParams': parameter 1\\"
+            });
           }
-          args.push(curArg);
+        } else {
+          curArg = \\"\\";
         }
-        return iface.setup(Object.create(new.target.prototype), globalObject, args);
+        args.push(curArg);
+      }
+      return exports.setup(Object.create(new.target.prototype), globalObject, args);
+    }
+
+    append(name, value) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      append(name, value) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      if (arguments.length < 2) {
+        throw new TypeError(
+          \\"Failed to execute 'append' on 'URLSearchParams': 2 arguments required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"USVString\\"](curArg, {
+          context: \\"Failed to execute 'append' on 'URLSearchParams': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      {
+        let curArg = arguments[1];
+        curArg = conversions[\\"USVString\\"](curArg, {
+          context: \\"Failed to execute 'append' on 'URLSearchParams': parameter 2\\"
+        });
+        args.push(curArg);
+      }
+      return this[impl].append(...args);
+    }
 
-        if (arguments.length < 2) {
-          throw new TypeError(
-            \\"Failed to execute 'append' on 'URLSearchParams': 2 arguments required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'append' on 'URLSearchParams': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        {
-          let curArg = arguments[1];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'append' on 'URLSearchParams': parameter 2\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].append(...args);
+    delete(name) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      delete(name) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'delete' on 'URLSearchParams': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"USVString\\"](curArg, {
+          context: \\"Failed to execute 'delete' on 'URLSearchParams': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return this[impl].delete(...args);
+    }
 
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'delete' on 'URLSearchParams': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'delete' on 'URLSearchParams': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].delete(...args);
+    get(name) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      get(name) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'get' on 'URLSearchParams': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"USVString\\"](curArg, {
+          context: \\"Failed to execute 'get' on 'URLSearchParams': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return this[impl].get(...args);
+    }
 
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'get' on 'URLSearchParams': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'get' on 'URLSearchParams': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].get(...args);
+    getAll(name) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      getAll(name) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'getAll' on 'URLSearchParams': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"USVString\\"](curArg, {
+          context: \\"Failed to execute 'getAll' on 'URLSearchParams': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(this[impl].getAll(...args));
+    }
 
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'getAll' on 'URLSearchParams': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'getAll' on 'URLSearchParams': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return utils.tryWrapperForImpl(this[impl].getAll(...args));
+    has(name) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      has(name) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'has' on 'URLSearchParams': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"USVString\\"](curArg, {
+          context: \\"Failed to execute 'has' on 'URLSearchParams': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return this[impl].has(...args);
+    }
 
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'has' on 'URLSearchParams': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'has' on 'URLSearchParams': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].has(...args);
+    set(name, value) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      set(name, value) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      if (arguments.length < 2) {
+        throw new TypeError(
+          \\"Failed to execute 'set' on 'URLSearchParams': 2 arguments required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"USVString\\"](curArg, {
+          context: \\"Failed to execute 'set' on 'URLSearchParams': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      {
+        let curArg = arguments[1];
+        curArg = conversions[\\"USVString\\"](curArg, {
+          context: \\"Failed to execute 'set' on 'URLSearchParams': parameter 2\\"
+        });
+        args.push(curArg);
+      }
+      return this[impl].set(...args);
+    }
 
-        if (arguments.length < 2) {
-          throw new TypeError(
-            \\"Failed to execute 'set' on 'URLSearchParams': 2 arguments required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'set' on 'URLSearchParams': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        {
-          let curArg = arguments[1];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'set' on 'URLSearchParams': parameter 2\\"
-          });
-          args.push(curArg);
-        }
-        return this[impl].set(...args);
+    sort() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      sort() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      return this[impl].sort();
+    }
 
-        return this[impl].sort();
+    toString() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      toString() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
+      return this[impl].toString();
+    }
 
-        return this[impl].toString();
+    keys() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
+      return exports.createDefaultIterator(this, \\"key\\");
+    }
 
-      keys() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-        return module.exports.createDefaultIterator(this, \\"key\\");
+    values() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
+      return exports.createDefaultIterator(this, \\"value\\");
+    }
 
-      values() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-        return module.exports.createDefaultIterator(this, \\"value\\");
+    entries() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
+      return exports.createDefaultIterator(this, \\"key+value\\");
+    }
 
-      entries() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-        return module.exports.createDefaultIterator(this, \\"key+value\\");
+    forEach(callback) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
-
-      forEach(callback) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'forEach' on 'iterable': 1 argument required, \\" + \\"but only 0 present.\\"
-          );
-        }
-        if (typeof callback !== \\"function\\") {
-          throw new TypeError(
-            \\"Failed to execute 'forEach' on 'iterable': The callback provided \\" + \\"as parameter 1 is not a function.\\"
-          );
-        }
-        const thisArg = arguments[1];
-        let pairs = Array.from(this[impl]);
-        let i = 0;
-        while (i < pairs.length) {
-          const [key, value] = pairs[i].map(utils.tryWrapperForImpl);
-          callback.call(thisArg, value, key, this);
-          pairs = Array.from(this[impl]);
-          i++;
-        }
+      if (arguments.length < 1) {
+        throw new TypeError(\\"Failed to execute 'forEach' on 'iterable': 1 argument required, \\" + \\"but only 0 present.\\");
+      }
+      if (typeof callback !== \\"function\\") {
+        throw new TypeError(
+          \\"Failed to execute 'forEach' on 'iterable': The callback provided \\" + \\"as parameter 1 is not a function.\\"
+        );
+      }
+      const thisArg = arguments[1];
+      let pairs = Array.from(this[impl]);
+      let i = 0;
+      while (i < pairs.length) {
+        const [key, value] = pairs[i].map(utils.tryWrapperForImpl);
+        callback.call(thisArg, value, key, this);
+        pairs = Array.from(this[impl]);
+        i++;
       }
     }
-    Object.defineProperties(URLSearchParams.prototype, {
-      append: { enumerable: true },
-      delete: { enumerable: true },
-      get: { enumerable: true },
-      getAll: { enumerable: true },
-      has: { enumerable: true },
-      set: { enumerable: true },
-      sort: { enumerable: true },
-      toString: { enumerable: true },
-      keys: { enumerable: true },
-      values: { enumerable: true },
-      entries: { enumerable: true },
-      forEach: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"URLSearchParams\\", configurable: true },
-      [Symbol.iterator]: { value: URLSearchParams.prototype.entries, configurable: true, writable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"URLSearchParams\\"] = URLSearchParams;
-
-    Object.defineProperty(globalObject, \\"URLSearchParams\\", {
-      configurable: true,
-      writable: true,
-      value: URLSearchParams
-    });
   }
-}; // iface
-module.exports = iface;
+  Object.defineProperties(URLSearchParams.prototype, {
+    append: { enumerable: true },
+    delete: { enumerable: true },
+    get: { enumerable: true },
+    getAll: { enumerable: true },
+    has: { enumerable: true },
+    set: { enumerable: true },
+    sort: { enumerable: true },
+    toString: { enumerable: true },
+    keys: { enumerable: true },
+    values: { enumerable: true },
+    entries: { enumerable: true },
+    forEach: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"URLSearchParams\\", configurable: true },
+    [Symbol.iterator]: { value: URLSearchParams.prototype.entries, configurable: true, writable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"URLSearchParams\\"] = URLSearchParams;
+
+  Object.defineProperty(globalObject, \\"URLSearchParams\\", {
+    configurable: true,
+    writable: true,
+    value: URLSearchParams
+  });
+};
 
 const Impl = require(\\"../implementations/URLSearchParams.js\\");
 "
@@ -5260,349 +5216,348 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
+  }
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
         return true;
       }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'URLSearchParamsCollection'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"URLSearchParamsCollection\\"];
-    if (ctor === undefined) {
-      throw new Error(
-        \\"Internal error: constructor URLSearchParamsCollection is not installed on the passed global object\\"
-      );
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
     return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
+  }
+  throw new TypeError(\`\${context} is not of type 'URLSearchParamsCollection'.\`);
+};
 
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
 
-    obj = new Proxy(obj, {
-      get(target, P, receiver) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.get(target, P, receiver);
-        }
-        const desc = this.getOwnPropertyDescriptor(target, P);
-        if (desc === undefined) {
-          const parent = Object.getPrototypeOf(target);
-          if (parent === null) {
-            return undefined;
-          }
-          return Reflect.get(target, P, receiver);
-        }
-        if (!desc.get && !desc.set) {
-          return desc.value;
-        }
-        const getter = desc.get;
-        if (getter === undefined) {
+  const ctor = globalObject[ctorRegistry][\\"URLSearchParamsCollection\\"];
+  if (ctor === undefined) {
+    throw new Error(
+      \\"Internal error: constructor URLSearchParamsCollection is not installed on the passed global object\\"
+    );
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj = new Proxy(obj, {
+    get(target, P, receiver) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.get(target, P, receiver);
+      }
+      const desc = this.getOwnPropertyDescriptor(target, P);
+      if (desc === undefined) {
+        const parent = Object.getPrototypeOf(target);
+        if (parent === null) {
           return undefined;
         }
-        return Reflect.apply(getter, receiver, []);
-      },
+        return Reflect.get(target, P, receiver);
+      }
+      if (!desc.get && !desc.set) {
+        return desc.value;
+      }
+      const getter = desc.get;
+      if (getter === undefined) {
+        return undefined;
+      }
+      return Reflect.apply(getter, receiver, []);
+    },
 
-      has(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.has(target, P);
-        }
-        const desc = this.getOwnPropertyDescriptor(target, P);
-        if (desc !== undefined) {
-          return true;
-        }
-        const parent = Object.getPrototypeOf(target);
-        if (parent !== null) {
-          return Reflect.has(parent, P);
-        }
-        return false;
-      },
+    has(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.has(target, P);
+      }
+      const desc = this.getOwnPropertyDescriptor(target, P);
+      if (desc !== undefined) {
+        return true;
+      }
+      const parent = Object.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.has(parent, P);
+      }
+      return false;
+    },
 
-      ownKeys(target) {
-        const keys = new Set();
+    ownKeys(target) {
+      const keys = new Set();
 
-        for (const key of target[impl][utils.supportedPropertyIndices]) {
+      for (const key of target[impl][utils.supportedPropertyIndices]) {
+        keys.add(\`\${key}\`);
+      }
+
+      for (const key of target[impl][utils.supportedPropertyNames]) {
+        if (!(key in target)) {
           keys.add(\`\${key}\`);
         }
+      }
 
-        for (const key of target[impl][utils.supportedPropertyNames]) {
-          if (!(key in target)) {
-            keys.add(\`\${key}\`);
-          }
-        }
+      for (const key of Reflect.ownKeys(target)) {
+        keys.add(key);
+      }
+      return [...keys];
+    },
 
-        for (const key of Reflect.ownKeys(target)) {
-          keys.add(key);
-        }
-        return [...keys];
-      },
+    getOwnPropertyDescriptor(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.getOwnPropertyDescriptor(target, P);
+      }
+      let ignoreNamedProps = false;
 
-      getOwnPropertyDescriptor(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.getOwnPropertyDescriptor(target, P);
-        }
-        let ignoreNamedProps = false;
-
-        if (utils.isArrayIndexPropName(P)) {
-          const index = P >>> 0;
-          const indexedValue = target[impl].item(index);
-          if (indexedValue !== undefined) {
-            return {
-              writable: false,
-              enumerable: true,
-              configurable: true,
-              value: utils.tryWrapperForImpl(indexedValue)
-            };
-          }
-          ignoreNamedProps = true;
-        }
-
-        const namedValue = target[impl].namedItem(P);
-
-        if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
+      if (utils.isArrayIndexPropName(P)) {
+        const index = P >>> 0;
+        const indexedValue = target[impl].item(index);
+        if (indexedValue !== undefined) {
           return {
             writable: false,
-            enumerable: false,
+            enumerable: true,
             configurable: true,
-            value: utils.tryWrapperForImpl(namedValue)
+            value: utils.tryWrapperForImpl(indexedValue)
           };
         }
+        ignoreNamedProps = true;
+      }
 
-        return Reflect.getOwnPropertyDescriptor(target, P);
-      },
+      const namedValue = target[impl].namedItem(P);
 
-      set(target, P, V, receiver) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.set(target, P, V, receiver);
-        }
-        if (target === receiver) {
-          utils.isArrayIndexPropName(P);
+      if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
+        return {
+          writable: false,
+          enumerable: false,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
 
-          typeof P === \\"string\\" && !utils.isArrayIndexPropName(P);
-        }
-        let ownDesc;
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    },
 
-        if (utils.isArrayIndexPropName(P)) {
-          const index = P >>> 0;
-          const indexedValue = target[impl].item(index);
-          if (indexedValue !== undefined) {
-            ownDesc = {
-              writable: false,
-              enumerable: true,
-              configurable: true,
-              value: utils.tryWrapperForImpl(indexedValue)
-            };
-          }
-        }
+    set(target, P, V, receiver) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.set(target, P, V, receiver);
+      }
+      if (target === receiver) {
+        utils.isArrayIndexPropName(P);
 
-        if (ownDesc === undefined) {
-          ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-        }
-        if (ownDesc === undefined) {
-          const parent = Reflect.getPrototypeOf(target);
-          if (parent !== null) {
-            return Reflect.set(parent, P, V, receiver);
-          }
-          ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-        }
-        if (!ownDesc.writable) {
-          return false;
-        }
-        if (!utils.isObject(receiver)) {
-          return false;
-        }
-        const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-        let valueDesc;
-        if (existingDesc !== undefined) {
-          if (existingDesc.get || existingDesc.set) {
-            return false;
-          }
-          if (!existingDesc.writable) {
-            return false;
-          }
-          valueDesc = { value: V };
-        } else {
-          valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-        }
-        return Reflect.defineProperty(receiver, P, valueDesc);
-      },
+        typeof P === \\"string\\" && !utils.isArrayIndexPropName(P);
+      }
+      let ownDesc;
 
-      defineProperty(target, P, desc) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.defineProperty(target, P, desc);
+      if (utils.isArrayIndexPropName(P)) {
+        const index = P >>> 0;
+        const indexedValue = target[impl].item(index);
+        if (indexedValue !== undefined) {
+          ownDesc = {
+            writable: false,
+            enumerable: true,
+            configurable: true,
+            value: utils.tryWrapperForImpl(indexedValue)
+          };
         }
+      }
 
-        if (utils.isArrayIndexPropName(P)) {
-          return false;
+      if (ownDesc === undefined) {
+        ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+      }
+      if (ownDesc === undefined) {
+        const parent = Reflect.getPrototypeOf(target);
+        if (parent !== null) {
+          return Reflect.set(parent, P, V, receiver);
         }
-        if (!utils.hasOwn(target, P)) {
-          const creating = !(target[impl].namedItem(P) !== null);
-          if (!creating) {
-            return false;
-          }
-        }
-        return Reflect.defineProperty(target, P, desc);
-      },
-
-      deleteProperty(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.deleteProperty(target, P);
-        }
-
-        if (utils.isArrayIndexPropName(P)) {
-          const index = P >>> 0;
-          return !(target[impl].item(index) !== undefined);
-        }
-
-        if (target[impl].namedItem(P) !== null && !(P in target)) {
-          return false;
-        }
-
-        return Reflect.deleteProperty(target, P);
-      },
-
-      preventExtensions() {
+        ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+      }
+      if (!ownDesc.writable) {
         return false;
       }
-    });
+      if (!utils.isObject(receiver)) {
+        return false;
+      }
+      const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+      let valueDesc;
+      if (existingDesc !== undefined) {
+        if (existingDesc.get || existingDesc.set) {
+          return false;
+        }
+        if (!existingDesc.writable) {
+          return false;
+        }
+        valueDesc = { value: V };
+      } else {
+        valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+      }
+      return Reflect.defineProperty(receiver, P, valueDesc);
+    },
 
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
+    defineProperty(target, P, desc) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.defineProperty(target, P, desc);
+      }
+
+      if (utils.isArrayIndexPropName(P)) {
+        return false;
+      }
+      if (!utils.hasOwn(target, P)) {
+        const creating = !(target[impl].namedItem(P) !== null);
+        if (!creating) {
+          return false;
+        }
+      }
+      return Reflect.defineProperty(target, P, desc);
+    },
+
+    deleteProperty(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.deleteProperty(target, P);
+      }
+
+      if (utils.isArrayIndexPropName(P)) {
+        const index = P >>> 0;
+        return !(target[impl].item(index) !== undefined);
+      }
+
+      if (target[impl].namedItem(P) !== null && !(P in target)) {
+        return false;
+      }
+
+      return Reflect.deleteProperty(target, P);
+    },
+
+    preventExtensions() {
+      return false;
     }
-    return obj;
-  },
+  });
 
-  install(globalObject) {
-    class URLSearchParamsCollection {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      item(index) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'item' on 'URLSearchParamsCollection': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"unsigned long\\"](curArg, {
-            context: \\"Failed to execute 'item' on 'URLSearchParamsCollection': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return utils.tryWrapperForImpl(this[impl].item(...args));
-      }
-
-      namedItem(name) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'namedItem' on 'URLSearchParamsCollection': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'namedItem' on 'URLSearchParamsCollection': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return utils.tryWrapperForImpl(this[impl].namedItem(...args));
-      }
-
-      get length() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"length\\"];
-      }
-    }
-    Object.defineProperties(URLSearchParamsCollection.prototype, {
-      item: { enumerable: true },
-      namedItem: { enumerable: true },
-      length: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"URLSearchParamsCollection\\", configurable: true },
-      [Symbol.iterator]: { value: Array.prototype[Symbol.iterator], configurable: true, writable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"URLSearchParamsCollection\\"] = URLSearchParamsCollection;
-
-    Object.defineProperty(globalObject, \\"URLSearchParamsCollection\\", {
-      configurable: true,
-      writable: true,
-      value: URLSearchParamsCollection
-    });
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
   }
-}; // iface
-module.exports = iface;
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class URLSearchParamsCollection {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    item(index) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'item' on 'URLSearchParamsCollection': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"unsigned long\\"](curArg, {
+          context: \\"Failed to execute 'item' on 'URLSearchParamsCollection': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(this[impl].item(...args));
+    }
+
+    namedItem(name) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'namedItem' on 'URLSearchParamsCollection': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'namedItem' on 'URLSearchParamsCollection': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(this[impl].namedItem(...args));
+    }
+
+    get length() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"length\\"];
+    }
+  }
+  Object.defineProperties(URLSearchParamsCollection.prototype, {
+    item: { enumerable: true },
+    namedItem: { enumerable: true },
+    length: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"URLSearchParamsCollection\\", configurable: true },
+    [Symbol.iterator]: { value: Array.prototype[Symbol.iterator], configurable: true, writable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"URLSearchParamsCollection\\"] = URLSearchParamsCollection;
+
+  Object.defineProperty(globalObject, \\"URLSearchParamsCollection\\", {
+    configurable: true,
+    writable: true,
+    value: URLSearchParamsCollection
+  });
+};
 
 const Impl = require(\\"../implementations/URLSearchParamsCollection.js\\");
 "
@@ -5619,254 +5574,179 @@ const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 const URLSearchParamsCollection = require(\\"./URLSearchParamsCollection.js\\");
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
+  }
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
         return true;
       }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'URLSearchParamsCollection2'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"URLSearchParamsCollection2\\"];
-    if (ctor === undefined) {
-      throw new Error(
-        \\"Internal error: constructor URLSearchParamsCollection2 is not installed on the passed global object\\"
-      );
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
     return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {
-    URLSearchParamsCollection._internalSetup(obj);
-  },
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
+  }
+  throw new TypeError(\`\${context} is not of type 'URLSearchParamsCollection2'.\`);
+};
 
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
 
-    obj = new Proxy(obj, {
-      get(target, P, receiver) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.get(target, P, receiver);
-        }
-        const desc = this.getOwnPropertyDescriptor(target, P);
-        if (desc === undefined) {
-          const parent = Object.getPrototypeOf(target);
-          if (parent === null) {
-            return undefined;
-          }
-          return Reflect.get(target, P, receiver);
-        }
-        if (!desc.get && !desc.set) {
-          return desc.value;
-        }
-        const getter = desc.get;
-        if (getter === undefined) {
+  const ctor = globalObject[ctorRegistry][\\"URLSearchParamsCollection2\\"];
+  if (ctor === undefined) {
+    throw new Error(
+      \\"Internal error: constructor URLSearchParamsCollection2 is not installed on the passed global object\\"
+    );
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {
+  URLSearchParamsCollection._internalSetup(obj);
+};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj = new Proxy(obj, {
+    get(target, P, receiver) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.get(target, P, receiver);
+      }
+      const desc = this.getOwnPropertyDescriptor(target, P);
+      if (desc === undefined) {
+        const parent = Object.getPrototypeOf(target);
+        if (parent === null) {
           return undefined;
         }
-        return Reflect.apply(getter, receiver, []);
-      },
+        return Reflect.get(target, P, receiver);
+      }
+      if (!desc.get && !desc.set) {
+        return desc.value;
+      }
+      const getter = desc.get;
+      if (getter === undefined) {
+        return undefined;
+      }
+      return Reflect.apply(getter, receiver, []);
+    },
 
-      has(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.has(target, P);
-        }
-        const desc = this.getOwnPropertyDescriptor(target, P);
-        if (desc !== undefined) {
-          return true;
-        }
-        const parent = Object.getPrototypeOf(target);
-        if (parent !== null) {
-          return Reflect.has(parent, P);
-        }
-        return false;
-      },
+    has(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.has(target, P);
+      }
+      const desc = this.getOwnPropertyDescriptor(target, P);
+      if (desc !== undefined) {
+        return true;
+      }
+      const parent = Object.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.has(parent, P);
+      }
+      return false;
+    },
 
-      ownKeys(target) {
-        const keys = new Set();
+    ownKeys(target) {
+      const keys = new Set();
 
-        for (const key of target[impl][utils.supportedPropertyIndices]) {
+      for (const key of target[impl][utils.supportedPropertyIndices]) {
+        keys.add(\`\${key}\`);
+      }
+
+      for (const key of target[impl][utils.supportedPropertyNames]) {
+        if (!(key in target)) {
           keys.add(\`\${key}\`);
         }
+      }
 
-        for (const key of target[impl][utils.supportedPropertyNames]) {
-          if (!(key in target)) {
-            keys.add(\`\${key}\`);
-          }
-        }
+      for (const key of Reflect.ownKeys(target)) {
+        keys.add(key);
+      }
+      return [...keys];
+    },
 
-        for (const key of Reflect.ownKeys(target)) {
-          keys.add(key);
-        }
-        return [...keys];
-      },
+    getOwnPropertyDescriptor(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.getOwnPropertyDescriptor(target, P);
+      }
+      let ignoreNamedProps = false;
 
-      getOwnPropertyDescriptor(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.getOwnPropertyDescriptor(target, P);
-        }
-        let ignoreNamedProps = false;
-
-        if (utils.isArrayIndexPropName(P)) {
-          const index = P >>> 0;
-          const indexedValue = target[impl].item(index);
-          if (indexedValue !== undefined) {
-            return {
-              writable: false,
-              enumerable: true,
-              configurable: true,
-              value: utils.tryWrapperForImpl(indexedValue)
-            };
-          }
-          ignoreNamedProps = true;
-        }
-
-        const namedValue = target[impl].namedItem(P);
-
-        if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
+      if (utils.isArrayIndexPropName(P)) {
+        const index = P >>> 0;
+        const indexedValue = target[impl].item(index);
+        if (indexedValue !== undefined) {
           return {
-            writable: true,
+            writable: false,
             enumerable: true,
             configurable: true,
-            value: utils.tryWrapperForImpl(namedValue)
+            value: utils.tryWrapperForImpl(indexedValue)
           };
         }
+        ignoreNamedProps = true;
+      }
 
-        return Reflect.getOwnPropertyDescriptor(target, P);
-      },
+      const namedValue = target[impl].namedItem(P);
 
-      set(target, P, V, receiver) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.set(target, P, V, receiver);
-        }
-        if (target === receiver) {
-          utils.isArrayIndexPropName(P);
+      if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
+        return {
+          writable: true,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
 
-          if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
-            let namedValue = V;
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    },
 
-            namedValue = convertURL(namedValue, {
-              context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
-            });
+    set(target, P, V, receiver) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.set(target, P, V, receiver);
+      }
+      if (target === receiver) {
+        utils.isArrayIndexPropName(P);
 
-            const creating = !(target[impl].namedItem(P) !== null);
-            if (creating) {
-              target[impl][utils.namedSetNew](P, namedValue);
-            } else {
-              target[impl][utils.namedSetExisting](P, namedValue);
-            }
-
-            return true;
-          }
-        }
-        let ownDesc;
-
-        if (utils.isArrayIndexPropName(P)) {
-          const index = P >>> 0;
-          const indexedValue = target[impl].item(index);
-          if (indexedValue !== undefined) {
-            ownDesc = {
-              writable: false,
-              enumerable: true,
-              configurable: true,
-              value: utils.tryWrapperForImpl(indexedValue)
-            };
-          }
-        }
-
-        if (ownDesc === undefined) {
-          ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-        }
-        if (ownDesc === undefined) {
-          const parent = Reflect.getPrototypeOf(target);
-          if (parent !== null) {
-            return Reflect.set(parent, P, V, receiver);
-          }
-          ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-        }
-        if (!ownDesc.writable) {
-          return false;
-        }
-        if (!utils.isObject(receiver)) {
-          return false;
-        }
-        const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-        let valueDesc;
-        if (existingDesc !== undefined) {
-          if (existingDesc.get || existingDesc.set) {
-            return false;
-          }
-          if (!existingDesc.writable) {
-            return false;
-          }
-          valueDesc = { value: V };
-        } else {
-          valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-        }
-        return Reflect.defineProperty(receiver, P, valueDesc);
-      },
-
-      defineProperty(target, P, desc) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.defineProperty(target, P, desc);
-        }
-
-        if (utils.isArrayIndexPropName(P)) {
-          return false;
-        }
-        if (!utils.hasOwn(target, P)) {
-          if (desc.get || desc.set) {
-            return false;
-          }
-
-          let namedValue = desc.value;
+        if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
+          let namedValue = V;
 
           namedValue = convertURL(namedValue, {
             context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
@@ -5881,66 +5761,140 @@ const iface = {
 
           return true;
         }
+      }
+      let ownDesc;
+
+      if (utils.isArrayIndexPropName(P)) {
+        const index = P >>> 0;
+        const indexedValue = target[impl].item(index);
+        if (indexedValue !== undefined) {
+          ownDesc = {
+            writable: false,
+            enumerable: true,
+            configurable: true,
+            value: utils.tryWrapperForImpl(indexedValue)
+          };
+        }
+      }
+
+      if (ownDesc === undefined) {
+        ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+      }
+      if (ownDesc === undefined) {
+        const parent = Reflect.getPrototypeOf(target);
+        if (parent !== null) {
+          return Reflect.set(parent, P, V, receiver);
+        }
+        ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+      }
+      if (!ownDesc.writable) {
+        return false;
+      }
+      if (!utils.isObject(receiver)) {
+        return false;
+      }
+      const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+      let valueDesc;
+      if (existingDesc !== undefined) {
+        if (existingDesc.get || existingDesc.set) {
+          return false;
+        }
+        if (!existingDesc.writable) {
+          return false;
+        }
+        valueDesc = { value: V };
+      } else {
+        valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+      }
+      return Reflect.defineProperty(receiver, P, valueDesc);
+    },
+
+    defineProperty(target, P, desc) {
+      if (typeof P === \\"symbol\\") {
         return Reflect.defineProperty(target, P, desc);
-      },
+      }
 
-      deleteProperty(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.deleteProperty(target, P);
-        }
-
-        if (utils.isArrayIndexPropName(P)) {
-          const index = P >>> 0;
-          return !(target[impl].item(index) !== undefined);
-        }
-
-        if (target[impl].namedItem(P) !== null && !(P in target)) {
+      if (utils.isArrayIndexPropName(P)) {
+        return false;
+      }
+      if (!utils.hasOwn(target, P)) {
+        if (desc.get || desc.set) {
           return false;
         }
 
-        return Reflect.deleteProperty(target, P);
-      },
+        let namedValue = desc.value;
 
-      preventExtensions() {
+        namedValue = convertURL(namedValue, {
+          context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
+        });
+
+        const creating = !(target[impl].namedItem(P) !== null);
+        if (creating) {
+          target[impl][utils.namedSetNew](P, namedValue);
+        } else {
+          target[impl][utils.namedSetExisting](P, namedValue);
+        }
+
+        return true;
+      }
+      return Reflect.defineProperty(target, P, desc);
+    },
+
+    deleteProperty(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.deleteProperty(target, P);
+      }
+
+      if (utils.isArrayIndexPropName(P)) {
+        const index = P >>> 0;
+        return !(target[impl].item(index) !== undefined);
+      }
+
+      if (target[impl].namedItem(P) !== null && !(P in target)) {
         return false;
       }
-    });
 
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
+      return Reflect.deleteProperty(target, P);
+    },
 
-  install(globalObject) {
-    if (globalObject.URLSearchParamsCollection === undefined) {
-      throw new Error(
-        \\"Internal error: attempting to evaluate URLSearchParamsCollection2 before URLSearchParamsCollection\\"
-      );
+    preventExtensions() {
+      return false;
     }
-    class URLSearchParamsCollection2 extends globalObject.URLSearchParamsCollection {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-    }
-    Object.defineProperties(URLSearchParamsCollection2.prototype, {
-      [Symbol.toStringTag]: { value: \\"URLSearchParamsCollection2\\", configurable: true },
-      [Symbol.iterator]: { value: Array.prototype[Symbol.iterator], configurable: true, writable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"URLSearchParamsCollection2\\"] = URLSearchParamsCollection2;
+  });
 
-    Object.defineProperty(globalObject, \\"URLSearchParamsCollection2\\", {
-      configurable: true,
-      writable: true,
-      value: URLSearchParamsCollection2
-    });
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
   }
-}; // iface
-module.exports = iface;
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  if (globalObject.URLSearchParamsCollection === undefined) {
+    throw new Error(
+      \\"Internal error: attempting to evaluate URLSearchParamsCollection2 before URLSearchParamsCollection\\"
+    );
+  }
+  class URLSearchParamsCollection2 extends globalObject.URLSearchParamsCollection {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+  }
+  Object.defineProperties(URLSearchParamsCollection2.prototype, {
+    [Symbol.toStringTag]: { value: \\"URLSearchParamsCollection2\\", configurable: true },
+    [Symbol.iterator]: { value: Array.prototype[Symbol.iterator], configurable: true, writable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"URLSearchParamsCollection2\\"] = URLSearchParamsCollection2;
+
+  Object.defineProperty(globalObject, \\"URLSearchParamsCollection2\\", {
+    configurable: true,
+    writable: true,
+    value: URLSearchParamsCollection2
+  });
+};
 
 const Impl = require(\\"../implementations/URLSearchParamsCollection2.js\\");
 "
@@ -5955,185 +5909,184 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'UnderscoredProperties'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"UnderscoredProperties\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor UnderscoredProperties is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class UnderscoredProperties {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      operation(sequence) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'operation' on 'UnderscoredProperties': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          if (!utils.isObject(curArg)) {
-            throw new TypeError(
-              \\"Failed to execute 'operation' on 'UnderscoredProperties': parameter 1\\" + \\" is not an iterable object.\\"
-            );
-          } else {
-            const V = [];
-            const tmp = curArg;
-            for (let nextItem of tmp) {
-              nextItem = conversions[\\"DOMString\\"](nextItem, {
-                context: \\"Failed to execute 'operation' on 'UnderscoredProperties': parameter 1\\" + \\"'s element\\"
-              });
-
-              V.push(nextItem);
-            }
-            curArg = V;
-          }
-          args.push(curArg);
-        }
-        return this[impl].operation(...args);
-      }
-
-      get attribute() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"attribute\\"];
-      }
-
-      set attribute(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"byte\\"](V, {
-          context: \\"Failed to set the 'attribute' property on 'UnderscoredProperties': The provided value\\"
-        });
-
-        this[impl][\\"attribute\\"] = V;
-      }
-
-      static static(void_) {
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'static' on 'UnderscoredProperties': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'static' on 'UnderscoredProperties': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return Impl.implementation.static(...args);
-      }
-    }
-    Object.defineProperties(UnderscoredProperties.prototype, {
-      operation: { enumerable: true },
-      attribute: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"UnderscoredProperties\\", configurable: true },
-      const: { value: 42, enumerable: true }
-    });
-    Object.defineProperties(UnderscoredProperties, {
-      static: { enumerable: true },
-      const: { value: 42, enumerable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"UnderscoredProperties\\"] = UnderscoredProperties;
-
-    Object.defineProperty(globalObject, \\"UnderscoredProperties\\", {
-      configurable: true,
-      writable: true,
-      value: UnderscoredProperties
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'UnderscoredProperties'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"UnderscoredProperties\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor UnderscoredProperties is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class UnderscoredProperties {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    operation(sequence) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'operation' on 'UnderscoredProperties': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (!utils.isObject(curArg)) {
+          throw new TypeError(
+            \\"Failed to execute 'operation' on 'UnderscoredProperties': parameter 1\\" + \\" is not an iterable object.\\"
+          );
+        } else {
+          const V = [];
+          const tmp = curArg;
+          for (let nextItem of tmp) {
+            nextItem = conversions[\\"DOMString\\"](nextItem, {
+              context: \\"Failed to execute 'operation' on 'UnderscoredProperties': parameter 1\\" + \\"'s element\\"
+            });
+
+            V.push(nextItem);
+          }
+          curArg = V;
+        }
+        args.push(curArg);
+      }
+      return this[impl].operation(...args);
+    }
+
+    get attribute() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"attribute\\"];
+    }
+
+    set attribute(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"byte\\"](V, {
+        context: \\"Failed to set the 'attribute' property on 'UnderscoredProperties': The provided value\\"
+      });
+
+      this[impl][\\"attribute\\"] = V;
+    }
+
+    static static(void_) {
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'static' on 'UnderscoredProperties': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'static' on 'UnderscoredProperties': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      return Impl.implementation.static(...args);
+    }
+  }
+  Object.defineProperties(UnderscoredProperties.prototype, {
+    operation: { enumerable: true },
+    attribute: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"UnderscoredProperties\\", configurable: true },
+    const: { value: 42, enumerable: true }
+  });
+  Object.defineProperties(UnderscoredProperties, {
+    static: { enumerable: true },
+    const: { value: 42, enumerable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"UnderscoredProperties\\"] = UnderscoredProperties;
+
+  Object.defineProperty(globalObject, \\"UnderscoredProperties\\", {
+    configurable: true,
+    writable: true,
+    value: UnderscoredProperties
+  });
+};
 
 const Impl = require(\\"../implementations/UnderscoredProperties.js\\");
 "
@@ -6148,188 +6101,187 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'Unforgeable'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"Unforgeable\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor Unforgeable is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {
-    Object.defineProperties(
-      obj,
-      Object.getOwnPropertyDescriptors({
-        assign(url) {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          if (arguments.length < 1) {
-            throw new TypeError(
-              \\"Failed to execute 'assign' on 'Unforgeable': 1 argument required, but only \\" +
-                arguments.length +
-                \\" present.\\"
-            );
-          }
-          const args = [];
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"USVString\\"](curArg, {
-              context: \\"Failed to execute 'assign' on 'Unforgeable': parameter 1\\"
-            });
-            args.push(curArg);
-          }
-          return this[impl].assign(...args);
-        },
-        get href() {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          return obj[impl][\\"href\\"];
-        },
-        set href(V) {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          V = conversions[\\"USVString\\"](V, {
-            context: \\"Failed to set the 'href' property on 'Unforgeable': The provided value\\"
-          });
-
-          obj[impl][\\"href\\"] = V;
-        },
-        toString() {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-          return obj[impl][\\"href\\"];
-        },
-        get origin() {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          return obj[impl][\\"origin\\"];
-        },
-        get protocol() {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          return obj[impl][\\"protocol\\"];
-        },
-        set protocol(V) {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
-
-          V = conversions[\\"USVString\\"](V, {
-            context: \\"Failed to set the 'protocol' property on 'Unforgeable': The provided value\\"
-          });
-
-          obj[impl][\\"protocol\\"] = V;
-        }
-      })
-    );
-
-    Object.defineProperties(obj, {
-      assign: { configurable: false, writable: false },
-      href: { configurable: false },
-      toString: { configurable: false, writable: false },
-      origin: { configurable: false },
-      protocol: { configurable: false }
-    });
-  },
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class Unforgeable {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-    }
-    Object.defineProperties(Unforgeable.prototype, {
-      [Symbol.toStringTag]: { value: \\"Unforgeable\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"Unforgeable\\"] = Unforgeable;
-
-    Object.defineProperty(globalObject, \\"Unforgeable\\", {
-      configurable: true,
-      writable: true,
-      value: Unforgeable
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'Unforgeable'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"Unforgeable\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Unforgeable is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {
+  Object.defineProperties(
+    obj,
+    Object.getOwnPropertyDescriptors({
+      assign(url) {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'assign' on 'Unforgeable': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          curArg = conversions[\\"USVString\\"](curArg, {
+            context: \\"Failed to execute 'assign' on 'Unforgeable': parameter 1\\"
+          });
+          args.push(curArg);
+        }
+        return this[impl].assign(...args);
+      },
+      get href() {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return obj[impl][\\"href\\"];
+      },
+      set href(V) {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        V = conversions[\\"USVString\\"](V, {
+          context: \\"Failed to set the 'href' property on 'Unforgeable': The provided value\\"
+        });
+
+        obj[impl][\\"href\\"] = V;
+      },
+      toString() {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+        return obj[impl][\\"href\\"];
+      },
+      get origin() {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return obj[impl][\\"origin\\"];
+      },
+      get protocol() {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return obj[impl][\\"protocol\\"];
+      },
+      set protocol(V) {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        V = conversions[\\"USVString\\"](V, {
+          context: \\"Failed to set the 'protocol' property on 'Unforgeable': The provided value\\"
+        });
+
+        obj[impl][\\"protocol\\"] = V;
+      }
+    })
+  );
+
+  Object.defineProperties(obj, {
+    assign: { configurable: false, writable: false },
+    href: { configurable: false },
+    toString: { configurable: false, writable: false },
+    origin: { configurable: false },
+    protocol: { configurable: false }
+  });
+};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class Unforgeable {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+  }
+  Object.defineProperties(Unforgeable.prototype, {
+    [Symbol.toStringTag]: { value: \\"Unforgeable\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"Unforgeable\\"] = Unforgeable;
+
+  Object.defineProperty(globalObject, \\"Unforgeable\\", {
+    configurable: true,
+    writable: true,
+    value: Unforgeable
+  });
+};
 
 const Impl = require(\\"../implementations/Unforgeable.js\\");
 "
@@ -6344,293 +6296,292 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
+  }
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
         return true;
       }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'UnforgeableMap'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"UnforgeableMap\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor UnforgeableMap is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
     return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {
-    Object.defineProperties(
-      obj,
-      Object.getOwnPropertyDescriptors({
-        get a() {
-          if (!this || !module.exports.is(this)) {
-            throw new TypeError(\\"Illegal invocation\\");
-          }
+  }
+  throw new TypeError(\`\${context} is not of type 'UnforgeableMap'.\`);
+};
 
-          return obj[impl][\\"a\\"];
-        }
-      })
-    );
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
 
-    Object.defineProperties(obj, { a: { configurable: false } });
-  },
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
+  const ctor = globalObject[ctorRegistry][\\"UnforgeableMap\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor UnforgeableMap is not installed on the passed global object\\");
+  }
 
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {
+  Object.defineProperties(
+    obj,
+    Object.getOwnPropertyDescriptors({
+      get a() {
+        if (!this || !exports.is(this)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
 
-    obj = new Proxy(obj, {
-      get(target, P, receiver) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.get(target, P, receiver);
-        }
-        const desc = this.getOwnPropertyDescriptor(target, P);
-        if (desc === undefined) {
-          const parent = Object.getPrototypeOf(target);
-          if (parent === null) {
-            return undefined;
-          }
-          return Reflect.get(target, P, receiver);
-        }
-        if (!desc.get && !desc.set) {
-          return desc.value;
-        }
-        const getter = desc.get;
-        if (getter === undefined) {
+        return obj[impl][\\"a\\"];
+      }
+    })
+  );
+
+  Object.defineProperties(obj, { a: { configurable: false } });
+};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj = new Proxy(obj, {
+    get(target, P, receiver) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.get(target, P, receiver);
+      }
+      const desc = this.getOwnPropertyDescriptor(target, P);
+      if (desc === undefined) {
+        const parent = Object.getPrototypeOf(target);
+        if (parent === null) {
           return undefined;
         }
-        return Reflect.apply(getter, receiver, []);
-      },
+        return Reflect.get(target, P, receiver);
+      }
+      if (!desc.get && !desc.set) {
+        return desc.value;
+      }
+      const getter = desc.get;
+      if (getter === undefined) {
+        return undefined;
+      }
+      return Reflect.apply(getter, receiver, []);
+    },
 
-      has(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.has(target, P);
+    has(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.has(target, P);
+      }
+      const desc = this.getOwnPropertyDescriptor(target, P);
+      if (desc !== undefined) {
+        return true;
+      }
+      const parent = Object.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.has(parent, P);
+      }
+      return false;
+    },
+
+    ownKeys(target) {
+      const keys = new Set();
+
+      for (const key of target[impl][utils.supportedPropertyNames]) {
+        if (!(key in target)) {
+          keys.add(\`\${key}\`);
         }
-        const desc = this.getOwnPropertyDescriptor(target, P);
-        if (desc !== undefined) {
+      }
+
+      for (const key of Reflect.ownKeys(target)) {
+        keys.add(key);
+      }
+      return [...keys];
+    },
+
+    getOwnPropertyDescriptor(target, P) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.getOwnPropertyDescriptor(target, P);
+      }
+      let ignoreNamedProps = false;
+
+      if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+        const namedValue = target[impl][utils.namedGet](P);
+
+        return {
+          writable: true,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
+
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    },
+
+    set(target, P, V, receiver) {
+      if (typeof P === \\"symbol\\") {
+        return Reflect.set(target, P, V, receiver);
+      }
+      if (target === receiver) {
+        if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
+          let namedValue = V;
+
+          namedValue = conversions[\\"DOMString\\"](namedValue, {
+            context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
+          });
+
+          const creating = !target[impl][utils.supportsPropertyName](P);
+          if (creating) {
+            target[impl][utils.namedSetNew](P, namedValue);
+          } else {
+            target[impl][utils.namedSetExisting](P, namedValue);
+          }
+
           return true;
         }
-        const parent = Object.getPrototypeOf(target);
+      }
+      let ownDesc;
+
+      if (ownDesc === undefined) {
+        ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+      }
+      if (ownDesc === undefined) {
+        const parent = Reflect.getPrototypeOf(target);
         if (parent !== null) {
-          return Reflect.has(parent, P);
+          return Reflect.set(parent, P, V, receiver);
         }
+        ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+      }
+      if (!ownDesc.writable) {
         return false;
-      },
-
-      ownKeys(target) {
-        const keys = new Set();
-
-        for (const key of target[impl][utils.supportedPropertyNames]) {
-          if (!(key in target)) {
-            keys.add(\`\${key}\`);
-          }
-        }
-
-        for (const key of Reflect.ownKeys(target)) {
-          keys.add(key);
-        }
-        return [...keys];
-      },
-
-      getOwnPropertyDescriptor(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.getOwnPropertyDescriptor(target, P);
-        }
-        let ignoreNamedProps = false;
-
-        if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-          const namedValue = target[impl][utils.namedGet](P);
-
-          return {
-            writable: true,
-            enumerable: true,
-            configurable: true,
-            value: utils.tryWrapperForImpl(namedValue)
-          };
-        }
-
-        return Reflect.getOwnPropertyDescriptor(target, P);
-      },
-
-      set(target, P, V, receiver) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.set(target, P, V, receiver);
-        }
-        if (target === receiver) {
-          if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
-            let namedValue = V;
-
-            namedValue = conversions[\\"DOMString\\"](namedValue, {
-              context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
-            });
-
-            const creating = !target[impl][utils.supportsPropertyName](P);
-            if (creating) {
-              target[impl][utils.namedSetNew](P, namedValue);
-            } else {
-              target[impl][utils.namedSetExisting](P, namedValue);
-            }
-
-            return true;
-          }
-        }
-        let ownDesc;
-
-        if (ownDesc === undefined) {
-          ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-        }
-        if (ownDesc === undefined) {
-          const parent = Reflect.getPrototypeOf(target);
-          if (parent !== null) {
-            return Reflect.set(parent, P, V, receiver);
-          }
-          ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-        }
-        if (!ownDesc.writable) {
+      }
+      if (!utils.isObject(receiver)) {
+        return false;
+      }
+      const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+      let valueDesc;
+      if (existingDesc !== undefined) {
+        if (existingDesc.get || existingDesc.set) {
           return false;
         }
-        if (!utils.isObject(receiver)) {
+        if (!existingDesc.writable) {
           return false;
         }
-        const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-        let valueDesc;
-        if (existingDesc !== undefined) {
-          if (existingDesc.get || existingDesc.set) {
-            return false;
-          }
-          if (!existingDesc.writable) {
-            return false;
-          }
-          valueDesc = { value: V };
-        } else {
-          valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-        }
-        return Reflect.defineProperty(receiver, P, valueDesc);
-      },
+        valueDesc = { value: V };
+      } else {
+        valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+      }
+      return Reflect.defineProperty(receiver, P, valueDesc);
+    },
 
-      defineProperty(target, P, desc) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.defineProperty(target, P, desc);
-        }
-        if (![\\"a\\"].includes(P)) {
-          if (!utils.hasOwn(target, P)) {
-            if (desc.get || desc.set) {
-              return false;
-            }
-
-            let namedValue = desc.value;
-
-            namedValue = conversions[\\"DOMString\\"](namedValue, {
-              context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
-            });
-
-            const creating = !target[impl][utils.supportsPropertyName](P);
-            if (creating) {
-              target[impl][utils.namedSetNew](P, namedValue);
-            } else {
-              target[impl][utils.namedSetExisting](P, namedValue);
-            }
-
-            return true;
-          }
-        }
+    defineProperty(target, P, desc) {
+      if (typeof P === \\"symbol\\") {
         return Reflect.defineProperty(target, P, desc);
-      },
+      }
+      if (![\\"a\\"].includes(P)) {
+        if (!utils.hasOwn(target, P)) {
+          if (desc.get || desc.set) {
+            return false;
+          }
 
-      deleteProperty(target, P) {
-        if (typeof P === \\"symbol\\") {
-          return Reflect.deleteProperty(target, P);
+          let namedValue = desc.value;
+
+          namedValue = conversions[\\"DOMString\\"](namedValue, {
+            context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
+          });
+
+          const creating = !target[impl][utils.supportsPropertyName](P);
+          if (creating) {
+            target[impl][utils.namedSetNew](P, namedValue);
+          } else {
+            target[impl][utils.namedSetExisting](P, namedValue);
+          }
+
+          return true;
         }
+      }
+      return Reflect.defineProperty(target, P, desc);
+    },
 
-        if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
-          return false;
-        }
-
+    deleteProperty(target, P) {
+      if (typeof P === \\"symbol\\") {
         return Reflect.deleteProperty(target, P);
-      },
+      }
 
-      preventExtensions() {
+      if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
         return false;
       }
-    });
 
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
+      return Reflect.deleteProperty(target, P);
+    },
 
-  install(globalObject) {
-    class UnforgeableMap {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
+    preventExtensions() {
+      return false;
     }
-    Object.defineProperties(UnforgeableMap.prototype, {
-      [Symbol.toStringTag]: { value: \\"UnforgeableMap\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"UnforgeableMap\\"] = UnforgeableMap;
+  });
 
-    Object.defineProperty(globalObject, \\"UnforgeableMap\\", {
-      configurable: true,
-      writable: true,
-      value: UnforgeableMap
-    });
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
   }
-}; // iface
-module.exports = iface;
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class UnforgeableMap {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+  }
+  Object.defineProperties(UnforgeableMap.prototype, {
+    [Symbol.toStringTag]: { value: \\"UnforgeableMap\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"UnforgeableMap\\"] = UnforgeableMap;
+
+  Object.defineProperty(globalObject, \\"UnforgeableMap\\", {
+    configurable: true,
+    writable: true,
+    value: UnforgeableMap
+  });
+};
 
 const Impl = require(\\"../implementations/UnforgeableMap.js\\");
 "
@@ -6645,149 +6596,148 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'Unscopable'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"Unscopable\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor Unscopable is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class Unscopable {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
-      }
-
-      get unscopableTest() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"unscopableTest\\"];
-      }
-
-      set unscopableTest(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"boolean\\"](V, {
-          context: \\"Failed to set the 'unscopableTest' property on 'Unscopable': The provided value\\"
-        });
-
-        this[impl][\\"unscopableTest\\"] = V;
-      }
-
-      get unscopableMixin() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return this[impl][\\"unscopableMixin\\"];
-      }
-
-      set unscopableMixin(V) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"boolean\\"](V, {
-          context: \\"Failed to set the 'unscopableMixin' property on 'Unscopable': The provided value\\"
-        });
-
-        this[impl][\\"unscopableMixin\\"] = V;
-      }
-    }
-    Object.defineProperties(Unscopable.prototype, {
-      unscopableTest: { enumerable: true },
-      unscopableMixin: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"Unscopable\\", configurable: true },
-      [Symbol.unscopables]: {
-        value: { unscopableTest: true, unscopableMixin: true, __proto__: null },
-        configurable: true
-      }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"Unscopable\\"] = Unscopable;
-
-    Object.defineProperty(globalObject, \\"Unscopable\\", {
-      configurable: true,
-      writable: true,
-      value: Unscopable
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'Unscopable'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"Unscopable\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Unscopable is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class Unscopable {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    get unscopableTest() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"unscopableTest\\"];
+    }
+
+    set unscopableTest(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"boolean\\"](V, {
+        context: \\"Failed to set the 'unscopableTest' property on 'Unscopable': The provided value\\"
+      });
+
+      this[impl][\\"unscopableTest\\"] = V;
+    }
+
+    get unscopableMixin() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return this[impl][\\"unscopableMixin\\"];
+    }
+
+    set unscopableMixin(V) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      V = conversions[\\"boolean\\"](V, {
+        context: \\"Failed to set the 'unscopableMixin' property on 'Unscopable': The provided value\\"
+      });
+
+      this[impl][\\"unscopableMixin\\"] = V;
+    }
+  }
+  Object.defineProperties(Unscopable.prototype, {
+    unscopableTest: { enumerable: true },
+    unscopableMixin: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"Unscopable\\", configurable: true },
+    [Symbol.unscopables]: {
+      value: { unscopableTest: true, unscopableMixin: true, __proto__: null },
+      configurable: true
+    }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"Unscopable\\"] = Unscopable;
+
+  Object.defineProperty(globalObject, \\"Unscopable\\", {
+    configurable: true,
+    writable: true,
+    value: Unscopable
+  });
+};
 
 const Impl = require(\\"../implementations/Unscopable.js\\");
 "
@@ -6803,254 +6753,253 @@ const convertURL = require(\\"./URL.js\\").convert;
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
+  }
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
         return true;
       }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'Variadic'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"Variadic\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor Variadic is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
     return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
+  }
+  throw new TypeError(\`\${context} is not of type 'Variadic'.\`);
+};
 
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
 
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
+  const ctor = globalObject[ctorRegistry][\\"Variadic\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Variadic is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class Variadic {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
     }
-    return obj;
-  },
 
-  install(globalObject) {
-    class Variadic {
-      constructor() {
-        throw new TypeError(\\"Illegal constructor\\");
+    simple1() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+      const args = [];
+      for (let i = 0; i < arguments.length; i++) {
+        let curArg = arguments[i];
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'simple1' on 'Variadic': parameter \\" + (i + 1)
+        });
+        args.push(curArg);
+      }
+      return this[impl].simple1(...args);
+    }
+
+    simple2(first) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      simple1() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-        const args = [];
-        for (let i = 0; i < arguments.length; i++) {
-          let curArg = arguments[i];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'simple1' on 'Variadic': parameter \\" + (i + 1)
-          });
-          args.push(curArg);
-        }
-        return this[impl].simple1(...args);
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'simple2' on 'Variadic': 1 argument required, but only \\" + arguments.length + \\" present.\\"
+        );
       }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        curArg = conversions[\\"DOMString\\"](curArg, {
+          context: \\"Failed to execute 'simple2' on 'Variadic': parameter 1\\"
+        });
+        args.push(curArg);
+      }
+      for (let i = 1; i < arguments.length; i++) {
+        let curArg = arguments[i];
+        curArg = convertURL(curArg, { context: \\"Failed to execute 'simple2' on 'Variadic': parameter \\" + (i + 1) });
+        args.push(curArg);
+      }
+      return this[impl].simple2(...args);
+    }
 
-      simple2(first) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'simple2' on 'Variadic': 1 argument required, but only \\" + arguments.length + \\" present.\\"
-          );
-        }
-        const args = [];
-        {
+    overloaded1() {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+      const args = [];
+      switch (arguments.length) {
+        case 0:
+          break;
+        default: {
           let curArg = arguments[0];
-          curArg = conversions[\\"DOMString\\"](curArg, {
-            context: \\"Failed to execute 'simple2' on 'Variadic': parameter 1\\"
-          });
-          args.push(curArg);
+          if (typeof curArg === \\"number\\") {
+            for (let i = 0; i < arguments.length; i++) {
+              let curArg = arguments[i];
+              curArg = conversions[\\"unsigned long\\"](curArg, {
+                context: \\"Failed to execute 'overloaded1' on 'Variadic': parameter \\" + (i + 1)
+              });
+              args.push(curArg);
+            }
+          } else {
+            for (let i = 0; i < arguments.length; i++) {
+              let curArg = arguments[i];
+              curArg = conversions[\\"DOMString\\"](curArg, {
+                context: \\"Failed to execute 'overloaded1' on 'Variadic': parameter \\" + (i + 1)
+              });
+              args.push(curArg);
+            }
+          }
         }
-        for (let i = 1; i < arguments.length; i++) {
-          let curArg = arguments[i];
-          curArg = convertURL(curArg, { context: \\"Failed to execute 'simple2' on 'Variadic': parameter \\" + (i + 1) });
-          args.push(curArg);
-        }
-        return this[impl].simple2(...args);
+      }
+      return this[impl].overloaded1(...args);
+    }
+
+    overloaded2(first) {
+      if (!this || !exports.is(this)) {
+        throw new TypeError(\\"Illegal invocation\\");
       }
 
-      overloaded1() {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-        const args = [];
-        switch (arguments.length) {
-          case 0:
-            break;
-          default: {
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloaded2' on 'Variadic': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      switch (arguments.length) {
+        case 1:
+          {
             let curArg = arguments[0];
             if (typeof curArg === \\"number\\") {
-              for (let i = 0; i < arguments.length; i++) {
-                let curArg = arguments[i];
+              {
+                let curArg = arguments[0];
                 curArg = conversions[\\"unsigned long\\"](curArg, {
-                  context: \\"Failed to execute 'overloaded1' on 'Variadic': parameter \\" + (i + 1)
+                  context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter 1\\"
                 });
                 args.push(curArg);
               }
             } else {
-              for (let i = 0; i < arguments.length; i++) {
-                let curArg = arguments[i];
+              {
+                let curArg = arguments[0];
                 curArg = conversions[\\"DOMString\\"](curArg, {
-                  context: \\"Failed to execute 'overloaded1' on 'Variadic': parameter \\" + (i + 1)
+                  context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter 1\\"
                 });
                 args.push(curArg);
               }
             }
           }
-        }
-        return this[impl].overloaded1(...args);
-      }
-
-      overloaded2(first) {
-        if (!this || !module.exports.is(this)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'overloaded2' on 'Variadic': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        switch (arguments.length) {
-          case 1:
+          break;
+        default: {
+          let curArg = arguments[0];
+          if (typeof curArg === \\"number\\") {
             {
               let curArg = arguments[0];
-              if (typeof curArg === \\"number\\") {
-                {
-                  let curArg = arguments[0];
-                  curArg = conversions[\\"unsigned long\\"](curArg, {
-                    context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter 1\\"
-                  });
-                  args.push(curArg);
-                }
-              } else {
-                {
-                  let curArg = arguments[0];
-                  curArg = conversions[\\"DOMString\\"](curArg, {
-                    context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter 1\\"
-                  });
-                  args.push(curArg);
-                }
-              }
+              curArg = conversions[\\"unsigned long\\"](curArg, {
+                context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter 1\\"
+              });
+              args.push(curArg);
             }
-            break;
-          default: {
-            let curArg = arguments[0];
-            if (typeof curArg === \\"number\\") {
-              {
-                let curArg = arguments[0];
-                curArg = conversions[\\"unsigned long\\"](curArg, {
-                  context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter 1\\"
-                });
-                args.push(curArg);
-              }
-              for (let i = 1; i < arguments.length; i++) {
-                let curArg = arguments[i];
-                curArg = conversions[\\"DOMString\\"](curArg, {
-                  context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter \\" + (i + 1)
-                });
-                args.push(curArg);
-              }
-            } else {
-              {
-                let curArg = arguments[0];
-                curArg = conversions[\\"DOMString\\"](curArg, {
-                  context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter 1\\"
-                });
-                args.push(curArg);
-              }
-              for (let i = 1; i < arguments.length; i++) {
-                let curArg = arguments[i];
-                curArg = conversions[\\"DOMString\\"](curArg, {
-                  context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter \\" + (i + 1)
-                });
-                args.push(curArg);
-              }
+            for (let i = 1; i < arguments.length; i++) {
+              let curArg = arguments[i];
+              curArg = conversions[\\"DOMString\\"](curArg, {
+                context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter \\" + (i + 1)
+              });
+              args.push(curArg);
+            }
+          } else {
+            {
+              let curArg = arguments[0];
+              curArg = conversions[\\"DOMString\\"](curArg, {
+                context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter 1\\"
+              });
+              args.push(curArg);
+            }
+            for (let i = 1; i < arguments.length; i++) {
+              let curArg = arguments[i];
+              curArg = conversions[\\"DOMString\\"](curArg, {
+                context: \\"Failed to execute 'overloaded2' on 'Variadic': parameter \\" + (i + 1)
+              });
+              args.push(curArg);
             }
           }
         }
-        return this[impl].overloaded2(...args);
       }
+      return this[impl].overloaded2(...args);
     }
-    Object.defineProperties(Variadic.prototype, {
-      simple1: { enumerable: true },
-      simple2: { enumerable: true },
-      overloaded1: { enumerable: true },
-      overloaded2: { enumerable: true },
-      [Symbol.toStringTag]: { value: \\"Variadic\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"Variadic\\"] = Variadic;
-
-    Object.defineProperty(globalObject, \\"Variadic\\", {
-      configurable: true,
-      writable: true,
-      value: Variadic
-    });
   }
-}; // iface
-module.exports = iface;
+  Object.defineProperties(Variadic.prototype, {
+    simple1: { enumerable: true },
+    simple2: { enumerable: true },
+    overloaded1: { enumerable: true },
+    overloaded2: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"Variadic\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"Variadic\\"] = Variadic;
+
+  Object.defineProperty(globalObject, \\"Variadic\\", {
+    configurable: true,
+    writable: true,
+    value: Variadic
+  });
+};
 
 const Impl = require(\\"../implementations/Variadic.js\\");
 "
@@ -7065,103 +7014,102 @@ const utils = require(\\"./utils.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
-const iface = {
-  // When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
-  // method into this array. It allows objects that directly implements *those* interfaces to be recognized as
-  // implementing this mixin interface.
-  _mixedIntoPredicates: [],
-  is(obj) {
-    if (obj) {
-      if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+/**
+ * When an interface-module that implements this interface as a mixin is loaded, it will append its own \`.is()\`
+ * method into this array. It allows objects that directly implements *those* interfaces to be recognized as
+ * implementing this mixin interface.
+ */
+exports._mixedIntoPredicates = [];
+exports.is = function is(obj) {
+  if (obj) {
+    if (utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation) {
+      return true;
+    }
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(obj)) {
         return true;
       }
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(obj)) {
-          return true;
-        }
-      }
     }
-    return false;
-  },
-  isImpl(obj) {
-    if (obj) {
-      if (obj instanceof Impl.implementation) {
-        return true;
-      }
-
-      const wrapper = utils.wrapperForImpl(obj);
-      for (const isMixedInto of module.exports._mixedIntoPredicates) {
-        if (isMixedInto(wrapper)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  },
-  convert(obj, { context = \\"The provided value\\" } = {}) {
-    if (module.exports.is(obj)) {
-      return utils.implForWrapper(obj);
-    }
-    throw new TypeError(\`\${context} is not of type 'ZeroArgConstructor'.\`);
-  },
-
-  create(globalObject, constructorArgs, privateData) {
-    if (globalObject[ctorRegistry] === undefined) {
-      throw new Error(\\"Internal error: invalid global object\\");
-    }
-
-    const ctor = globalObject[ctorRegistry][\\"ZeroArgConstructor\\"];
-    if (ctor === undefined) {
-      throw new Error(\\"Internal error: constructor ZeroArgConstructor is not installed on the passed global object\\");
-    }
-
-    let obj = Object.create(ctor.prototype);
-    obj = iface.setup(obj, globalObject, constructorArgs, privateData);
-    return obj;
-  },
-  createImpl(globalObject, constructorArgs, privateData) {
-    const obj = iface.create(globalObject, constructorArgs, privateData);
-    return utils.implForWrapper(obj);
-  },
-  _internalSetup(obj) {},
-  setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-    privateData.wrapper = obj;
-
-    iface._internalSetup(obj);
-    Object.defineProperty(obj, impl, {
-      value: new Impl.implementation(globalObject, constructorArgs, privateData),
-      configurable: true
-    });
-
-    obj[impl][utils.wrapperSymbol] = obj;
-    if (Impl.init) {
-      Impl.init(obj[impl], privateData);
-    }
-    return obj;
-  },
-
-  install(globalObject) {
-    class ZeroArgConstructor {
-      constructor() {
-        return iface.setup(Object.create(new.target.prototype), globalObject, undefined);
-      }
-    }
-    Object.defineProperties(ZeroArgConstructor.prototype, {
-      [Symbol.toStringTag]: { value: \\"ZeroArgConstructor\\", configurable: true }
-    });
-    if (globalObject[ctorRegistry] === undefined) {
-      globalObject[ctorRegistry] = Object.create(null);
-    }
-    globalObject[ctorRegistry][\\"ZeroArgConstructor\\"] = ZeroArgConstructor;
-
-    Object.defineProperty(globalObject, \\"ZeroArgConstructor\\", {
-      configurable: true,
-      writable: true,
-      value: ZeroArgConstructor
-    });
   }
-}; // iface
-module.exports = iface;
+  return false;
+};
+exports.isImpl = function isImpl(obj) {
+  if (obj) {
+    if (obj instanceof Impl.implementation) {
+      return true;
+    }
+
+    const wrapper = utils.wrapperForImpl(obj);
+    for (const isMixedInto of exports._mixedIntoPredicates) {
+      if (isMixedInto(wrapper)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (exports.is(obj)) {
+    return utils.implForWrapper(obj);
+  }
+  throw new TypeError(\`\${context} is not of type 'ZeroArgConstructor'.\`);
+};
+
+exports.create = function create(globalObject, constructorArgs, privateData) {
+  if (globalObject[ctorRegistry] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistry][\\"ZeroArgConstructor\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor ZeroArgConstructor is not installed on the passed global object\\");
+  }
+
+  let obj = Object.create(ctor.prototype);
+  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
+  return obj;
+};
+exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
+  const obj = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(obj);
+};
+exports._internalSetup = function _internalSetup(obj) {};
+exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
+  privateData.wrapper = obj;
+
+  exports._internalSetup(obj);
+  Object.defineProperty(obj, impl, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  obj[impl][utils.wrapperSymbol] = obj;
+  if (Impl.init) {
+    Impl.init(obj[impl], privateData);
+  }
+  return obj;
+};
+
+exports.install = function install(globalObject) {
+  class ZeroArgConstructor {
+    constructor() {
+      return exports.setup(Object.create(new.target.prototype), globalObject, undefined);
+    }
+  }
+  Object.defineProperties(ZeroArgConstructor.prototype, {
+    [Symbol.toStringTag]: { value: \\"ZeroArgConstructor\\", configurable: true }
+  });
+  if (globalObject[ctorRegistry] === undefined) {
+    globalObject[ctorRegistry] = Object.create(null);
+  }
+  globalObject[ctorRegistry][\\"ZeroArgConstructor\\"] = ZeroArgConstructor;
+
+  Object.defineProperty(globalObject, \\"ZeroArgConstructor\\", {
+    configurable: true,
+    writable: true,
+    value: ZeroArgConstructor
+  });
+};
 
 const Impl = require(\\"../implementations/ZeroArgConstructor.js\\");
 "


### PR DESCRIPTION
Needed&nbsp;for&nbsp;<https://github.com/jsdom/jsdom/pull/2770> and&nbsp;converting&nbsp;`Window` to&nbsp;use&nbsp;**WebIDL** (<https://github.com/jsdom/jsdom/pull/2771>).

Re‑assigning&nbsp;`module.exports` breaks&nbsp;circular&nbsp;`require(…)`s, as&nbsp;any&nbsp;module that&nbsp;was&nbsp;evaluated before&nbsp;`module.exports` was&nbsp;re-assigned will&nbsp;keep the&nbsp;reference to&nbsp;the&nbsp;old&nbsp;object, which&nbsp;is&nbsp;still&nbsp;empty.

By&nbsp;instead creating&nbsp;data&nbsp;properties on&nbsp;`exports` and&nbsp;treating&nbsp;it as&nbsp;a&nbsp;constant, then&nbsp;every&nbsp;reference will&nbsp;have all&nbsp;the&nbsp;properties after&nbsp;all&nbsp;modules have&nbsp;been&nbsp;evaluated.

This&nbsp;is&nbsp;also&nbsp;closer to&nbsp;how&nbsp;**ECMAScript** modules&nbsp;work.