### PR TITLE
perf(proxy): Use per‑class Proxy handler

### DIFF
--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -582,7 +582,7 @@ class Interface {
     }
   }
 
-  generateLegacyProxy() {
+  generateLegacyProxyHandler() {
     const hasIndexedSetter = this.indexedSetter !== null;
     const hasNamedSetter = this.namedSetter !== null;
     const hasNamedDeleter = this.namedDeleter !== null;
@@ -694,7 +694,7 @@ class Interface {
     };
 
     this.str += `
-      obj = new Proxy(obj, {
+      const proxyHandler = {
     `;
 
     // [[Get]] (necessary because of proxy semantics)
@@ -1094,7 +1094,7 @@ class Interface {
     `;
 
     this.str += `
-      });
+      };
     `;
   }
 
@@ -1142,7 +1142,9 @@ class Interface {
     `;
 
     if (this.isLegacyPlatformObj) {
-      this.generateLegacyProxy();
+      this.str += `
+        obj = new Proxy(obj, proxyHandler);
+      `;
     }
 
     this.str += `
@@ -1456,6 +1458,9 @@ class Interface {
     this.generateExport();
     this.generateIface();
     this.generateInstall();
+    if (this.isLegacyPlatformObj) {
+      this.generateLegacyProxyHandler();
+    }
 
     this.generateMixins();
     this.generateRequires();

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -2748,169 +2748,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
     configurable: true
   });
 
-  obj = new Proxy(obj, {
-    get(target, P, receiver) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.get(target, P, receiver);
-      }
-      const desc = this.getOwnPropertyDescriptor(target, P);
-      if (desc === undefined) {
-        const parent = Object.getPrototypeOf(target);
-        if (parent === null) {
-          return undefined;
-        }
-        return Reflect.get(target, P, receiver);
-      }
-      if (!desc.get && !desc.set) {
-        return desc.value;
-      }
-      const getter = desc.get;
-      if (getter === undefined) {
-        return undefined;
-      }
-      return Reflect.apply(getter, receiver, []);
-    },
-
-    has(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.has(target, P);
-      }
-      const desc = this.getOwnPropertyDescriptor(target, P);
-      if (desc !== undefined) {
-        return true;
-      }
-      const parent = Object.getPrototypeOf(target);
-      if (parent !== null) {
-        return Reflect.has(parent, P);
-      }
-      return false;
-    },
-
-    ownKeys(target) {
-      const keys = new Set();
-
-      for (const key of target[impl][utils.supportedPropertyNames]) {
-        if (!(key in target)) {
-          keys.add(\`\${key}\`);
-        }
-      }
-
-      for (const key of Reflect.ownKeys(target)) {
-        keys.add(key);
-      }
-      return [...keys];
-    },
-
-    getOwnPropertyDescriptor(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.getOwnPropertyDescriptor(target, P);
-      }
-      let ignoreNamedProps = false;
-
-      if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-        const namedValue = target[impl].getItem(P);
-
-        return {
-          writable: true,
-          enumerable: true,
-          configurable: true,
-          value: utils.tryWrapperForImpl(namedValue)
-        };
-      }
-
-      return Reflect.getOwnPropertyDescriptor(target, P);
-    },
-
-    set(target, P, V, receiver) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.set(target, P, V, receiver);
-      }
-      if (target === receiver) {
-        if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
-          let namedValue = V;
-
-          namedValue = conversions[\\"DOMString\\"](namedValue, {
-            context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
-          });
-
-          target[impl].setItem(P, namedValue);
-
-          return true;
-        }
-      }
-      let ownDesc;
-
-      if (ownDesc === undefined) {
-        ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-      }
-      if (ownDesc === undefined) {
-        const parent = Reflect.getPrototypeOf(target);
-        if (parent !== null) {
-          return Reflect.set(parent, P, V, receiver);
-        }
-        ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-      }
-      if (!ownDesc.writable) {
-        return false;
-      }
-      if (!utils.isObject(receiver)) {
-        return false;
-      }
-      const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-      let valueDesc;
-      if (existingDesc !== undefined) {
-        if (existingDesc.get || existingDesc.set) {
-          return false;
-        }
-        if (!existingDesc.writable) {
-          return false;
-        }
-        valueDesc = { value: V };
-      } else {
-        valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-      }
-      return Reflect.defineProperty(receiver, P, valueDesc);
-    },
-
-    defineProperty(target, P, desc) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.defineProperty(target, P, desc);
-      }
-      if (!utils.hasOwn(target, P)) {
-        if (desc.get || desc.set) {
-          return false;
-        }
-
-        let namedValue = desc.value;
-
-        namedValue = conversions[\\"DOMString\\"](namedValue, {
-          context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
-        });
-
-        target[impl].setItem(P, namedValue);
-
-        return true;
-      }
-      return Reflect.defineProperty(target, P, desc);
-    },
-
-    deleteProperty(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.deleteProperty(target, P);
-      }
-
-      if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
-        target[impl].removeItem(P);
-        return true;
-      }
-
-      return Reflect.deleteProperty(target, P);
-    },
-
-    preventExtensions() {
-      return false;
-    }
-  });
+  obj = new Proxy(obj, proxyHandler);
 
   obj[impl][utils.wrapperSymbol] = obj;
   if (Impl.init) {
@@ -3043,6 +2881,170 @@ exports.install = function install(globalObject) {
     writable: true,
     value: Storage
   });
+};
+
+const proxyHandler = {
+  get(target, P, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.get(target, P, receiver);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc === undefined) {
+      const parent = Object.getPrototypeOf(target);
+      if (parent === null) {
+        return undefined;
+      }
+      return Reflect.get(target, P, receiver);
+    }
+    if (!desc.get && !desc.set) {
+      return desc.value;
+    }
+    const getter = desc.get;
+    if (getter === undefined) {
+      return undefined;
+    }
+    return Reflect.apply(getter, receiver, []);
+  },
+
+  has(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.has(target, P);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc !== undefined) {
+      return true;
+    }
+    const parent = Object.getPrototypeOf(target);
+    if (parent !== null) {
+      return Reflect.has(parent, P);
+    }
+    return false;
+  },
+
+  ownKeys(target) {
+    const keys = new Set();
+
+    for (const key of target[impl][utils.supportedPropertyNames]) {
+      if (!(key in target)) {
+        keys.add(\`\${key}\`);
+      }
+    }
+
+    for (const key of Reflect.ownKeys(target)) {
+      keys.add(key);
+    }
+    return [...keys];
+  },
+
+  getOwnPropertyDescriptor(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    let ignoreNamedProps = false;
+
+    if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+      const namedValue = target[impl].getItem(P);
+
+      return {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value: utils.tryWrapperForImpl(namedValue)
+      };
+    }
+
+    return Reflect.getOwnPropertyDescriptor(target, P);
+  },
+
+  set(target, P, V, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.set(target, P, V, receiver);
+    }
+    if (target === receiver) {
+      if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
+        let namedValue = V;
+
+        namedValue = conversions[\\"DOMString\\"](namedValue, {
+          context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
+        });
+
+        target[impl].setItem(P, namedValue);
+
+        return true;
+      }
+    }
+    let ownDesc;
+
+    if (ownDesc === undefined) {
+      ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    if (ownDesc === undefined) {
+      const parent = Reflect.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.set(parent, P, V, receiver);
+      }
+      ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+    }
+    if (!ownDesc.writable) {
+      return false;
+    }
+    if (!utils.isObject(receiver)) {
+      return false;
+    }
+    const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+    let valueDesc;
+    if (existingDesc !== undefined) {
+      if (existingDesc.get || existingDesc.set) {
+        return false;
+      }
+      if (!existingDesc.writable) {
+        return false;
+      }
+      valueDesc = { value: V };
+    } else {
+      valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+    }
+    return Reflect.defineProperty(receiver, P, valueDesc);
+  },
+
+  defineProperty(target, P, desc) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.defineProperty(target, P, desc);
+    }
+    if (!utils.hasOwn(target, P)) {
+      if (desc.get || desc.set) {
+        return false;
+      }
+
+      let namedValue = desc.value;
+
+      namedValue = conversions[\\"DOMString\\"](namedValue, {
+        context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
+      });
+
+      target[impl].setItem(P, namedValue);
+
+      return true;
+    }
+    return Reflect.defineProperty(target, P, desc);
+  },
+
+  deleteProperty(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.deleteProperty(target, P);
+    }
+
+    if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
+      target[impl].removeItem(P);
+      return true;
+    }
+
+    return Reflect.deleteProperty(target, P);
+  },
+
+  preventExtensions() {
+    return false;
+  }
 };
 
 const Impl = require(\\"../implementations/Storage.js\\");
@@ -4516,165 +4518,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
     configurable: true
   });
 
-  obj = new Proxy(obj, {
-    get(target, P, receiver) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.get(target, P, receiver);
-      }
-      const desc = this.getOwnPropertyDescriptor(target, P);
-      if (desc === undefined) {
-        const parent = Object.getPrototypeOf(target);
-        if (parent === null) {
-          return undefined;
-        }
-        return Reflect.get(target, P, receiver);
-      }
-      if (!desc.get && !desc.set) {
-        return desc.value;
-      }
-      const getter = desc.get;
-      if (getter === undefined) {
-        return undefined;
-      }
-      return Reflect.apply(getter, receiver, []);
-    },
-
-    has(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.has(target, P);
-      }
-      const desc = this.getOwnPropertyDescriptor(target, P);
-      if (desc !== undefined) {
-        return true;
-      }
-      const parent = Object.getPrototypeOf(target);
-      if (parent !== null) {
-        return Reflect.has(parent, P);
-      }
-      return false;
-    },
-
-    ownKeys(target) {
-      const keys = new Set();
-
-      for (const key of target[impl][utils.supportedPropertyIndices]) {
-        keys.add(\`\${key}\`);
-      }
-
-      for (const key of Reflect.ownKeys(target)) {
-        keys.add(key);
-      }
-      return [...keys];
-    },
-
-    getOwnPropertyDescriptor(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.getOwnPropertyDescriptor(target, P);
-      }
-      let ignoreNamedProps = false;
-
-      if (utils.isArrayIndexPropName(P)) {
-        const index = P >>> 0;
-
-        if (target[impl][utils.supportsPropertyIndex](index)) {
-          const indexedValue = target[impl].item(index);
-          return {
-            writable: false,
-            enumerable: true,
-            configurable: true,
-            value: utils.tryWrapperForImpl(indexedValue)
-          };
-        }
-        ignoreNamedProps = true;
-      }
-
-      return Reflect.getOwnPropertyDescriptor(target, P);
-    },
-
-    set(target, P, V, receiver) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.set(target, P, V, receiver);
-      }
-      if (target === receiver) {
-        utils.isArrayIndexPropName(P);
-      }
-      let ownDesc;
-
-      if (utils.isArrayIndexPropName(P)) {
-        const index = P >>> 0;
-
-        if (target[impl][utils.supportsPropertyIndex](index)) {
-          const indexedValue = target[impl].item(index);
-          ownDesc = {
-            writable: false,
-            enumerable: true,
-            configurable: true,
-            value: utils.tryWrapperForImpl(indexedValue)
-          };
-        }
-      }
-
-      if (ownDesc === undefined) {
-        ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-      }
-      if (ownDesc === undefined) {
-        const parent = Reflect.getPrototypeOf(target);
-        if (parent !== null) {
-          return Reflect.set(parent, P, V, receiver);
-        }
-        ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-      }
-      if (!ownDesc.writable) {
-        return false;
-      }
-      if (!utils.isObject(receiver)) {
-        return false;
-      }
-      const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-      let valueDesc;
-      if (existingDesc !== undefined) {
-        if (existingDesc.get || existingDesc.set) {
-          return false;
-        }
-        if (!existingDesc.writable) {
-          return false;
-        }
-        valueDesc = { value: V };
-      } else {
-        valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-      }
-      return Reflect.defineProperty(receiver, P, valueDesc);
-    },
-
-    defineProperty(target, P, desc) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.defineProperty(target, P, desc);
-      }
-
-      if (utils.isArrayIndexPropName(P)) {
-        return false;
-      }
-
-      return Reflect.defineProperty(target, P, desc);
-    },
-
-    deleteProperty(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.deleteProperty(target, P);
-      }
-
-      if (utils.isArrayIndexPropName(P)) {
-        const index = P >>> 0;
-        return !target[impl][utils.supportsPropertyIndex](index);
-      }
-
-      return Reflect.deleteProperty(target, P);
-    },
-
-    preventExtensions() {
-      return false;
-    }
-  });
+  obj = new Proxy(obj, proxyHandler);
 
   obj[impl][utils.wrapperSymbol] = obj;
   if (Impl.init) {
@@ -4738,6 +4582,166 @@ exports.install = function install(globalObject) {
     writable: true,
     value: URLList
   });
+};
+
+const proxyHandler = {
+  get(target, P, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.get(target, P, receiver);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc === undefined) {
+      const parent = Object.getPrototypeOf(target);
+      if (parent === null) {
+        return undefined;
+      }
+      return Reflect.get(target, P, receiver);
+    }
+    if (!desc.get && !desc.set) {
+      return desc.value;
+    }
+    const getter = desc.get;
+    if (getter === undefined) {
+      return undefined;
+    }
+    return Reflect.apply(getter, receiver, []);
+  },
+
+  has(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.has(target, P);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc !== undefined) {
+      return true;
+    }
+    const parent = Object.getPrototypeOf(target);
+    if (parent !== null) {
+      return Reflect.has(parent, P);
+    }
+    return false;
+  },
+
+  ownKeys(target) {
+    const keys = new Set();
+
+    for (const key of target[impl][utils.supportedPropertyIndices]) {
+      keys.add(\`\${key}\`);
+    }
+
+    for (const key of Reflect.ownKeys(target)) {
+      keys.add(key);
+    }
+    return [...keys];
+  },
+
+  getOwnPropertyDescriptor(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      if (target[impl][utils.supportsPropertyIndex](index)) {
+        const indexedValue = target[impl].item(index);
+        return {
+          writable: false,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(indexedValue)
+        };
+      }
+      ignoreNamedProps = true;
+    }
+
+    return Reflect.getOwnPropertyDescriptor(target, P);
+  },
+
+  set(target, P, V, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.set(target, P, V, receiver);
+    }
+    if (target === receiver) {
+      utils.isArrayIndexPropName(P);
+    }
+    let ownDesc;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      if (target[impl][utils.supportsPropertyIndex](index)) {
+        const indexedValue = target[impl].item(index);
+        ownDesc = {
+          writable: false,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(indexedValue)
+        };
+      }
+    }
+
+    if (ownDesc === undefined) {
+      ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    if (ownDesc === undefined) {
+      const parent = Reflect.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.set(parent, P, V, receiver);
+      }
+      ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+    }
+    if (!ownDesc.writable) {
+      return false;
+    }
+    if (!utils.isObject(receiver)) {
+      return false;
+    }
+    const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+    let valueDesc;
+    if (existingDesc !== undefined) {
+      if (existingDesc.get || existingDesc.set) {
+        return false;
+      }
+      if (!existingDesc.writable) {
+        return false;
+      }
+      valueDesc = { value: V };
+    } else {
+      valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+    }
+    return Reflect.defineProperty(receiver, P, valueDesc);
+  },
+
+  defineProperty(target, P, desc) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.defineProperty(target, P, desc);
+    }
+
+    if (utils.isArrayIndexPropName(P)) {
+      return false;
+    }
+
+    return Reflect.defineProperty(target, P, desc);
+  },
+
+  deleteProperty(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.deleteProperty(target, P);
+    }
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+      return !target[impl][utils.supportsPropertyIndex](index);
+    }
+
+    return Reflect.deleteProperty(target, P);
+  },
+
+  preventExtensions() {
+    return false;
+  }
 };
 
 const Impl = require(\\"../implementations/URLList.js\\");
@@ -5287,191 +5291,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
     configurable: true
   });
 
-  obj = new Proxy(obj, {
-    get(target, P, receiver) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.get(target, P, receiver);
-      }
-      const desc = this.getOwnPropertyDescriptor(target, P);
-      if (desc === undefined) {
-        const parent = Object.getPrototypeOf(target);
-        if (parent === null) {
-          return undefined;
-        }
-        return Reflect.get(target, P, receiver);
-      }
-      if (!desc.get && !desc.set) {
-        return desc.value;
-      }
-      const getter = desc.get;
-      if (getter === undefined) {
-        return undefined;
-      }
-      return Reflect.apply(getter, receiver, []);
-    },
-
-    has(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.has(target, P);
-      }
-      const desc = this.getOwnPropertyDescriptor(target, P);
-      if (desc !== undefined) {
-        return true;
-      }
-      const parent = Object.getPrototypeOf(target);
-      if (parent !== null) {
-        return Reflect.has(parent, P);
-      }
-      return false;
-    },
-
-    ownKeys(target) {
-      const keys = new Set();
-
-      for (const key of target[impl][utils.supportedPropertyIndices]) {
-        keys.add(\`\${key}\`);
-      }
-
-      for (const key of target[impl][utils.supportedPropertyNames]) {
-        if (!(key in target)) {
-          keys.add(\`\${key}\`);
-        }
-      }
-
-      for (const key of Reflect.ownKeys(target)) {
-        keys.add(key);
-      }
-      return [...keys];
-    },
-
-    getOwnPropertyDescriptor(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.getOwnPropertyDescriptor(target, P);
-      }
-      let ignoreNamedProps = false;
-
-      if (utils.isArrayIndexPropName(P)) {
-        const index = P >>> 0;
-        const indexedValue = target[impl].item(index);
-        if (indexedValue !== undefined) {
-          return {
-            writable: false,
-            enumerable: true,
-            configurable: true,
-            value: utils.tryWrapperForImpl(indexedValue)
-          };
-        }
-        ignoreNamedProps = true;
-      }
-
-      const namedValue = target[impl].namedItem(P);
-
-      if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
-        return {
-          writable: false,
-          enumerable: false,
-          configurable: true,
-          value: utils.tryWrapperForImpl(namedValue)
-        };
-      }
-
-      return Reflect.getOwnPropertyDescriptor(target, P);
-    },
-
-    set(target, P, V, receiver) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.set(target, P, V, receiver);
-      }
-      if (target === receiver) {
-        utils.isArrayIndexPropName(P);
-
-        typeof P === \\"string\\" && !utils.isArrayIndexPropName(P);
-      }
-      let ownDesc;
-
-      if (utils.isArrayIndexPropName(P)) {
-        const index = P >>> 0;
-        const indexedValue = target[impl].item(index);
-        if (indexedValue !== undefined) {
-          ownDesc = {
-            writable: false,
-            enumerable: true,
-            configurable: true,
-            value: utils.tryWrapperForImpl(indexedValue)
-          };
-        }
-      }
-
-      if (ownDesc === undefined) {
-        ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-      }
-      if (ownDesc === undefined) {
-        const parent = Reflect.getPrototypeOf(target);
-        if (parent !== null) {
-          return Reflect.set(parent, P, V, receiver);
-        }
-        ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-      }
-      if (!ownDesc.writable) {
-        return false;
-      }
-      if (!utils.isObject(receiver)) {
-        return false;
-      }
-      const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-      let valueDesc;
-      if (existingDesc !== undefined) {
-        if (existingDesc.get || existingDesc.set) {
-          return false;
-        }
-        if (!existingDesc.writable) {
-          return false;
-        }
-        valueDesc = { value: V };
-      } else {
-        valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-      }
-      return Reflect.defineProperty(receiver, P, valueDesc);
-    },
-
-    defineProperty(target, P, desc) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.defineProperty(target, P, desc);
-      }
-
-      if (utils.isArrayIndexPropName(P)) {
-        return false;
-      }
-      if (!utils.hasOwn(target, P)) {
-        const creating = !(target[impl].namedItem(P) !== null);
-        if (!creating) {
-          return false;
-        }
-      }
-      return Reflect.defineProperty(target, P, desc);
-    },
-
-    deleteProperty(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.deleteProperty(target, P);
-      }
-
-      if (utils.isArrayIndexPropName(P)) {
-        const index = P >>> 0;
-        return !(target[impl].item(index) !== undefined);
-      }
-
-      if (target[impl].namedItem(P) !== null && !(P in target)) {
-        return false;
-      }
-
-      return Reflect.deleteProperty(target, P);
-    },
-
-    preventExtensions() {
-      return false;
-    }
-  });
+  obj = new Proxy(obj, proxyHandler);
 
   obj[impl][utils.wrapperSymbol] = obj;
   if (Impl.init) {
@@ -5557,6 +5377,192 @@ exports.install = function install(globalObject) {
     writable: true,
     value: URLSearchParamsCollection
   });
+};
+
+const proxyHandler = {
+  get(target, P, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.get(target, P, receiver);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc === undefined) {
+      const parent = Object.getPrototypeOf(target);
+      if (parent === null) {
+        return undefined;
+      }
+      return Reflect.get(target, P, receiver);
+    }
+    if (!desc.get && !desc.set) {
+      return desc.value;
+    }
+    const getter = desc.get;
+    if (getter === undefined) {
+      return undefined;
+    }
+    return Reflect.apply(getter, receiver, []);
+  },
+
+  has(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.has(target, P);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc !== undefined) {
+      return true;
+    }
+    const parent = Object.getPrototypeOf(target);
+    if (parent !== null) {
+      return Reflect.has(parent, P);
+    }
+    return false;
+  },
+
+  ownKeys(target) {
+    const keys = new Set();
+
+    for (const key of target[impl][utils.supportedPropertyIndices]) {
+      keys.add(\`\${key}\`);
+    }
+
+    for (const key of target[impl][utils.supportedPropertyNames]) {
+      if (!(key in target)) {
+        keys.add(\`\${key}\`);
+      }
+    }
+
+    for (const key of Reflect.ownKeys(target)) {
+      keys.add(key);
+    }
+    return [...keys];
+  },
+
+  getOwnPropertyDescriptor(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+      const indexedValue = target[impl].item(index);
+      if (indexedValue !== undefined) {
+        return {
+          writable: false,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(indexedValue)
+        };
+      }
+      ignoreNamedProps = true;
+    }
+
+    const namedValue = target[impl].namedItem(P);
+
+    if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
+      return {
+        writable: false,
+        enumerable: false,
+        configurable: true,
+        value: utils.tryWrapperForImpl(namedValue)
+      };
+    }
+
+    return Reflect.getOwnPropertyDescriptor(target, P);
+  },
+
+  set(target, P, V, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.set(target, P, V, receiver);
+    }
+    if (target === receiver) {
+      utils.isArrayIndexPropName(P);
+
+      typeof P === \\"string\\" && !utils.isArrayIndexPropName(P);
+    }
+    let ownDesc;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+      const indexedValue = target[impl].item(index);
+      if (indexedValue !== undefined) {
+        ownDesc = {
+          writable: false,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(indexedValue)
+        };
+      }
+    }
+
+    if (ownDesc === undefined) {
+      ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    if (ownDesc === undefined) {
+      const parent = Reflect.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.set(parent, P, V, receiver);
+      }
+      ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+    }
+    if (!ownDesc.writable) {
+      return false;
+    }
+    if (!utils.isObject(receiver)) {
+      return false;
+    }
+    const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+    let valueDesc;
+    if (existingDesc !== undefined) {
+      if (existingDesc.get || existingDesc.set) {
+        return false;
+      }
+      if (!existingDesc.writable) {
+        return false;
+      }
+      valueDesc = { value: V };
+    } else {
+      valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+    }
+    return Reflect.defineProperty(receiver, P, valueDesc);
+  },
+
+  defineProperty(target, P, desc) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.defineProperty(target, P, desc);
+    }
+
+    if (utils.isArrayIndexPropName(P)) {
+      return false;
+    }
+    if (!utils.hasOwn(target, P)) {
+      const creating = !(target[impl].namedItem(P) !== null);
+      if (!creating) {
+        return false;
+      }
+    }
+    return Reflect.defineProperty(target, P, desc);
+  },
+
+  deleteProperty(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.deleteProperty(target, P);
+    }
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+      return !(target[impl].item(index) !== undefined);
+    }
+
+    if (target[impl].namedItem(P) !== null && !(P in target)) {
+      return false;
+    }
+
+    return Reflect.deleteProperty(target, P);
+  },
+
+  preventExtensions() {
+    return false;
+  }
 };
 
 const Impl = require(\\"../implementations/URLSearchParamsCollection.js\\");
@@ -5647,220 +5653,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
     configurable: true
   });
 
-  obj = new Proxy(obj, {
-    get(target, P, receiver) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.get(target, P, receiver);
-      }
-      const desc = this.getOwnPropertyDescriptor(target, P);
-      if (desc === undefined) {
-        const parent = Object.getPrototypeOf(target);
-        if (parent === null) {
-          return undefined;
-        }
-        return Reflect.get(target, P, receiver);
-      }
-      if (!desc.get && !desc.set) {
-        return desc.value;
-      }
-      const getter = desc.get;
-      if (getter === undefined) {
-        return undefined;
-      }
-      return Reflect.apply(getter, receiver, []);
-    },
-
-    has(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.has(target, P);
-      }
-      const desc = this.getOwnPropertyDescriptor(target, P);
-      if (desc !== undefined) {
-        return true;
-      }
-      const parent = Object.getPrototypeOf(target);
-      if (parent !== null) {
-        return Reflect.has(parent, P);
-      }
-      return false;
-    },
-
-    ownKeys(target) {
-      const keys = new Set();
-
-      for (const key of target[impl][utils.supportedPropertyIndices]) {
-        keys.add(\`\${key}\`);
-      }
-
-      for (const key of target[impl][utils.supportedPropertyNames]) {
-        if (!(key in target)) {
-          keys.add(\`\${key}\`);
-        }
-      }
-
-      for (const key of Reflect.ownKeys(target)) {
-        keys.add(key);
-      }
-      return [...keys];
-    },
-
-    getOwnPropertyDescriptor(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.getOwnPropertyDescriptor(target, P);
-      }
-      let ignoreNamedProps = false;
-
-      if (utils.isArrayIndexPropName(P)) {
-        const index = P >>> 0;
-        const indexedValue = target[impl].item(index);
-        if (indexedValue !== undefined) {
-          return {
-            writable: false,
-            enumerable: true,
-            configurable: true,
-            value: utils.tryWrapperForImpl(indexedValue)
-          };
-        }
-        ignoreNamedProps = true;
-      }
-
-      const namedValue = target[impl].namedItem(P);
-
-      if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
-        return {
-          writable: true,
-          enumerable: true,
-          configurable: true,
-          value: utils.tryWrapperForImpl(namedValue)
-        };
-      }
-
-      return Reflect.getOwnPropertyDescriptor(target, P);
-    },
-
-    set(target, P, V, receiver) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.set(target, P, V, receiver);
-      }
-      if (target === receiver) {
-        utils.isArrayIndexPropName(P);
-
-        if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
-          let namedValue = V;
-
-          namedValue = convertURL(namedValue, {
-            context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
-          });
-
-          const creating = !(target[impl].namedItem(P) !== null);
-          if (creating) {
-            target[impl][utils.namedSetNew](P, namedValue);
-          } else {
-            target[impl][utils.namedSetExisting](P, namedValue);
-          }
-
-          return true;
-        }
-      }
-      let ownDesc;
-
-      if (utils.isArrayIndexPropName(P)) {
-        const index = P >>> 0;
-        const indexedValue = target[impl].item(index);
-        if (indexedValue !== undefined) {
-          ownDesc = {
-            writable: false,
-            enumerable: true,
-            configurable: true,
-            value: utils.tryWrapperForImpl(indexedValue)
-          };
-        }
-      }
-
-      if (ownDesc === undefined) {
-        ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-      }
-      if (ownDesc === undefined) {
-        const parent = Reflect.getPrototypeOf(target);
-        if (parent !== null) {
-          return Reflect.set(parent, P, V, receiver);
-        }
-        ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-      }
-      if (!ownDesc.writable) {
-        return false;
-      }
-      if (!utils.isObject(receiver)) {
-        return false;
-      }
-      const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-      let valueDesc;
-      if (existingDesc !== undefined) {
-        if (existingDesc.get || existingDesc.set) {
-          return false;
-        }
-        if (!existingDesc.writable) {
-          return false;
-        }
-        valueDesc = { value: V };
-      } else {
-        valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-      }
-      return Reflect.defineProperty(receiver, P, valueDesc);
-    },
-
-    defineProperty(target, P, desc) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.defineProperty(target, P, desc);
-      }
-
-      if (utils.isArrayIndexPropName(P)) {
-        return false;
-      }
-      if (!utils.hasOwn(target, P)) {
-        if (desc.get || desc.set) {
-          return false;
-        }
-
-        let namedValue = desc.value;
-
-        namedValue = convertURL(namedValue, {
-          context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
-        });
-
-        const creating = !(target[impl].namedItem(P) !== null);
-        if (creating) {
-          target[impl][utils.namedSetNew](P, namedValue);
-        } else {
-          target[impl][utils.namedSetExisting](P, namedValue);
-        }
-
-        return true;
-      }
-      return Reflect.defineProperty(target, P, desc);
-    },
-
-    deleteProperty(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.deleteProperty(target, P);
-      }
-
-      if (utils.isArrayIndexPropName(P)) {
-        const index = P >>> 0;
-        return !(target[impl].item(index) !== undefined);
-      }
-
-      if (target[impl].namedItem(P) !== null && !(P in target)) {
-        return false;
-      }
-
-      return Reflect.deleteProperty(target, P);
-    },
-
-    preventExtensions() {
-      return false;
-    }
-  });
+  obj = new Proxy(obj, proxyHandler);
 
   obj[impl][utils.wrapperSymbol] = obj;
   if (Impl.init) {
@@ -5894,6 +5687,221 @@ exports.install = function install(globalObject) {
     writable: true,
     value: URLSearchParamsCollection2
   });
+};
+
+const proxyHandler = {
+  get(target, P, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.get(target, P, receiver);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc === undefined) {
+      const parent = Object.getPrototypeOf(target);
+      if (parent === null) {
+        return undefined;
+      }
+      return Reflect.get(target, P, receiver);
+    }
+    if (!desc.get && !desc.set) {
+      return desc.value;
+    }
+    const getter = desc.get;
+    if (getter === undefined) {
+      return undefined;
+    }
+    return Reflect.apply(getter, receiver, []);
+  },
+
+  has(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.has(target, P);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc !== undefined) {
+      return true;
+    }
+    const parent = Object.getPrototypeOf(target);
+    if (parent !== null) {
+      return Reflect.has(parent, P);
+    }
+    return false;
+  },
+
+  ownKeys(target) {
+    const keys = new Set();
+
+    for (const key of target[impl][utils.supportedPropertyIndices]) {
+      keys.add(\`\${key}\`);
+    }
+
+    for (const key of target[impl][utils.supportedPropertyNames]) {
+      if (!(key in target)) {
+        keys.add(\`\${key}\`);
+      }
+    }
+
+    for (const key of Reflect.ownKeys(target)) {
+      keys.add(key);
+    }
+    return [...keys];
+  },
+
+  getOwnPropertyDescriptor(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+      const indexedValue = target[impl].item(index);
+      if (indexedValue !== undefined) {
+        return {
+          writable: false,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(indexedValue)
+        };
+      }
+      ignoreNamedProps = true;
+    }
+
+    const namedValue = target[impl].namedItem(P);
+
+    if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
+      return {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value: utils.tryWrapperForImpl(namedValue)
+      };
+    }
+
+    return Reflect.getOwnPropertyDescriptor(target, P);
+  },
+
+  set(target, P, V, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.set(target, P, V, receiver);
+    }
+    if (target === receiver) {
+      utils.isArrayIndexPropName(P);
+
+      if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
+        let namedValue = V;
+
+        namedValue = convertURL(namedValue, {
+          context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
+        });
+
+        const creating = !(target[impl].namedItem(P) !== null);
+        if (creating) {
+          target[impl][utils.namedSetNew](P, namedValue);
+        } else {
+          target[impl][utils.namedSetExisting](P, namedValue);
+        }
+
+        return true;
+      }
+    }
+    let ownDesc;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+      const indexedValue = target[impl].item(index);
+      if (indexedValue !== undefined) {
+        ownDesc = {
+          writable: false,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(indexedValue)
+        };
+      }
+    }
+
+    if (ownDesc === undefined) {
+      ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    if (ownDesc === undefined) {
+      const parent = Reflect.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.set(parent, P, V, receiver);
+      }
+      ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+    }
+    if (!ownDesc.writable) {
+      return false;
+    }
+    if (!utils.isObject(receiver)) {
+      return false;
+    }
+    const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+    let valueDesc;
+    if (existingDesc !== undefined) {
+      if (existingDesc.get || existingDesc.set) {
+        return false;
+      }
+      if (!existingDesc.writable) {
+        return false;
+      }
+      valueDesc = { value: V };
+    } else {
+      valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+    }
+    return Reflect.defineProperty(receiver, P, valueDesc);
+  },
+
+  defineProperty(target, P, desc) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.defineProperty(target, P, desc);
+    }
+
+    if (utils.isArrayIndexPropName(P)) {
+      return false;
+    }
+    if (!utils.hasOwn(target, P)) {
+      if (desc.get || desc.set) {
+        return false;
+      }
+
+      let namedValue = desc.value;
+
+      namedValue = convertURL(namedValue, {
+        context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
+      });
+
+      const creating = !(target[impl].namedItem(P) !== null);
+      if (creating) {
+        target[impl][utils.namedSetNew](P, namedValue);
+      } else {
+        target[impl][utils.namedSetExisting](P, namedValue);
+      }
+
+      return true;
+    }
+    return Reflect.defineProperty(target, P, desc);
+  },
+
+  deleteProperty(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.deleteProperty(target, P);
+    }
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+      return !(target[impl].item(index) !== undefined);
+    }
+
+    if (target[impl].namedItem(P) !== null && !(P in target)) {
+      return false;
+    }
+
+    return Reflect.deleteProperty(target, P);
+  },
+
+  preventExtensions() {
+    return false;
+  }
 };
 
 const Impl = require(\\"../implementations/URLSearchParamsCollection2.js\\");
@@ -6380,180 +6388,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
     configurable: true
   });
 
-  obj = new Proxy(obj, {
-    get(target, P, receiver) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.get(target, P, receiver);
-      }
-      const desc = this.getOwnPropertyDescriptor(target, P);
-      if (desc === undefined) {
-        const parent = Object.getPrototypeOf(target);
-        if (parent === null) {
-          return undefined;
-        }
-        return Reflect.get(target, P, receiver);
-      }
-      if (!desc.get && !desc.set) {
-        return desc.value;
-      }
-      const getter = desc.get;
-      if (getter === undefined) {
-        return undefined;
-      }
-      return Reflect.apply(getter, receiver, []);
-    },
-
-    has(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.has(target, P);
-      }
-      const desc = this.getOwnPropertyDescriptor(target, P);
-      if (desc !== undefined) {
-        return true;
-      }
-      const parent = Object.getPrototypeOf(target);
-      if (parent !== null) {
-        return Reflect.has(parent, P);
-      }
-      return false;
-    },
-
-    ownKeys(target) {
-      const keys = new Set();
-
-      for (const key of target[impl][utils.supportedPropertyNames]) {
-        if (!(key in target)) {
-          keys.add(\`\${key}\`);
-        }
-      }
-
-      for (const key of Reflect.ownKeys(target)) {
-        keys.add(key);
-      }
-      return [...keys];
-    },
-
-    getOwnPropertyDescriptor(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.getOwnPropertyDescriptor(target, P);
-      }
-      let ignoreNamedProps = false;
-
-      if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-        const namedValue = target[impl][utils.namedGet](P);
-
-        return {
-          writable: true,
-          enumerable: true,
-          configurable: true,
-          value: utils.tryWrapperForImpl(namedValue)
-        };
-      }
-
-      return Reflect.getOwnPropertyDescriptor(target, P);
-    },
-
-    set(target, P, V, receiver) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.set(target, P, V, receiver);
-      }
-      if (target === receiver) {
-        if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
-          let namedValue = V;
-
-          namedValue = conversions[\\"DOMString\\"](namedValue, {
-            context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
-          });
-
-          const creating = !target[impl][utils.supportsPropertyName](P);
-          if (creating) {
-            target[impl][utils.namedSetNew](P, namedValue);
-          } else {
-            target[impl][utils.namedSetExisting](P, namedValue);
-          }
-
-          return true;
-        }
-      }
-      let ownDesc;
-
-      if (ownDesc === undefined) {
-        ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-      }
-      if (ownDesc === undefined) {
-        const parent = Reflect.getPrototypeOf(target);
-        if (parent !== null) {
-          return Reflect.set(parent, P, V, receiver);
-        }
-        ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-      }
-      if (!ownDesc.writable) {
-        return false;
-      }
-      if (!utils.isObject(receiver)) {
-        return false;
-      }
-      const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-      let valueDesc;
-      if (existingDesc !== undefined) {
-        if (existingDesc.get || existingDesc.set) {
-          return false;
-        }
-        if (!existingDesc.writable) {
-          return false;
-        }
-        valueDesc = { value: V };
-      } else {
-        valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-      }
-      return Reflect.defineProperty(receiver, P, valueDesc);
-    },
-
-    defineProperty(target, P, desc) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.defineProperty(target, P, desc);
-      }
-      if (![\\"a\\"].includes(P)) {
-        if (!utils.hasOwn(target, P)) {
-          if (desc.get || desc.set) {
-            return false;
-          }
-
-          let namedValue = desc.value;
-
-          namedValue = conversions[\\"DOMString\\"](namedValue, {
-            context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
-          });
-
-          const creating = !target[impl][utils.supportsPropertyName](P);
-          if (creating) {
-            target[impl][utils.namedSetNew](P, namedValue);
-          } else {
-            target[impl][utils.namedSetExisting](P, namedValue);
-          }
-
-          return true;
-        }
-      }
-      return Reflect.defineProperty(target, P, desc);
-    },
-
-    deleteProperty(target, P) {
-      if (typeof P === \\"symbol\\") {
-        return Reflect.deleteProperty(target, P);
-      }
-
-      if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
-        return false;
-      }
-
-      return Reflect.deleteProperty(target, P);
-    },
-
-    preventExtensions() {
-      return false;
-    }
-  });
+  obj = new Proxy(obj, proxyHandler);
 
   obj[impl][utils.wrapperSymbol] = obj;
   if (Impl.init) {
@@ -6581,6 +6416,181 @@ exports.install = function install(globalObject) {
     writable: true,
     value: UnforgeableMap
   });
+};
+
+const proxyHandler = {
+  get(target, P, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.get(target, P, receiver);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc === undefined) {
+      const parent = Object.getPrototypeOf(target);
+      if (parent === null) {
+        return undefined;
+      }
+      return Reflect.get(target, P, receiver);
+    }
+    if (!desc.get && !desc.set) {
+      return desc.value;
+    }
+    const getter = desc.get;
+    if (getter === undefined) {
+      return undefined;
+    }
+    return Reflect.apply(getter, receiver, []);
+  },
+
+  has(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.has(target, P);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc !== undefined) {
+      return true;
+    }
+    const parent = Object.getPrototypeOf(target);
+    if (parent !== null) {
+      return Reflect.has(parent, P);
+    }
+    return false;
+  },
+
+  ownKeys(target) {
+    const keys = new Set();
+
+    for (const key of target[impl][utils.supportedPropertyNames]) {
+      if (!(key in target)) {
+        keys.add(\`\${key}\`);
+      }
+    }
+
+    for (const key of Reflect.ownKeys(target)) {
+      keys.add(key);
+    }
+    return [...keys];
+  },
+
+  getOwnPropertyDescriptor(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    let ignoreNamedProps = false;
+
+    if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+      const namedValue = target[impl][utils.namedGet](P);
+
+      return {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value: utils.tryWrapperForImpl(namedValue)
+      };
+    }
+
+    return Reflect.getOwnPropertyDescriptor(target, P);
+  },
+
+  set(target, P, V, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.set(target, P, V, receiver);
+    }
+    if (target === receiver) {
+      if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
+        let namedValue = V;
+
+        namedValue = conversions[\\"DOMString\\"](namedValue, {
+          context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
+        });
+
+        const creating = !target[impl][utils.supportsPropertyName](P);
+        if (creating) {
+          target[impl][utils.namedSetNew](P, namedValue);
+        } else {
+          target[impl][utils.namedSetExisting](P, namedValue);
+        }
+
+        return true;
+      }
+    }
+    let ownDesc;
+
+    if (ownDesc === undefined) {
+      ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    if (ownDesc === undefined) {
+      const parent = Reflect.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.set(parent, P, V, receiver);
+      }
+      ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+    }
+    if (!ownDesc.writable) {
+      return false;
+    }
+    if (!utils.isObject(receiver)) {
+      return false;
+    }
+    const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+    let valueDesc;
+    if (existingDesc !== undefined) {
+      if (existingDesc.get || existingDesc.set) {
+        return false;
+      }
+      if (!existingDesc.writable) {
+        return false;
+      }
+      valueDesc = { value: V };
+    } else {
+      valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+    }
+    return Reflect.defineProperty(receiver, P, valueDesc);
+  },
+
+  defineProperty(target, P, desc) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.defineProperty(target, P, desc);
+    }
+    if (![\\"a\\"].includes(P)) {
+      if (!utils.hasOwn(target, P)) {
+        if (desc.get || desc.set) {
+          return false;
+        }
+
+        let namedValue = desc.value;
+
+        namedValue = conversions[\\"DOMString\\"](namedValue, {
+          context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
+        });
+
+        const creating = !target[impl][utils.supportsPropertyName](P);
+        if (creating) {
+          target[impl][utils.namedSetNew](P, namedValue);
+        } else {
+          target[impl][utils.namedSetExisting](P, namedValue);
+        }
+
+        return true;
+      }
+    }
+    return Reflect.defineProperty(target, P, desc);
+  },
+
+  deleteProperty(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.deleteProperty(target, P);
+    }
+
+    if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
+      return false;
+    }
+
+    return Reflect.deleteProperty(target, P);
+  },
+
+  preventExtensions() {
+    return false;
+  }
 };
 
 const Impl = require(\\"../implementations/UnforgeableMap.js\\");


### PR DESCRIPTION
Currently, a&nbsp;new&nbsp;Proxy&nbsp;handler is&nbsp;created&nbsp;per‑instance, this&nbsp;is&nbsp;inefficient and&nbsp;unnecessary, especially&nbsp;since&nbsp;the&nbsp;proxy&nbsp;handlers don’t&nbsp;depend on&nbsp;any&nbsp;instance‑specific&nbsp;state.