### PR TITLE
perf: Use bound `hasOwn` helper

### DIFF
--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -5,9 +5,7 @@ function isObject(value) {
   return typeof value === "object" && value !== null || typeof value === "function";
 }
 
-/** @type {function(*, string | number | symbol): boolean} */
 const hasOwn = Function.prototype.bind.call(Function.prototype.call, Object.prototype.hasOwnProperty);
-Object.defineProperties(hasOwn, { name: { value: "hasOwn" }, length: { value: 2 } });
 
 const wrapperSymbol = Symbol("wrapper");
 const implSymbol = Symbol("impl");

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -5,9 +5,9 @@ function isObject(value) {
   return typeof value === "object" && value !== null || typeof value === "function";
 }
 
-function hasOwn(obj, prop) {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-}
+/** @type {function(*, string | number | symbol): boolean} */
+const hasOwn = Function.prototype.bind.call(Function.prototype.call, Object.prototype.hasOwnProperty);
+Object.defineProperties(hasOwn, { name: { value: "hasOwn" }, length: { value: 2 } });
 
 const wrapperSymbol = Symbol("wrapper");
 const implSymbol = Symbol("impl");

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -5,7 +5,7 @@ function isObject(value) {
   return typeof value === "object" && value !== null || typeof value === "function";
 }
 
-const hasOwn = Function.prototype.bind.call(Function.prototype.call, Object.prototype.hasOwnProperty);
+const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
 
 const wrapperSymbol = Symbol("wrapper");
 const implSymbol = Symbol("impl");


### PR DESCRIPTION
The&nbsp;current&nbsp;version needs&nbsp;to&nbsp;perform `[[Get]]`&nbsp;4&nbsp;times per&nbsp;invocation (5×&nbsp;when doing&nbsp;`idlUtils.hasOwn`).

The&nbsp;new&nbsp;version only&nbsp;performs&nbsp;it once&nbsp;during&nbsp;binding, which&nbsp;gives&nbsp;us performance&nbsp;gains:

<details>
<summary>Benchmark&nbsp;results</summary>
<p></p>

| benchmark                                                                                    | <code>Object&#x200B;.prototype&#x200B;.hasOwnProperty&#x200B;.call</code>                       | Bound&nbsp;`hasOwn`
| ---------                                                                                    | -------------------------------------------------------------------------                       | ---------
| dom/compare-document-position/compare&nbsp;ancestor                                          | jsdom  ×&nbsp;33,129&nbsp;ops/sec ±2.45%&nbsp;(13&nbsp;runs&nbsp;sampled)                       | jsdom  ×&nbsp;34,889&nbsp;ops/sec ±2.23%&nbsp;(15&nbsp;runs&nbsp;sampled)
| dom/compare-document-position/compare&nbsp;descendant                                        | jsdom  ×&nbsp;33,442&nbsp;ops/sec ±1.98%&nbsp;(13&nbsp;runs&nbsp;sampled)                       | jsdom  ×&nbsp;35,206&nbsp;ops/sec ±1.71%&nbsp;(14&nbsp;runs&nbsp;sampled)
| dom/compare-document-position/compare&nbsp;siblings                                          | jsdom  ×&nbsp;1,266,275&nbsp;ops/sec ±3.63%&nbsp;(12&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,382,478&nbsp;ops/sec ±1.46%&nbsp;(13&nbsp;runs&nbsp;sampled)
| dom/construction/createComment                                                               | jsdom  ×&nbsp;1,209,307&nbsp;ops/sec ±2.52%&nbsp;(94&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,240,698&nbsp;ops/sec ±0.31%&nbsp;(98&nbsp;runs&nbsp;sampled)
| dom/construction/createDocumentFragment                                                      | jsdom  ×&nbsp;1,247,934&nbsp;ops/sec ±0.43%&nbsp;(96&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,219,952&nbsp;ops/sec ±1.94%&nbsp;(92&nbsp;runs&nbsp;sampled)
| dom/construction/createElement                                                               | jsdom  ×&nbsp;307,048&nbsp;ops/sec ±0.40%&nbsp;(97&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;334,162&nbsp;ops/sec ±0.30%&nbsp;(100&nbsp;runs&nbsp;sampled)
| dom/construction/createEvent                                                                 | jsdom  ×&nbsp;197,815&nbsp;ops/sec ±1.65%&nbsp;(93&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;195,584&nbsp;ops/sec ±1.32%&nbsp;(93&nbsp;runs&nbsp;sampled)
| dom/construction/createNodeIterator                                                          | jsdom  ×&nbsp;1,236,096&nbsp;ops/sec ±0.49%&nbsp;(95&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,298,147&nbsp;ops/sec ±0.18%&nbsp;(99&nbsp;runs&nbsp;sampled)
| dom/construction/createProcessingInstruction                                                 | jsdom  ×&nbsp;631,325&nbsp;ops/sec ±0.34%&nbsp;(96&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;652,046&nbsp;ops/sec ±0.23%&nbsp;(98&nbsp;runs&nbsp;sampled)
| dom/construction/createTextNode                                                              | jsdom  ×&nbsp;1,021,687&nbsp;ops/sec ±0.45%&nbsp;(97&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,016,487&nbsp;ops/sec ±0.38%&nbsp;(96&nbsp;runs&nbsp;sampled)
| dom/inner-html/tables                                                                        | jsdom  ×&nbsp;0.36&nbsp;ops/sec ±2.87%&nbsp;(5&nbsp;runs&nbsp;sampled)                          | jsdom  ×&nbsp;0.37&nbsp;ops/sec ±2.74%&nbsp;(5&nbsp;runs&nbsp;sampled)
| dom/named-properties/setAttribute(): Remove&nbsp;a&nbsp;named&nbsp;property from&nbsp;window | jsdom  ×&nbsp;3,381&nbsp;ops/sec ±1.15%&nbsp;(59&nbsp;runs&nbsp;sampled)                        | jsdom  ×&nbsp;3,154&nbsp;ops/sec ±4.16%&nbsp;(58&nbsp;runs&nbsp;sampled)
| dom/tree-modification/appendChild: many&nbsp;parents                                         | jsdom  ×&nbsp;29.58&nbsp;ops/sec ±0.70%&nbsp;(51&nbsp;runs&nbsp;sampled)                        | jsdom  ×&nbsp;30.70&nbsp;ops/sec ±0.62%&nbsp;(53&nbsp;runs&nbsp;sampled)
| dom/tree-modification/appendChild: many&nbsp;siblings                                        | jsdom  ×&nbsp;279,842&nbsp;ops/sec ±3.21%&nbsp;(19&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;256,220&nbsp;ops/sec ±25.47%&nbsp;(18&nbsp;runs&nbsp;sampled)
| dom/tree-modification/appendChild: no&nbsp;siblings                                          | jsdom  ×&nbsp;251,487&nbsp;ops/sec ±8.99%&nbsp;(28&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;261,153&nbsp;ops/sec ±7.29%&nbsp;(26&nbsp;runs&nbsp;sampled)
| dom/tree-modification/insertBefore: many&nbsp;siblings                                       | jsdom  ×&nbsp;256,010&nbsp;ops/sec ±6.61%&nbsp;(18&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;247,584&nbsp;ops/sec ±9.78%&nbsp;(18&nbsp;runs&nbsp;sampled)
| dom/tree-modification/removeChild: many&nbsp;parents                                         | jsdom  ×&nbsp;127&nbsp;ops/sec ±0.79%&nbsp;(67&nbsp;runs&nbsp;sampled)                          | jsdom  ×&nbsp;128&nbsp;ops/sec ±2.26%&nbsp;(66&nbsp;runs&nbsp;sampled)
| dom/tree-modification/removeChild: many&nbsp;siblings                                        | jsdom  ×&nbsp;159,257&nbsp;ops/sec ±5.02%&nbsp;(40&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;153,989&nbsp;ops/sec ±4.89%&nbsp;(42&nbsp;runs&nbsp;sampled)
| dom/tree-modification/removeChild: no&nbsp;siblings                                          | jsdom  ×&nbsp;143,140&nbsp;ops/sec ±4.82%&nbsp;(31&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;138,030&nbsp;ops/sec ±7.21%&nbsp;(32&nbsp;runs&nbsp;sampled)
| html/parsing/text                                                                            | jsdom  ×&nbsp;14.62&nbsp;ops/sec ±1.31%&nbsp;(41&nbsp;runs&nbsp;sampled)                        | jsdom  ×&nbsp;15.39&nbsp;ops/sec ±1.20%&nbsp;(43&nbsp;runs&nbsp;sampled)
| jsdom/api/new JSDOM() defaults                                                               | &lt;Test&nbsp;#&#x2060;10&gt; ×&nbsp;283&nbsp;ops/sec ±3.06%&nbsp;(81&nbsp;runs&nbsp;sampled)   | &lt;Test&nbsp;#&#x2060;10&gt; ×&nbsp;299&nbsp;ops/sec ±3.49%&nbsp;(78&nbsp;runs&nbsp;sampled)
| jsdom/api/new JSDOM() with&nbsp;many&nbsp;elements                                           | &lt;Test&nbsp;#&#x2060;11&gt; ×&nbsp;32.03&nbsp;ops/sec ±4.28%&nbsp;(58&nbsp;runs&nbsp;sampled) | &lt;Test&nbsp;#&#x2060;11&gt; ×&nbsp;32.36&nbsp;ops/sec ±4.68%&nbsp;(58&nbsp;runs&nbsp;sampled)
</details>