### PR TITLE
fix: Use `fs.promises`

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -2,7 +2,7 @@
 
 const path = require("path");
 
-const fs = require("pn/fs");
+const fs = require("fs").promises;
 const webidl = require("webidl2");
 const prettier = require("prettier");
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "lib/transformer.js",
   "repository": "github:jsdom/webidl2js",
   "dependencies": {
-    "pn": "^1.1.0",
     "prettier": "^1.19.1",
     "webidl-conversions": "^5.0.0",
     "webidl2": "^23.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,11 +2784,6 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pn@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
-  integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
-
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"


### PR DESCRIPTION
This removes the no longer necessary `pn/fs` dependency, like what was done in <https://github.com/jsdom/jsdom/pull/2783>.