### PR TITLE
fix: Don’t break on circular type dependencies

### DIFF
--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -130,10 +130,10 @@ module.exports.generateOverloadConversions = function (ctx, typeOfOp, name, pare
           let fn;
           // Avoid requiring the interface itself
           if (iface !== parent.name) {
-            fn = `is${iface}`;
-            requires.add(iface, "is");
+            fn = `${iface}.is`;
+            requires.add(iface);
           } else {
-            fn = "module.exports.is";
+            fn = "exports.is";
           }
           possibilities.push(`
             if (${fn}(curArg)) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -121,10 +121,10 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
     let fn;
     // Avoid requiring the interface itself
     if (idlType.idlType !== parentName) {
-      fn = `convert${idlType.idlType}`;
-      requires.add(idlType.idlType, "convert");
+      fn = `${idlType.idlType}.convert`;
+      requires.add(idlType.idlType);
     } else {
-      fn = `module.exports.convert`;
+      fn = `exports.convert`;
     }
     generateGeneric(fn);
   } else {
@@ -173,10 +173,10 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
         let fn;
         // Avoid requiring the interface itself
         if (iface !== parentName) {
-          fn = `is${iface}`;
-          requires.add(iface, "is");
+          fn = `${iface}.is`;
+          requires.add(iface);
         } else {
-          fn = "module.exports.is";
+          fn = "exports.is";
         }
         return `${fn}(${name})`;
       });

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -847,8 +847,8 @@ exports[`with processors Dictionary.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertURL = require(\\"./URL.js\\").convert;
-const convertURLSearchParams = require(\\"./URLSearchParams.js\\").convert;
+const URL = require(\\"./URL.js\\");
+const URLSearchParams = require(\\"./URLSearchParams.js\\");
 
 exports.convertInherit = function convertInherit(obj, ret, { context = \\"The provided value\\" } = {}) {
   {
@@ -867,7 +867,7 @@ exports.convertInherit = function convertInherit(obj, ret, { context = \\"The pr
     const key = \\"requiredInterface\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = convertURL(value, { context: context + \\" has member requiredInterface that\\" });
+      value = URL.convert(value, { context: context + \\" has member requiredInterface that\\" });
 
       ret[key] = value;
     } else {
@@ -885,7 +885,7 @@ exports.convertInherit = function convertInherit(obj, ret, { context = \\"The pr
         const V = [];
         const tmp = value;
         for (let nextItem of tmp) {
-          nextItem = convertURLSearchParams(nextItem, { context: context + \\" has member seq that\\" + \\"'s element\\" });
+          nextItem = URLSearchParams.convert(nextItem, { context: context + \\" has member seq that\\" + \\"'s element\\" });
 
           V.push(nextItem);
         }
@@ -925,7 +925,7 @@ exports[`with processors DictionaryConvert.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertDictionary = require(\\"./Dictionary.js\\").convert;
+const Dictionary = require(\\"./Dictionary.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
@@ -1028,7 +1028,7 @@ exports.install = function install(globalObject) {
       }
       {
         let curArg = arguments[1];
-        curArg = convertDictionary(curArg, { context: \\"Failed to execute 'op' on 'DictionaryConvert': parameter 2\\" });
+        curArg = Dictionary.convert(curArg, { context: \\"Failed to execute 'op' on 'DictionaryConvert': parameter 2\\" });
         args.push(curArg);
       }
       return this[impl].op(...args);
@@ -1060,7 +1060,6 @@ exports[`with processors Enum.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertRequestDestination = require(\\"./RequestDestination.js\\").convert;
 const RequestDestination = require(\\"./RequestDestination.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
@@ -1161,7 +1160,7 @@ exports.install = function install(globalObject) {
       const args = [];
       {
         let curArg = arguments[0];
-        curArg = convertRequestDestination(curArg, { context: \\"Failed to execute 'op' on 'Enum': parameter 1\\" });
+        curArg = RequestDestination.convert(curArg, { context: \\"Failed to execute 'op' on 'Enum': parameter 1\\" });
         args.push(curArg);
       }
       return this[impl].op(...args);
@@ -1819,8 +1818,7 @@ exports[`with processors Overloads.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const isURL = require(\\"./URL.js\\").is;
-const convertURL = require(\\"./URL.js\\").convert;
+const URL = require(\\"./URL.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
@@ -1910,10 +1908,10 @@ exports.install = function install(globalObject) {
           break;
         default: {
           let curArg = arguments[0];
-          if (isURL(curArg)) {
+          if (URL.is(curArg)) {
             {
               let curArg = arguments[0];
-              curArg = convertURL(curArg, { context: \\"Failed to construct 'Overloads': parameter 1\\" });
+              curArg = URL.convert(curArg, { context: \\"Failed to construct 'Overloads': parameter 1\\" });
               args.push(curArg);
             }
           } else {
@@ -2112,17 +2110,17 @@ exports.install = function install(globalObject) {
               {
                 let curArg = arguments[1];
                 if (curArg !== undefined) {
-                  curArg = convertURL(curArg, {
+                  curArg = URL.convert(curArg, {
                     context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
                   });
                 }
                 args.push(curArg);
               }
-            } else if (isURL(curArg)) {
+            } else if (URL.is(curArg)) {
               {
                 let curArg = arguments[1];
                 if (curArg !== undefined) {
-                  curArg = convertURL(curArg, {
+                  curArg = URL.convert(curArg, {
                     context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
                   });
                 }
@@ -2684,7 +2682,7 @@ exports[`with processors SeqAndRec.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertURL = require(\\"./URL.js\\").convert;
+const URL = require(\\"./URL.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
@@ -2845,7 +2843,7 @@ exports.install = function install(globalObject) {
 
               let typedValue = curArg[key];
 
-              typedValue = convertURL(typedValue, {
+              typedValue = URL.convert(typedValue, {
                 context: \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': parameter 1\\" + \\"'s value\\"
               });
 
@@ -4031,9 +4029,8 @@ exports[`with processors TypedefsAndUnions.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertRequestDestination = require(\\"./RequestDestination.js\\").convert;
-const isURL = require(\\"./URL.js\\").is;
-const convertURL = require(\\"./URL.js\\").convert;
+const RequestDestination = require(\\"./RequestDestination.js\\");
+const URL = require(\\"./URL.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
@@ -4173,7 +4170,7 @@ exports.install = function install(globalObject) {
               context: \\"Failed to execute 'numOrEnumConsumer' on 'TypedefsAndUnions': parameter 1\\"
             });
           } else {
-            curArg = convertRequestDestination(curArg, {
+            curArg = RequestDestination.convert(curArg, {
               context: \\"Failed to execute 'numOrEnumConsumer' on 'TypedefsAndUnions': parameter 1\\"
             });
           }
@@ -4237,7 +4234,7 @@ exports.install = function install(globalObject) {
         if (curArg === null || curArg === undefined) {
           curArg = null;
         } else {
-          if (isURL(curArg)) {
+          if (URL.is(curArg)) {
             curArg = utils.implForWrapper(curArg);
           } else if (typeof curArg === \\"number\\") {
             curArg = conversions[\\"double\\"](curArg, {
@@ -4289,7 +4286,7 @@ exports.install = function install(globalObject) {
 
               let typedValue = curArg[key];
 
-              typedValue = convertURL(typedValue, {
+              typedValue = URL.convert(typedValue, {
                 context: \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s value\\"
               });
 
@@ -4338,7 +4335,7 @@ exports.install = function install(globalObject) {
 
                 let typedValue = curArg[key];
 
-                typedValue = convertURL(typedValue, {
+                typedValue = URL.convert(typedValue, {
                   context: \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s value\\"
                 });
 
@@ -4368,7 +4365,7 @@ exports.install = function install(globalObject) {
       const args = [];
       {
         let curArg = arguments[0];
-        if (isURL(curArg)) {
+        if (URL.is(curArg)) {
           curArg = utils.implForWrapper(curArg);
         } else if (utils.isArrayBuffer(curArg)) {
         } else if (ArrayBuffer.isView(curArg)) {
@@ -4425,7 +4422,7 @@ exports.install = function install(globalObject) {
 
                   let typedValue = curArg[key];
 
-                  typedValue = convertURL(typedValue, {
+                  typedValue = URL.convert(typedValue, {
                     context:
                       \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': parameter 1\\" +
                       \\" record\\" +
@@ -6057,7 +6054,7 @@ exports[`with processors URLSearchParamsCollection2.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertURL = require(\\"./URL.js\\").convert;
+const URL = require(\\"./URL.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 const URLSearchParamsCollection = require(\\"./URLSearchParamsCollection.js\\");
@@ -6274,7 +6271,7 @@ const proxyHandler = {
       if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
         let namedValue = V;
 
-        namedValue = convertURL(namedValue, {
+        namedValue = URL.convert(namedValue, {
           context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
         });
 
@@ -6350,7 +6347,7 @@ const proxyHandler = {
 
       let namedValue = desc.value;
 
-      namedValue = convertURL(namedValue, {
+      namedValue = URL.convert(namedValue, {
         context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
       });
 
@@ -7247,7 +7244,7 @@ exports[`with processors Variadic.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertURL = require(\\"./URL.js\\").convert;
+const URL = require(\\"./URL.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
@@ -7369,7 +7366,7 @@ exports.install = function install(globalObject) {
       }
       for (let i = 1; i < arguments.length; i++) {
         let curArg = arguments[i];
-        curArg = convertURL(curArg, { context: \\"Failed to execute 'simple2' on 'Variadic': parameter \\" + (i + 1) });
+        curArg = URL.convert(curArg, { context: \\"Failed to execute 'simple2' on 'Variadic': parameter \\" + (i + 1) });
         args.push(curArg);
       }
       return this[impl].simple2(...args);
@@ -8431,8 +8428,8 @@ exports[`without processors Dictionary.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertURL = require(\\"./URL.js\\").convert;
-const convertURLSearchParams = require(\\"./URLSearchParams.js\\").convert;
+const URL = require(\\"./URL.js\\");
+const URLSearchParams = require(\\"./URLSearchParams.js\\");
 
 exports.convertInherit = function convertInherit(obj, ret, { context = \\"The provided value\\" } = {}) {
   {
@@ -8451,7 +8448,7 @@ exports.convertInherit = function convertInherit(obj, ret, { context = \\"The pr
     const key = \\"requiredInterface\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = convertURL(value, { context: context + \\" has member requiredInterface that\\" });
+      value = URL.convert(value, { context: context + \\" has member requiredInterface that\\" });
 
       ret[key] = value;
     } else {
@@ -8469,7 +8466,7 @@ exports.convertInherit = function convertInherit(obj, ret, { context = \\"The pr
         const V = [];
         const tmp = value;
         for (let nextItem of tmp) {
-          nextItem = convertURLSearchParams(nextItem, { context: context + \\" has member seq that\\" + \\"'s element\\" });
+          nextItem = URLSearchParams.convert(nextItem, { context: context + \\" has member seq that\\" + \\"'s element\\" });
 
           V.push(nextItem);
         }
@@ -8509,7 +8506,7 @@ exports[`without processors DictionaryConvert.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertDictionary = require(\\"./Dictionary.js\\").convert;
+const Dictionary = require(\\"./Dictionary.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
@@ -8612,7 +8609,7 @@ exports.install = function install(globalObject) {
       }
       {
         let curArg = arguments[1];
-        curArg = convertDictionary(curArg, { context: \\"Failed to execute 'op' on 'DictionaryConvert': parameter 2\\" });
+        curArg = Dictionary.convert(curArg, { context: \\"Failed to execute 'op' on 'DictionaryConvert': parameter 2\\" });
         args.push(curArg);
       }
       return this[impl].op(...args);
@@ -8644,7 +8641,6 @@ exports[`without processors Enum.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertRequestDestination = require(\\"./RequestDestination.js\\").convert;
 const RequestDestination = require(\\"./RequestDestination.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
@@ -8745,7 +8741,7 @@ exports.install = function install(globalObject) {
       const args = [];
       {
         let curArg = arguments[0];
-        curArg = convertRequestDestination(curArg, { context: \\"Failed to execute 'op' on 'Enum': parameter 1\\" });
+        curArg = RequestDestination.convert(curArg, { context: \\"Failed to execute 'op' on 'Enum': parameter 1\\" });
         args.push(curArg);
       }
       return this[impl].op(...args);
@@ -9402,8 +9398,7 @@ exports[`without processors Overloads.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const isURL = require(\\"./URL.js\\").is;
-const convertURL = require(\\"./URL.js\\").convert;
+const URL = require(\\"./URL.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
@@ -9493,10 +9488,10 @@ exports.install = function install(globalObject) {
           break;
         default: {
           let curArg = arguments[0];
-          if (isURL(curArg)) {
+          if (URL.is(curArg)) {
             {
               let curArg = arguments[0];
-              curArg = convertURL(curArg, { context: \\"Failed to construct 'Overloads': parameter 1\\" });
+              curArg = URL.convert(curArg, { context: \\"Failed to construct 'Overloads': parameter 1\\" });
               args.push(curArg);
             }
           } else {
@@ -9695,17 +9690,17 @@ exports.install = function install(globalObject) {
               {
                 let curArg = arguments[1];
                 if (curArg !== undefined) {
-                  curArg = convertURL(curArg, {
+                  curArg = URL.convert(curArg, {
                     context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
                   });
                 }
                 args.push(curArg);
               }
-            } else if (isURL(curArg)) {
+            } else if (URL.is(curArg)) {
               {
                 let curArg = arguments[1];
                 if (curArg !== undefined) {
-                  curArg = convertURL(curArg, {
+                  curArg = URL.convert(curArg, {
                     context: \\"Failed to execute 'incompatible3' on 'Overloads': parameter 2\\"
                   });
                 }
@@ -10267,7 +10262,7 @@ exports[`without processors SeqAndRec.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertURL = require(\\"./URL.js\\").convert;
+const URL = require(\\"./URL.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
@@ -10428,7 +10423,7 @@ exports.install = function install(globalObject) {
 
               let typedValue = curArg[key];
 
-              typedValue = convertURL(typedValue, {
+              typedValue = URL.convert(typedValue, {
                 context: \\"Failed to execute 'recordConsumer2' on 'SeqAndRec': parameter 1\\" + \\"'s value\\"
               });
 
@@ -11614,9 +11609,8 @@ exports[`without processors TypedefsAndUnions.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertRequestDestination = require(\\"./RequestDestination.js\\").convert;
-const isURL = require(\\"./URL.js\\").is;
-const convertURL = require(\\"./URL.js\\").convert;
+const RequestDestination = require(\\"./RequestDestination.js\\");
+const URL = require(\\"./URL.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
@@ -11756,7 +11750,7 @@ exports.install = function install(globalObject) {
               context: \\"Failed to execute 'numOrEnumConsumer' on 'TypedefsAndUnions': parameter 1\\"
             });
           } else {
-            curArg = convertRequestDestination(curArg, {
+            curArg = RequestDestination.convert(curArg, {
               context: \\"Failed to execute 'numOrEnumConsumer' on 'TypedefsAndUnions': parameter 1\\"
             });
           }
@@ -11820,7 +11814,7 @@ exports.install = function install(globalObject) {
         if (curArg === null || curArg === undefined) {
           curArg = null;
         } else {
-          if (isURL(curArg)) {
+          if (URL.is(curArg)) {
             curArg = utils.implForWrapper(curArg);
           } else if (typeof curArg === \\"number\\") {
             curArg = conversions[\\"double\\"](curArg, {
@@ -11872,7 +11866,7 @@ exports.install = function install(globalObject) {
 
               let typedValue = curArg[key];
 
-              typedValue = convertURL(typedValue, {
+              typedValue = URL.convert(typedValue, {
                 context: \\"Failed to execute 'urlMapInnerConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s value\\"
               });
 
@@ -11921,7 +11915,7 @@ exports.install = function install(globalObject) {
 
                 let typedValue = curArg[key];
 
-                typedValue = convertURL(typedValue, {
+                typedValue = URL.convert(typedValue, {
                   context: \\"Failed to execute 'urlMapConsumer' on 'TypedefsAndUnions': parameter 1\\" + \\"'s value\\"
                 });
 
@@ -11951,7 +11945,7 @@ exports.install = function install(globalObject) {
       const args = [];
       {
         let curArg = arguments[0];
-        if (isURL(curArg)) {
+        if (URL.is(curArg)) {
           curArg = utils.implForWrapper(curArg);
         } else if (utils.isArrayBuffer(curArg)) {
         } else if (ArrayBuffer.isView(curArg)) {
@@ -12008,7 +12002,7 @@ exports.install = function install(globalObject) {
 
                   let typedValue = curArg[key];
 
-                  typedValue = convertURL(typedValue, {
+                  typedValue = URL.convert(typedValue, {
                     context:
                       \\"Failed to execute 'arrayBufferViewOrURLMapConsumer' on 'TypedefsAndUnions': parameter 1\\" +
                       \\" record\\" +
@@ -13640,7 +13634,7 @@ exports[`without processors URLSearchParamsCollection2.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertURL = require(\\"./URL.js\\").convert;
+const URL = require(\\"./URL.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 const URLSearchParamsCollection = require(\\"./URLSearchParamsCollection.js\\");
@@ -13857,7 +13851,7 @@ const proxyHandler = {
       if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
         let namedValue = V;
 
-        namedValue = convertURL(namedValue, {
+        namedValue = URL.convert(namedValue, {
           context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
         });
 
@@ -13933,7 +13927,7 @@ const proxyHandler = {
 
       let namedValue = desc.value;
 
-      namedValue = convertURL(namedValue, {
+      namedValue = URL.convert(namedValue, {
         context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
       });
 
@@ -14830,7 +14824,7 @@ exports[`without processors Variadic.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const convertURL = require(\\"./URL.js\\").convert;
+const URL = require(\\"./URL.js\\");
 const impl = utils.implSymbol;
 const ctorRegistry = utils.ctorRegistrySymbol;
 
@@ -14952,7 +14946,7 @@ exports.install = function install(globalObject) {
       }
       for (let i = 1; i < arguments.length; i++) {
         let curArg = arguments[i];
-        curArg = convertURL(curArg, { context: \\"Failed to execute 'simple2' on 'Variadic': parameter \\" + (i + 1) });
+        curArg = URL.convert(curArg, { context: \\"Failed to execute 'simple2' on 'Variadic': parameter \\" + (i + 1) });
         args.push(curArg);
       }
       return this[impl].simple2(...args);


### PR DESCRIPTION
This&nbsp;was&nbsp;encountered while&nbsp;working on&nbsp;<https://github.com/jsdom/jsdom/pull/2835>, where&nbsp;a&nbsp;circular&nbsp;dependency between&nbsp;`UIEvent` and&nbsp;`Window` causes&nbsp;`convertWindow` to&nbsp;be&nbsp;`undefined`.

I&nbsp;forgot to&nbsp;fix&nbsp;this in&nbsp;#154.