### PR TITLE
docs(README): Remove mentions of `[PrimaryGlobal]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Notable missing features include:
 - `maplike<>` and `setlike<>`
 - `[AllowShared]`
 - `[Default]` (for `toJSON()` operations)
-- `[Global]` and `[PrimaryGlobal]`'s various consequences, including the named properties object and `[[SetPrototypeOf]]`
+- `[Global]`'s various consequences, including the named properties object and `[[SetPrototypeOf]]`
 - `[Exposed]`
 - `[LegacyWindowAlias]`
 - `[LenientSetter]`


### PR DESCRIPTION
`[PrimaryGlobal]` was removed from **WebIDL** in <https://github.com/heycam/webidl/pull/423> and from **WebIDL2JS** in commit [`112a4aa`](https://github.com/jsdom/webidl2js/commit/112a4aa57aaf9fbb5da4e7241b411e03bf25d036#diff-50e3aa130a4f97a42ee2cf111c7b1d9dL32-R32).