### PR TITLE
refactor: Rename imported symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ will generate a JavaScript wrapper class file roughly like this:
 
 ```js
 const conversions = require("webidl-conversions");
-const impl = require("./utils.js").implSymbol;
-const ctorRegistry = require("./utils.js").ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = require("./utils.js");
 
 const Impl = require("./SomeInterface-impl.js").implementation;
 
@@ -56,7 +55,7 @@ class SomeInterface {
       context: "Failed to execute 'add' on 'SomeInterface': parameter 2"
     });
 
-    return this[impl].add(...args);
+    return this[implSymbol].add(...args);
   }
 }
 
@@ -66,13 +65,13 @@ Object.defineProperties(SomeInterface.prototype, {
 });
 
 exports.create = (globalObject, constructorArgs = [], privateData = {}) => {
-  const ctor = globalObject[ctorRegistry].SomeInterface;
+  const ctor = globalObject[ctorRegistrySymbol].SomeInterface;
   const obj = Object.create(ctor.prototype);
-  obj[impl] = new Impl(constructorArgs, privateData);
+  obj[implSymbol] = new Impl(constructorArgs, privateData);
   return obj;
 };
 
-exports.is = obj => obj && obj[impl] instanceof Impl;
+exports.is = obj => obj && obj[implSymbol] instanceof Impl;
 ```
 
 The above is a simplification of the actual generated code, but should give you some idea of what's going on. We bring your attention to a few points:

--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -28,10 +28,10 @@ class Attribute {
         throw new TypeError("Illegal invocation");
       }
     `;
-    let getterBody = `return utils.tryWrapperForImpl(esValue[impl]["${this.idl.name}"]);`;
-    let setterBody = `esValue[impl]["${this.idl.name}"] = V;`;
+    let getterBody = `return utils.tryWrapperForImpl(esValue[implSymbol]["${this.idl.name}"]);`;
+    let setterBody = `esValue[implSymbol]["${this.idl.name}"] = V;`;
     if (conversions[this.idl.idlType.idlType]) {
-      getterBody = `return esValue[impl]["${this.idl.name}"];`;
+      getterBody = `return esValue[implSymbol]["${this.idl.name}"];`;
     }
 
     const addMethod = this.static ?

--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -43,7 +43,7 @@ class Attribute {
       getterBody = `return Impl.implementation["${this.idl.name}"];`;
       setterBody = `Impl.implementation["${this.idl.name}"] = V;`;
     } else if (shouldReflect) {
-      const processedOutput = this.ctx.invokeProcessReflect(this.idl, "esValue[impl]", { requires });
+      const processedOutput = this.ctx.invokeProcessReflect(this.idl, "esValue[implSymbol]", { requires });
       getterBody = processedOutput.get;
       setterBody = processedOutput.set;
     }

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -492,7 +492,8 @@ class Interface {
   }
 
   generateRequires() {
-    this.requires.addRaw(`{ implSymbol, ctorRegistrySymbol }`, "utils");
+    this.requires.addRaw("implSymbol", "utils.implSymbol");
+    this.requires.addRaw("ctorRegistrySymbol", "utils.ctorRegistrySymbol");
 
     if (this.idl.inheritance !== null) {
       this.requires.addRelative(this.idl.inheritance);

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -413,7 +413,7 @@ class Interface {
             value: function next() {
               const internal = this[utils.iterInternalSymbol];
               const { target, kind, index } = internal;
-              const values = Array.from(target[impl]);
+              const values = Array.from(target[implSymbol]);
               const len = values.length;
               if (index >= len) {
                 return { value: undefined, done: true };
@@ -492,8 +492,7 @@ class Interface {
   }
 
   generateRequires() {
-    this.requires.addRaw("impl", "utils.implSymbol");
-    this.requires.addRaw("ctorRegistry", "utils.ctorRegistrySymbol");
+    this.requires.addRaw(`{ implSymbol, ctorRegistrySymbol }`, "utils");
 
     if (this.idl.inheritance !== null) {
       this.requires.addRelative(this.idl.inheritance);
@@ -509,7 +508,7 @@ class Interface {
   generateExport() {
     this.str += `
       exports.is = function is(obj) {
-        return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+        return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
       };
       exports.isImpl = function isImpl(obj) {
         return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -549,10 +548,10 @@ class Interface {
       }
       if (unsupportedValue) {
         const func = this.indexedGetter.name ? `.${this.indexedGetter.name}` : "[utils.indexedGet]";
-        const value = indexedValue || `${O}[impl]${func}(${index})`;
+        const value = indexedValue || `${O}[implSymbol]${func}(${index})`;
         return `${value} !== ${unsupportedValue}`;
       }
-      return `${O}[impl][utils.supportsPropertyIndex](${index})`;
+      return `${O}[implSymbol][utils.supportsPropertyIndex](${index})`;
     };
 
     const supportsPropertyName = (O, P, namedValue) => {
@@ -562,10 +561,10 @@ class Interface {
       }
       if (unsupportedValue) {
         const func = this.namedGetter.name ? `.${this.namedGetter.name}` : "[utils.namedGet]";
-        const value = namedValue || `${O}[impl]${func}(${P})`;
+        const value = namedValue || `${O}[implSymbol]${func}(${P})`;
         return `${value} !== ${unsupportedValue}`;
       }
-      return `${O}[impl][utils.supportsPropertyName](${P})`;
+      return `${O}[implSymbol][utils.supportsPropertyName](${P})`;
     };
 
     // "named property visibility algorithm"
@@ -603,14 +602,14 @@ class Interface {
         invocation = `
           const creating = !(${supportsPropertyIndex(O, "index")});
           if (creating) {
-            ${O}[impl][utils.indexedSetNew](index, indexedValue);
+            ${O}[implSymbol][utils.indexedSetNew](index, indexedValue);
           } else {
-            ${O}[impl][utils.indexedSetExisting](index, indexedValue);
+            ${O}[implSymbol][utils.indexedSetExisting](index, indexedValue);
           }
         `;
       } else {
         invocation = `
-          ${O}[impl].${this.indexedSetter.name}(index, indexedValue);
+          ${O}[implSymbol].${this.indexedSetter.name}(index, indexedValue);
         `;
       }
 
@@ -641,14 +640,14 @@ class Interface {
         invocation = `
           const creating = !(${supportsPropertyName(O, P)});
           if (creating) {
-            ${O}[impl][utils.namedSetNew](${P}, namedValue);
+            ${O}[implSymbol][utils.namedSetNew](${P}, namedValue);
           } else {
-            ${O}[impl][utils.namedSetExisting](${P}, namedValue);
+            ${O}[implSymbol][utils.namedSetExisting](${P}, namedValue);
           }
         `;
       } else {
         invocation = `
-          ${O}[impl].${this.namedSetter.name}(${P}, namedValue);
+          ${O}[implSymbol].${this.namedSetter.name}(${P}, namedValue);
         `;
       }
 
@@ -729,14 +728,14 @@ class Interface {
     `;
     if (this.supportsIndexedProperties) {
       this.str += `
-          for (const key of target[impl][utils.supportedPropertyIndices]) {
+          for (const key of target[implSymbol][utils.supportedPropertyIndices]) {
             keys.add(\`\${key}\`);
           }
       `;
     }
     if (this.supportsNamedProperties) {
       this.str += `
-          for (const key of target[impl][utils.supportedPropertyNames]) {
+          for (const key of target[implSymbol][utils.supportedPropertyNames]) {
             if (${namedPropertyVisible("key", "target", true)}) {
               keys.add(\`\${key}\`);
             }
@@ -769,10 +768,10 @@ class Interface {
       let preamble = "";
       let condition;
       if (utils.getExtAttr(this.indexedGetter.extAttrs, "WebIDL2JSValueAsUnsupported")) {
-        this.str += `const indexedValue = target[impl]${func}(index);`;
+        this.str += `const indexedValue = target[implSymbol]${func}(index);`;
         condition = supportsPropertyIndex("target", "index", "indexedValue");
       } else {
-        preamble = `const indexedValue = target[impl]${func}(index);`;
+        preamble = `const indexedValue = target[implSymbol]${func}(index);`;
         condition = supportsPropertyIndex("target", "index");
       }
 
@@ -797,13 +796,13 @@ class Interface {
       const conditions = [];
       if (utils.getExtAttr(this.namedGetter.extAttrs, "WebIDL2JSValueAsUnsupported")) {
         this.str += `
-          const namedValue = target[impl]${func}(P);
+          const namedValue = target[implSymbol]${func}(P);
         `;
         conditions.push(supportsPropertyName("target", "index", "namedValue"));
         conditions.push(namedPropertyVisible("P", "target", true));
       } else {
         preamble = `
-          const namedValue = target[impl]${func}(P);
+          const namedValue = target[implSymbol]${func}(P);
         `;
         conditions.push(namedPropertyVisible("P", "target", false));
       }
@@ -885,10 +884,10 @@ class Interface {
       let preamble = "";
       let condition;
       if (utils.getExtAttr(this.indexedGetter.extAttrs, "WebIDL2JSValueAsUnsupported")) {
-        this.str += `const indexedValue = target[impl]${func}(index);`;
+        this.str += `const indexedValue = target[implSymbol]${func}(index);`;
         condition = supportsPropertyIndex("target", "index", "indexedValue");
       } else {
-        preamble = `const indexedValue = target[impl]${func}(index);`;
+        preamble = `const indexedValue = target[implSymbol]${func}(index);`;
         condition = supportsPropertyIndex("target", "index");
       }
 
@@ -1070,11 +1069,11 @@ class Interface {
 
         if (this.namedDeleter.idlType.idlType === "bool") {
           invocation = `
-            return target[impl]${func}(P);
+            return target[implSymbol]${func}(P);
           `;
         } else {
           invocation = `
-            target[impl]${func}(P);
+            target[implSymbol]${func}(P);
             return true;
           `;
         }
@@ -1111,11 +1110,11 @@ class Interface {
   generateIface() {
     this.str += `
       exports.create = function create(globalObject, constructorArgs, privateData) {
-        if (globalObject[ctorRegistry] === undefined) {
+        if (globalObject[ctorRegistrySymbol] === undefined) {
           throw new Error('Internal error: invalid global object');
         }
 
-        const ctor = globalObject[ctorRegistry]["${this.name}"];
+        const ctor = globalObject[ctorRegistrySymbol]["${this.name}"];
         if (ctor === undefined) {
           throw new Error('Internal error: constructor ${this.name} is not installed on the passed global object');
         }
@@ -1145,7 +1144,7 @@ class Interface {
         privateData.wrapper = obj;
 
         exports._internalSetup(obj, globalObject);
-        Object.defineProperty(obj, impl, {
+        Object.defineProperty(obj, implSymbol, {
           value: new Impl.implementation(globalObject, constructorArgs, privateData),
           configurable: true
         });
@@ -1171,9 +1170,9 @@ class Interface {
     }
 
     this.str += `
-        obj[impl][utils.wrapperSymbol] = obj;
+        obj[implSymbol][utils.wrapperSymbol] = obj;
         if (Impl.init) {
-          Impl.init(obj[impl], privateData);
+          Impl.init(obj[implSymbol], privateData);
         }
         return obj;
       };
@@ -1467,10 +1466,10 @@ class Interface {
     this.generateOffInstanceAfterClass();
 
     this.str += `
-        if (globalObject[ctorRegistry] === undefined) {
-          globalObject[ctorRegistry] = Object.create(null);
+        if (globalObject[ctorRegistrySymbol] === undefined) {
+          globalObject[ctorRegistrySymbol] = Object.create(null);
         }
-        globalObject[ctorRegistry][interfaceName] = ${name};
+        globalObject[ctorRegistrySymbol][interfaceName] = ${name};
 
         Object.defineProperty(globalObject, interfaceName, {
           configurable: true,

--- a/lib/constructs/iterable.js
+++ b/lib/constructs/iterable.js
@@ -47,12 +47,12 @@ class Iterable {
                               "as parameter 1 is not a function.");
         }
         const thisArg = arguments[1];
-        let pairs = Array.from(this[impl]);
+        let pairs = Array.from(this[implSymbol]);
         let i = 0;
         while (i < pairs.length) {
           const [key, value] = pairs[i].map(utils.tryWrapperForImpl);
           callback.call(thisArg, value, key, this);
-          pairs = Array.from(this[impl]);
+          pairs = Array.from(this[implSymbol]);
           i++;
         }
       `);

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -69,7 +69,7 @@ class Operation {
       `;
     }
 
-    const callOn = this.static ? "Impl.implementation" : `esValue[impl]`;
+    const callOn = this.static ? "Impl.implementation" : `esValue[implSymbol]`;
     // In case of stringifiers, use the named implementation function rather than hardcoded "toString".
     // All overloads will have the same name, so pick the first one.
     const implFunc = this.idls[0].name || this.name;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -6,13 +6,12 @@ exports[`with processors BufferSourceTypes.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"BufferSourceTypes\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -25,11 +24,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"BufferSourceTypes\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"BufferSourceTypes\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor BufferSourceTypes is not installed on the passed global object\\");
   }
@@ -47,14 +46,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -90,7 +89,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].bs(...args);
+      return esValue[implSymbol].bs(...args);
     }
 
     ab(ab) {
@@ -114,7 +113,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].ab(...args);
+      return esValue[implSymbol].ab(...args);
     }
 
     abv(abv) {
@@ -141,7 +140,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].abv(...args);
+      return esValue[implSymbol].abv(...args);
     }
 
     u8a(u8) {
@@ -165,7 +164,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].u8a(...args);
+      return esValue[implSymbol].u8a(...args);
     }
 
     abUnion(ab) {
@@ -192,7 +191,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].abUnion(...args);
+      return esValue[implSymbol].abUnion(...args);
     }
 
     u8aUnion(ab) {
@@ -219,7 +218,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].u8aUnion(...args);
+      return esValue[implSymbol].u8aUnion(...args);
     }
   }
   Object.defineProperties(BufferSourceTypes.prototype, {
@@ -231,10 +230,10 @@ exports.install = function install(globalObject) {
     u8aUnion: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"BufferSourceTypes\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = BufferSourceTypes;
+  globalObject[ctorRegistrySymbol][interfaceName] = BufferSourceTypes;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -254,13 +253,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const CEReactions = require(\\"../CEReactions.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"CEReactions\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -273,11 +271,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"CEReactions\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"CEReactions\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor CEReactions is not installed on the passed global object\\");
   }
@@ -295,7 +293,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
@@ -309,9 +307,9 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
     obj = new Proxy(obj, proxyHandler);
   }
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -330,7 +328,7 @@ exports.install = function install(globalObject) {
 
       CEReactions.preSteps(globalObject);
       try {
-        return esValue[impl].method();
+        return esValue[implSymbol].method();
       } finally {
         CEReactions.postSteps(globalObject);
       }
@@ -345,7 +343,7 @@ exports.install = function install(globalObject) {
 
       CEReactions.preSteps(globalObject);
       try {
-        return esValue[impl][\\"attr\\"];
+        return esValue[implSymbol][\\"attr\\"];
       } finally {
         CEReactions.postSteps(globalObject);
       }
@@ -364,7 +362,7 @@ exports.install = function install(globalObject) {
 
       CEReactions.preSteps(globalObject);
       try {
-        esValue[impl][\\"attr\\"] = V;
+        esValue[implSymbol][\\"attr\\"] = V;
       } finally {
         CEReactions.postSteps(globalObject);
       }
@@ -375,10 +373,10 @@ exports.install = function install(globalObject) {
     attr: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"CEReactions\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = CEReactions;
+  globalObject[ctorRegistrySymbol][interfaceName] = CEReactions;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -433,7 +431,7 @@ class ProxyHandler {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyNames]) {
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
       if (!(key in target)) {
         keys.add(\`\${key}\`);
       }
@@ -451,8 +449,8 @@ class ProxyHandler {
     }
     let ignoreNamedProps = false;
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-      const namedValue = target[impl][utils.namedGet](P);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
 
       return {
         writable: true,
@@ -481,11 +479,11 @@ class ProxyHandler {
 
         CEReactions.preSteps(globalObject);
         try {
-          const creating = !target[impl][utils.supportsPropertyName](P);
+          const creating = !target[implSymbol][utils.supportsPropertyName](P);
           if (creating) {
-            target[impl][utils.namedSetNew](P, namedValue);
+            target[implSymbol][utils.namedSetNew](P, namedValue);
           } else {
-            target[impl][utils.namedSetExisting](P, namedValue);
+            target[implSymbol][utils.namedSetExisting](P, namedValue);
           }
         } finally {
           CEReactions.postSteps(globalObject);
@@ -547,11 +545,11 @@ class ProxyHandler {
 
       CEReactions.preSteps(globalObject);
       try {
-        const creating = !target[impl][utils.supportsPropertyName](P);
+        const creating = !target[implSymbol][utils.supportsPropertyName](P);
         if (creating) {
-          target[impl][utils.namedSetNew](P, namedValue);
+          target[implSymbol][utils.namedSetNew](P, namedValue);
         } else {
-          target[impl][utils.namedSetExisting](P, namedValue);
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
         }
       } finally {
         CEReactions.postSteps(globalObject);
@@ -569,10 +567,10 @@ class ProxyHandler {
 
     const globalObject = this._globalObject;
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
       CEReactions.preSteps(globalObject);
       try {
-        target[impl][utils.namedDelete](P);
+        target[implSymbol][utils.namedDelete](P);
         return true;
       } finally {
         CEReactions.postSteps(globalObject);
@@ -597,13 +595,12 @@ exports[`with processors DOMImplementation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"DOMImplementation\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -616,11 +613,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"DOMImplementation\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"DOMImplementation\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor DOMImplementation is not installed on the passed global object\\");
   }
@@ -638,14 +635,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -691,7 +688,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].createDocumentType(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].createDocumentType(...args));
     }
 
     createDocument(namespace, qualifiedName) {
@@ -740,7 +737,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].createDocument(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].createDocument(...args));
     }
 
     createHTMLDocument() {
@@ -758,7 +755,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].createHTMLDocument(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].createHTMLDocument(...args));
     }
 
     hasFeature() {
@@ -767,7 +764,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].hasFeature();
+      return esValue[implSymbol].hasFeature();
     }
   }
   Object.defineProperties(DOMImplementation.prototype, {
@@ -777,10 +774,10 @@ exports.install = function install(globalObject) {
     hasFeature: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"DOMImplementation\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = DOMImplementation;
+  globalObject[ctorRegistrySymbol][interfaceName] = DOMImplementation;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -878,13 +875,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const Dictionary = require(\\"./Dictionary.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"DictionaryConvert\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -897,11 +893,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"DictionaryConvert\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"DictionaryConvert\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor DictionaryConvert is not installed on the passed global object\\");
   }
@@ -919,14 +915,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -957,17 +953,17 @@ exports.install = function install(globalObject) {
         curArg = Dictionary.convert(curArg, { context: \\"Failed to execute 'op' on 'DictionaryConvert': parameter 2\\" });
         args.push(curArg);
       }
-      return esValue[impl].op(...args);
+      return esValue[implSymbol].op(...args);
     }
   }
   Object.defineProperties(DictionaryConvert.prototype, {
     op: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"DictionaryConvert\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = DictionaryConvert;
+  globalObject[ctorRegistrySymbol][interfaceName] = DictionaryConvert;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -987,13 +983,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const RequestDestination = require(\\"./RequestDestination.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Enum\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -1006,11 +1001,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Enum\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Enum\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Enum is not installed on the passed global object\\");
   }
@@ -1028,14 +1023,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -1063,7 +1058,7 @@ exports.install = function install(globalObject) {
         curArg = RequestDestination.convert(curArg, { context: \\"Failed to execute 'op' on 'Enum': parameter 1\\" });
         args.push(curArg);
       }
-      return esValue[impl].op(...args);
+      return esValue[implSymbol].op(...args);
     }
 
     get attr() {
@@ -1073,7 +1068,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return utils.tryWrapperForImpl(esValue[impl][\\"attr\\"]);
+      return utils.tryWrapperForImpl(esValue[implSymbol][\\"attr\\"]);
     }
 
     set attr(V) {
@@ -1088,7 +1083,7 @@ exports.install = function install(globalObject) {
         return;
       }
 
-      esValue[impl][\\"attr\\"] = V;
+      esValue[implSymbol][\\"attr\\"] = V;
     }
   }
   Object.defineProperties(Enum.prototype, {
@@ -1096,10 +1091,10 @@ exports.install = function install(globalObject) {
     attr: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"Enum\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Enum;
+  globalObject[ctorRegistrySymbol][interfaceName] = Enum;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -1118,13 +1113,12 @@ exports[`with processors Global.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Global\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -1137,11 +1131,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Global\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Global\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Global is not installed on the passed global object\\");
   }
@@ -1164,7 +1158,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl].op();
+        return esValue[implSymbol].op();
       },
       unforgeableOp() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -1172,7 +1166,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl].unforgeableOp();
+        return esValue[implSymbol].unforgeableOp();
       },
       get attr() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -1181,7 +1175,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"attr\\"];
+        return esValue[implSymbol][\\"attr\\"];
       },
       set attr(V) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -1194,7 +1188,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           context: \\"Failed to set the 'attr' property on 'Global': The provided value\\"
         });
 
-        esValue[impl][\\"attr\\"] = V;
+        esValue[implSymbol][\\"attr\\"] = V;
       },
       get unforgeableAttr() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -1203,7 +1197,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"unforgeableAttr\\"];
+        return esValue[implSymbol][\\"unforgeableAttr\\"];
       },
       set unforgeableAttr(V) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -1216,7 +1210,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           context: \\"Failed to set the 'unforgeableAttr' property on 'Global': The provided value\\"
         });
 
-        esValue[impl][\\"unforgeableAttr\\"] = V;
+        esValue[implSymbol][\\"unforgeableAttr\\"] = V;
       },
       get length() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -1225,7 +1219,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"length\\"];
+        return esValue[implSymbol][\\"length\\"];
       },
       set length(V) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -1238,7 +1232,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           context: \\"Failed to set the 'length' property on 'Global': The provided value\\"
         });
 
-        esValue[impl][\\"length\\"] = V;
+        esValue[implSymbol][\\"length\\"] = V;
       },
       [Symbol.iterator]: Array.prototype[Symbol.iterator],
       keys: Array.prototype.keys,
@@ -1258,14 +1252,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -1294,10 +1288,10 @@ exports.install = function install(globalObject) {
   }
   Object.defineProperties(Global.prototype, { [Symbol.toStringTag]: { value: \\"Global\\", configurable: true } });
   Object.defineProperties(Global, { staticOp: { enumerable: true }, staticAttr: { enumerable: true } });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Global;
+  globalObject[ctorRegistrySymbol][interfaceName] = Global;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -1317,13 +1311,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const HTMLConstructor_HTMLConstructor = require(\\"../HTMLConstructor.js\\").HTMLConstructor;
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"HTMLConstructor\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -1336,11 +1329,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"HTMLConstructor\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"HTMLConstructor\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor HTMLConstructor is not installed on the passed global object\\");
   }
@@ -1358,14 +1351,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -1379,10 +1372,10 @@ exports.install = function install(globalObject) {
   Object.defineProperties(HTMLConstructor.prototype, {
     [Symbol.toStringTag]: { value: \\"HTMLConstructor\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = HTMLConstructor;
+  globalObject[ctorRegistrySymbol][interfaceName] = HTMLConstructor;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -1401,13 +1394,12 @@ exports[`with processors LegacyArrayClass.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"LegacyArrayClass\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -1420,11 +1412,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"LegacyArrayClass\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"LegacyArrayClass\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor LegacyArrayClass is not installed on the passed global object\\");
   }
@@ -1442,14 +1434,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -1467,7 +1459,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"length\\"];
+      return esValue[implSymbol][\\"length\\"];
     }
   }
   Object.setPrototypeOf(LegacyArrayClass.prototype, Array.prototype);
@@ -1475,10 +1467,10 @@ exports.install = function install(globalObject) {
     length: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"LegacyArrayClass\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = LegacyArrayClass;
+  globalObject[ctorRegistrySymbol][interfaceName] = LegacyArrayClass;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -1497,13 +1489,12 @@ exports[`with processors MixedIn.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"MixedIn\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -1516,11 +1507,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"MixedIn\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"MixedIn\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor MixedIn is not installed on the passed global object\\");
   }
@@ -1538,14 +1529,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -1562,7 +1553,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].mixedInOp();
+      return esValue[implSymbol].mixedInOp();
     }
 
     ifaceMixinOp() {
@@ -1571,7 +1562,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].ifaceMixinOp();
+      return esValue[implSymbol].ifaceMixinOp();
     }
 
     get mixedInAttr() {
@@ -1581,7 +1572,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"mixedInAttr\\"];
+      return esValue[implSymbol][\\"mixedInAttr\\"];
     }
 
     set mixedInAttr(V) {
@@ -1595,7 +1586,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'mixedInAttr' property on 'MixedIn': The provided value\\"
       });
 
-      esValue[impl][\\"mixedInAttr\\"] = V;
+      esValue[implSymbol][\\"mixedInAttr\\"] = V;
     }
 
     get ifaceMixinAttr() {
@@ -1605,7 +1596,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"ifaceMixinAttr\\"];
+      return esValue[implSymbol][\\"ifaceMixinAttr\\"];
     }
 
     set ifaceMixinAttr(V) {
@@ -1619,7 +1610,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'ifaceMixinAttr' property on 'MixedIn': The provided value\\"
       });
 
-      esValue[impl][\\"ifaceMixinAttr\\"] = V;
+      esValue[implSymbol][\\"ifaceMixinAttr\\"] = V;
     }
   }
   Object.defineProperties(MixedIn.prototype, {
@@ -1635,10 +1626,10 @@ exports.install = function install(globalObject) {
     mixedInConst: { value: 43, enumerable: true },
     ifaceMixinConst: { value: 42, enumerable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = MixedIn;
+  globalObject[ctorRegistrySymbol][interfaceName] = MixedIn;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -1658,13 +1649,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Overloads\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -1677,11 +1667,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Overloads\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Overloads\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Overloads is not installed on the passed global object\\");
   }
@@ -1699,14 +1689,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -1805,7 +1795,7 @@ exports.install = function install(globalObject) {
             args.push(curArg);
           }
       }
-      return utils.tryWrapperForImpl(esValue[impl].compatible(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].compatible(...args));
     }
 
     incompatible1(arg1) {
@@ -1842,7 +1832,7 @@ exports.install = function install(globalObject) {
           }
         }
       }
-      return esValue[impl].incompatible1(...args);
+      return esValue[implSymbol].incompatible1(...args);
     }
 
     incompatible2(arg1) {
@@ -1885,7 +1875,7 @@ exports.install = function install(globalObject) {
             args.push(curArg);
           }
       }
-      return esValue[impl].incompatible2(...args);
+      return esValue[implSymbol].incompatible2(...args);
     }
 
     incompatible3(arg1) {
@@ -2020,7 +2010,7 @@ exports.install = function install(globalObject) {
             args.push(curArg);
           }
       }
-      return esValue[impl].incompatible3(...args);
+      return esValue[implSymbol].incompatible3(...args);
     }
   }
   Object.defineProperties(Overloads.prototype, {
@@ -2030,10 +2020,10 @@ exports.install = function install(globalObject) {
     incompatible3: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"Overloads\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Overloads;
+  globalObject[ctorRegistrySymbol][interfaceName] = Overloads;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -2052,13 +2042,12 @@ exports[`with processors PromiseTypes.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"PromiseTypes\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -2071,11 +2060,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"PromiseTypes\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"PromiseTypes\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor PromiseTypes is not installed on the passed global object\\");
   }
@@ -2093,14 +2082,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -2133,7 +2122,7 @@ exports.install = function install(globalObject) {
         );
         args.push(curArg);
       }
-      return esValue[impl].voidPromiseConsumer(...args);
+      return esValue[implSymbol].voidPromiseConsumer(...args);
     }
 
     promiseConsumer(p) {
@@ -2164,7 +2153,7 @@ exports.install = function install(globalObject) {
         );
         args.push(curArg);
       }
-      return esValue[impl].promiseConsumer(...args);
+      return esValue[implSymbol].promiseConsumer(...args);
     }
   }
   Object.defineProperties(PromiseTypes.prototype, {
@@ -2172,10 +2161,10 @@ exports.install = function install(globalObject) {
     promiseConsumer: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"PromiseTypes\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = PromiseTypes;
+  globalObject[ctorRegistrySymbol][interfaceName] = PromiseTypes;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -2195,13 +2184,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const whatwg_url = require(\\"whatwg-url\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Reflect\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -2214,11 +2202,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Reflect\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Reflect\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Reflect is not installed on the passed global object\\");
   }
@@ -2236,14 +2224,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -2446,10 +2434,10 @@ exports.install = function install(globalObject) {
     withUnderscore: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"Reflect\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Reflect;
+  globalObject[ctorRegistrySymbol][interfaceName] = Reflect;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -2502,13 +2490,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"SeqAndRec\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -2521,11 +2508,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"SeqAndRec\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"SeqAndRec\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor SeqAndRec is not installed on the passed global object\\");
   }
@@ -2543,14 +2530,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -2603,7 +2590,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].recordConsumer(...args);
+      return esValue[implSymbol].recordConsumer(...args);
     }
 
     recordConsumer2(rec) {
@@ -2648,7 +2635,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].recordConsumer2(...args);
+      return esValue[implSymbol].recordConsumer2(...args);
     }
 
     sequenceConsumer(seq) {
@@ -2685,7 +2672,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].sequenceConsumer(...args);
+      return esValue[implSymbol].sequenceConsumer(...args);
     }
 
     sequenceConsumer2(seq) {
@@ -2720,7 +2707,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].sequenceConsumer2(...args);
+      return esValue[implSymbol].sequenceConsumer2(...args);
     }
 
     frozenArrayConsumer(arr) {
@@ -2758,7 +2745,7 @@ exports.install = function install(globalObject) {
         curArg = Object.freeze(curArg);
         args.push(curArg);
       }
-      return esValue[impl].frozenArrayConsumer(...args);
+      return esValue[implSymbol].frozenArrayConsumer(...args);
     }
   }
   Object.defineProperties(SeqAndRec.prototype, {
@@ -2769,10 +2756,10 @@ exports.install = function install(globalObject) {
     frozenArrayConsumer: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"SeqAndRec\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = SeqAndRec;
+  globalObject[ctorRegistrySymbol][interfaceName] = SeqAndRec;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -2791,13 +2778,12 @@ exports[`with processors Static.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Static\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -2810,11 +2796,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Static\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Static\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Static is not installed on the passed global object\\");
   }
@@ -2832,14 +2818,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -2856,7 +2842,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].def();
+      return esValue[implSymbol].def();
     }
 
     get abc() {
@@ -2866,7 +2852,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"abc\\"];
+      return esValue[implSymbol][\\"abc\\"];
     }
 
     set abc(V) {
@@ -2878,7 +2864,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"DOMString\\"](V, { context: \\"Failed to set the 'abc' property on 'Static': The provided value\\" });
 
-      esValue[impl][\\"abc\\"] = V;
+      esValue[implSymbol][\\"abc\\"] = V;
     }
 
     static def() {
@@ -2903,10 +2889,10 @@ exports.install = function install(globalObject) {
     [Symbol.toStringTag]: { value: \\"Static\\", configurable: true }
   });
   Object.defineProperties(Static, { def: { enumerable: true }, abc: { enumerable: true } });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Static;
+  globalObject[ctorRegistrySymbol][interfaceName] = Static;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -2925,13 +2911,12 @@ exports[`with processors Storage.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Storage\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -2944,11 +2929,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Storage\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Storage\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Storage is not installed on the passed global object\\");
   }
@@ -2966,16 +2951,16 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
   obj = new Proxy(obj, proxyHandler);
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -3003,7 +2988,7 @@ exports.install = function install(globalObject) {
         curArg = conversions[\\"unsigned long\\"](curArg, { context: \\"Failed to execute 'key' on 'Storage': parameter 1\\" });
         args.push(curArg);
       }
-      return esValue[impl].key(...args);
+      return esValue[implSymbol].key(...args);
     }
 
     getItem(key) {
@@ -3023,7 +3008,7 @@ exports.install = function install(globalObject) {
         curArg = conversions[\\"DOMString\\"](curArg, { context: \\"Failed to execute 'getItem' on 'Storage': parameter 1\\" });
         args.push(curArg);
       }
-      return esValue[impl].getItem(...args);
+      return esValue[implSymbol].getItem(...args);
     }
 
     setItem(key, value) {
@@ -3048,7 +3033,7 @@ exports.install = function install(globalObject) {
         curArg = conversions[\\"DOMString\\"](curArg, { context: \\"Failed to execute 'setItem' on 'Storage': parameter 2\\" });
         args.push(curArg);
       }
-      return esValue[impl].setItem(...args);
+      return esValue[implSymbol].setItem(...args);
     }
 
     removeItem(key) {
@@ -3070,7 +3055,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].removeItem(...args);
+      return esValue[implSymbol].removeItem(...args);
     }
 
     clear() {
@@ -3079,7 +3064,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].clear();
+      return esValue[implSymbol].clear();
     }
 
     get length() {
@@ -3089,7 +3074,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"length\\"];
+      return esValue[implSymbol][\\"length\\"];
     }
   }
   Object.defineProperties(Storage.prototype, {
@@ -3101,10 +3086,10 @@ exports.install = function install(globalObject) {
     length: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"Storage\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Storage;
+  globalObject[ctorRegistrySymbol][interfaceName] = Storage;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -3154,7 +3139,7 @@ const proxyHandler = {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyNames]) {
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
       if (!(key in target)) {
         keys.add(\`\${key}\`);
       }
@@ -3172,8 +3157,8 @@ const proxyHandler = {
     }
     let ignoreNamedProps = false;
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-      const namedValue = target[impl].getItem(P);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+      const namedValue = target[implSymbol].getItem(P);
 
       return {
         writable: true,
@@ -3198,7 +3183,7 @@ const proxyHandler = {
           context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
         });
 
-        target[impl].setItem(P, namedValue);
+        target[implSymbol].setItem(P, namedValue);
 
         return true;
       }
@@ -3252,7 +3237,7 @@ const proxyHandler = {
         context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
       });
 
-      target[impl].setItem(P, namedValue);
+      target[implSymbol].setItem(P, namedValue);
 
       return true;
     }
@@ -3264,8 +3249,8 @@ const proxyHandler = {
       return Reflect.deleteProperty(target, P);
     }
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
-      target[impl].removeItem(P);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      target[implSymbol].removeItem(P);
       return true;
     }
 
@@ -3287,13 +3272,12 @@ exports[`with processors StringifierAttribute.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"StringifierAttribute\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -3306,11 +3290,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"StringifierAttribute\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"StringifierAttribute\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor StringifierAttribute is not installed on the passed global object\\");
   }
@@ -3328,14 +3312,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -3353,7 +3337,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"attr\\"];
+      return esValue[implSymbol][\\"attr\\"];
     }
 
     toString() {
@@ -3362,7 +3346,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"attr\\"];
+      return esValue[implSymbol][\\"attr\\"];
     }
   }
   Object.defineProperties(StringifierAttribute.prototype, {
@@ -3370,10 +3354,10 @@ exports.install = function install(globalObject) {
     toString: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"StringifierAttribute\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = StringifierAttribute;
+  globalObject[ctorRegistrySymbol][interfaceName] = StringifierAttribute;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -3392,13 +3376,12 @@ exports[`with processors StringifierDefaultOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"StringifierDefaultOperation\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -3411,11 +3394,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"StringifierDefaultOperation\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"StringifierDefaultOperation\\"];
   if (ctor === undefined) {
     throw new Error(
       \\"Internal error: constructor StringifierDefaultOperation is not installed on the passed global object\\"
@@ -3435,14 +3418,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -3459,17 +3442,17 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].toString();
+      return esValue[implSymbol].toString();
     }
   }
   Object.defineProperties(StringifierDefaultOperation.prototype, {
     toString: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"StringifierDefaultOperation\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = StringifierDefaultOperation;
+  globalObject[ctorRegistrySymbol][interfaceName] = StringifierDefaultOperation;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -3488,13 +3471,12 @@ exports[`with processors StringifierNamedOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"StringifierNamedOperation\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -3507,11 +3489,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"StringifierNamedOperation\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"StringifierNamedOperation\\"];
   if (ctor === undefined) {
     throw new Error(
       \\"Internal error: constructor StringifierNamedOperation is not installed on the passed global object\\"
@@ -3531,14 +3513,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -3555,7 +3537,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].operation();
+      return esValue[implSymbol].operation();
     }
 
     toString() {
@@ -3564,7 +3546,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].operation();
+      return esValue[implSymbol].operation();
     }
   }
   Object.defineProperties(StringifierNamedOperation.prototype, {
@@ -3572,10 +3554,10 @@ exports.install = function install(globalObject) {
     toString: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"StringifierNamedOperation\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = StringifierNamedOperation;
+  globalObject[ctorRegistrySymbol][interfaceName] = StringifierNamedOperation;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -3594,13 +3576,12 @@ exports[`with processors StringifierOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"StringifierOperation\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -3613,11 +3594,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"StringifierOperation\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"StringifierOperation\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor StringifierOperation is not installed on the passed global object\\");
   }
@@ -3635,14 +3616,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -3659,17 +3640,17 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].toString();
+      return esValue[implSymbol].toString();
     }
   }
   Object.defineProperties(StringifierOperation.prototype, {
     toString: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"StringifierOperation\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = StringifierOperation;
+  globalObject[ctorRegistrySymbol][interfaceName] = StringifierOperation;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -3690,13 +3671,12 @@ const utils = require(\\"./utils.js\\");
 
 const RequestDestination = require(\\"./RequestDestination.js\\");
 const URL = require(\\"./URL.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"TypedefsAndUnions\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -3709,11 +3689,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"TypedefsAndUnions\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"TypedefsAndUnions\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor TypedefsAndUnions is not installed on the passed global object\\");
   }
@@ -3731,14 +3711,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -3777,7 +3757,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].numOrStrConsumer(...args);
+      return esValue[implSymbol].numOrStrConsumer(...args);
     }
 
     numOrEnumConsumer(a) {
@@ -3811,7 +3791,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].numOrEnumConsumer(...args);
+      return esValue[implSymbol].numOrEnumConsumer(...args);
     }
 
     numOrStrOrNullConsumer(a) {
@@ -3848,7 +3828,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].numOrStrOrNullConsumer(...args);
+      return esValue[implSymbol].numOrStrOrNullConsumer(...args);
     }
 
     numOrStrOrURLOrNullConsumer(a) {
@@ -3887,7 +3867,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].numOrStrOrURLOrNullConsumer(...args);
+      return esValue[implSymbol].numOrStrOrURLOrNullConsumer(...args);
     }
 
     urlMapInnerConsumer(a) {
@@ -3934,7 +3914,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].urlMapInnerConsumer(...args);
+      return esValue[implSymbol].urlMapInnerConsumer(...args);
     }
 
     urlMapConsumer(a) {
@@ -3985,7 +3965,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].urlMapConsumer(...args);
+      return esValue[implSymbol].urlMapConsumer(...args);
     }
 
     bufferSourceOrURLConsumer(b) {
@@ -4016,7 +3996,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].bufferSourceOrURLConsumer(...args);
+      return esValue[implSymbol].bufferSourceOrURLConsumer(...args);
     }
 
     arrayBufferViewOrURLMapConsumer(b) {
@@ -4083,7 +4063,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].arrayBufferViewOrURLMapConsumer(...args);
+      return esValue[implSymbol].arrayBufferViewOrURLMapConsumer(...args);
     }
 
     arrayBufferViewDupConsumer(b) {
@@ -4111,7 +4091,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].arrayBufferViewDupConsumer(...args);
+      return esValue[implSymbol].arrayBufferViewDupConsumer(...args);
     }
 
     get buf() {
@@ -4121,7 +4101,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return utils.tryWrapperForImpl(esValue[impl][\\"buf\\"]);
+      return utils.tryWrapperForImpl(esValue[implSymbol][\\"buf\\"]);
     }
 
     set buf(V) {
@@ -4142,7 +4122,7 @@ exports.install = function install(globalObject) {
             \\" is not of any supported type.\\"
         );
       }
-      esValue[impl][\\"buf\\"] = V;
+      esValue[implSymbol][\\"buf\\"] = V;
     }
 
     get time() {
@@ -4152,7 +4132,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"time\\"];
+      return esValue[implSymbol][\\"time\\"];
     }
 
     set time(V) {
@@ -4166,7 +4146,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'time' property on 'TypedefsAndUnions': The provided value\\"
       });
 
-      esValue[impl][\\"time\\"] = V;
+      esValue[implSymbol][\\"time\\"] = V;
     }
   }
   Object.defineProperties(TypedefsAndUnions.prototype, {
@@ -4183,10 +4163,10 @@ exports.install = function install(globalObject) {
     time: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"TypedefsAndUnions\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = TypedefsAndUnions;
+  globalObject[ctorRegistrySymbol][interfaceName] = TypedefsAndUnions;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -4205,13 +4185,12 @@ exports[`with processors URL.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"URL\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -4224,11 +4203,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"URL\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"URL\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor URL is not installed on the passed global object\\");
   }
@@ -4246,14 +4225,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -4288,7 +4267,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].toJSON();
+      return esValue[implSymbol].toJSON();
     }
 
     get href() {
@@ -4298,7 +4277,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"href\\"];
+      return esValue[implSymbol][\\"href\\"];
     }
 
     set href(V) {
@@ -4310,7 +4289,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'href' property on 'URL': The provided value\\" });
 
-      esValue[impl][\\"href\\"] = V;
+      esValue[implSymbol][\\"href\\"] = V;
     }
 
     toString() {
@@ -4319,7 +4298,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"href\\"];
+      return esValue[implSymbol][\\"href\\"];
     }
 
     get origin() {
@@ -4329,7 +4308,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"origin\\"];
+      return esValue[implSymbol][\\"origin\\"];
     }
 
     get protocol() {
@@ -4339,7 +4318,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"protocol\\"];
+      return esValue[implSymbol][\\"protocol\\"];
     }
 
     set protocol(V) {
@@ -4353,7 +4332,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'protocol' property on 'URL': The provided value\\"
       });
 
-      esValue[impl][\\"protocol\\"] = V;
+      esValue[implSymbol][\\"protocol\\"] = V;
     }
 
     get username() {
@@ -4363,7 +4342,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"username\\"];
+      return esValue[implSymbol][\\"username\\"];
     }
 
     set username(V) {
@@ -4377,7 +4356,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'username' property on 'URL': The provided value\\"
       });
 
-      esValue[impl][\\"username\\"] = V;
+      esValue[implSymbol][\\"username\\"] = V;
     }
 
     get password() {
@@ -4387,7 +4366,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"password\\"];
+      return esValue[implSymbol][\\"password\\"];
     }
 
     set password(V) {
@@ -4401,7 +4380,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'password' property on 'URL': The provided value\\"
       });
 
-      esValue[impl][\\"password\\"] = V;
+      esValue[implSymbol][\\"password\\"] = V;
     }
 
     get host() {
@@ -4411,7 +4390,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"host\\"];
+      return esValue[implSymbol][\\"host\\"];
     }
 
     set host(V) {
@@ -4423,7 +4402,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'host' property on 'URL': The provided value\\" });
 
-      esValue[impl][\\"host\\"] = V;
+      esValue[implSymbol][\\"host\\"] = V;
     }
 
     get hostname() {
@@ -4433,7 +4412,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"hostname\\"];
+      return esValue[implSymbol][\\"hostname\\"];
     }
 
     set hostname(V) {
@@ -4447,7 +4426,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'hostname' property on 'URL': The provided value\\"
       });
 
-      esValue[impl][\\"hostname\\"] = V;
+      esValue[implSymbol][\\"hostname\\"] = V;
     }
 
     get port() {
@@ -4457,7 +4436,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"port\\"];
+      return esValue[implSymbol][\\"port\\"];
     }
 
     set port(V) {
@@ -4469,7 +4448,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'port' property on 'URL': The provided value\\" });
 
-      esValue[impl][\\"port\\"] = V;
+      esValue[implSymbol][\\"port\\"] = V;
     }
 
     get pathname() {
@@ -4479,7 +4458,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"pathname\\"];
+      return esValue[implSymbol][\\"pathname\\"];
     }
 
     set pathname(V) {
@@ -4493,7 +4472,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'pathname' property on 'URL': The provided value\\"
       });
 
-      esValue[impl][\\"pathname\\"] = V;
+      esValue[implSymbol][\\"pathname\\"] = V;
     }
 
     get search() {
@@ -4503,7 +4482,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"search\\"];
+      return esValue[implSymbol][\\"search\\"];
     }
 
     set search(V) {
@@ -4515,7 +4494,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'search' property on 'URL': The provided value\\" });
 
-      esValue[impl][\\"search\\"] = V;
+      esValue[implSymbol][\\"search\\"] = V;
     }
 
     get searchParams() {
@@ -4526,7 +4505,7 @@ exports.install = function install(globalObject) {
       }
 
       return utils.getSameObject(this, \\"searchParams\\", () => {
-        return utils.tryWrapperForImpl(esValue[impl][\\"searchParams\\"]);
+        return utils.tryWrapperForImpl(esValue[implSymbol][\\"searchParams\\"]);
       });
     }
 
@@ -4537,7 +4516,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"hash\\"];
+      return esValue[implSymbol][\\"hash\\"];
     }
 
     set hash(V) {
@@ -4549,7 +4528,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'hash' property on 'URL': The provided value\\" });
 
-      esValue[impl][\\"hash\\"] = V;
+      esValue[implSymbol][\\"hash\\"] = V;
     }
   }
   Object.defineProperties(URL.prototype, {
@@ -4569,10 +4548,10 @@ exports.install = function install(globalObject) {
     hash: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"URL\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = URL;
+  globalObject[ctorRegistrySymbol][interfaceName] = URL;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -4591,13 +4570,12 @@ exports[`with processors URLList.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"URLList\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -4610,11 +4588,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"URLList\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"URLList\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor URLList is not installed on the passed global object\\");
   }
@@ -4632,16 +4610,16 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
   obj = new Proxy(obj, proxyHandler);
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -4671,7 +4649,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].item(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].item(...args));
     }
 
     get length() {
@@ -4681,7 +4659,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"length\\"];
+      return esValue[implSymbol][\\"length\\"];
     }
   }
   Object.defineProperties(URLList.prototype, {
@@ -4694,10 +4672,10 @@ exports.install = function install(globalObject) {
     entries: { value: Array.prototype.entries, configurable: true, enumerable: true, writable: true },
     forEach: { value: Array.prototype.forEach, configurable: true, enumerable: true, writable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = URLList;
+  globalObject[ctorRegistrySymbol][interfaceName] = URLList;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -4747,7 +4725,7 @@ const proxyHandler = {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyIndices]) {
+    for (const key of target[implSymbol][utils.supportedPropertyIndices]) {
       keys.add(\`\${key}\`);
     }
 
@@ -4766,8 +4744,8 @@ const proxyHandler = {
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
 
-      if (target[impl][utils.supportsPropertyIndex](index)) {
-        const indexedValue = target[impl].item(index);
+      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
+        const indexedValue = target[implSymbol].item(index);
         return {
           writable: false,
           enumerable: true,
@@ -4793,8 +4771,8 @@ const proxyHandler = {
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
 
-      if (target[impl][utils.supportsPropertyIndex](index)) {
-        const indexedValue = target[impl].item(index);
+      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
+        const indexedValue = target[implSymbol].item(index);
         ownDesc = {
           writable: false,
           enumerable: true,
@@ -4855,7 +4833,7 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      return !target[impl][utils.supportsPropertyIndex](index);
+      return !target[implSymbol][utils.supportsPropertyIndex](index);
     }
 
     return Reflect.deleteProperty(target, P);
@@ -4876,8 +4854,7 @@ exports[`with processors URLSearchParams.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"URLSearchParams\\";
 
@@ -4886,7 +4863,7 @@ const IteratorPrototype = Object.create(utils.IteratorPrototype, {
     value: function next() {
       const internal = this[utils.iterInternalSymbol];
       const { target, kind, index } = internal;
-      const values = Array.from(target[impl]);
+      const values = Array.from(target[implSymbol]);
       const len = values.length;
       if (index >= len) {
         return { value: undefined, done: true };
@@ -4921,7 +4898,7 @@ const IteratorPrototype = Object.create(utils.IteratorPrototype, {
 });
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -4943,11 +4920,11 @@ exports.createDefaultIterator = function createDefaultIterator(target, kind) {
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"URLSearchParams\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"URLSearchParams\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor URLSearchParams is not installed on the passed global object\\");
   }
@@ -4965,14 +4942,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -5091,7 +5068,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].append(...args);
+      return esValue[implSymbol].append(...args);
     }
 
     delete(name) {
@@ -5115,7 +5092,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].delete(...args);
+      return esValue[implSymbol].delete(...args);
     }
 
     get(name) {
@@ -5139,7 +5116,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].get(...args);
+      return esValue[implSymbol].get(...args);
     }
 
     getAll(name) {
@@ -5163,7 +5140,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].getAll(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].getAll(...args));
     }
 
     has(name) {
@@ -5187,7 +5164,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].has(...args);
+      return esValue[implSymbol].has(...args);
     }
 
     set(name, value) {
@@ -5218,7 +5195,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].set(...args);
+      return esValue[implSymbol].set(...args);
     }
 
     sort() {
@@ -5227,7 +5204,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].sort();
+      return esValue[implSymbol].sort();
     }
 
     toString() {
@@ -5236,7 +5213,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].toString();
+      return esValue[implSymbol].toString();
     }
 
     keys() {
@@ -5273,12 +5250,12 @@ exports.install = function install(globalObject) {
         );
       }
       const thisArg = arguments[1];
-      let pairs = Array.from(this[impl]);
+      let pairs = Array.from(this[implSymbol]);
       let i = 0;
       while (i < pairs.length) {
         const [key, value] = pairs[i].map(utils.tryWrapperForImpl);
         callback.call(thisArg, value, key, this);
-        pairs = Array.from(this[impl]);
+        pairs = Array.from(this[implSymbol]);
         i++;
       }
     }
@@ -5299,10 +5276,10 @@ exports.install = function install(globalObject) {
     [Symbol.toStringTag]: { value: \\"URLSearchParams\\", configurable: true },
     [Symbol.iterator]: { value: URLSearchParams.prototype.entries, configurable: true, writable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = URLSearchParams;
+  globalObject[ctorRegistrySymbol][interfaceName] = URLSearchParams;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -5321,13 +5298,12 @@ exports[`with processors URLSearchParamsCollection.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"URLSearchParamsCollection\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -5340,11 +5316,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"URLSearchParamsCollection\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"URLSearchParamsCollection\\"];
   if (ctor === undefined) {
     throw new Error(
       \\"Internal error: constructor URLSearchParamsCollection is not installed on the passed global object\\"
@@ -5364,16 +5340,16 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
   obj = new Proxy(obj, proxyHandler);
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -5405,7 +5381,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].item(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].item(...args));
     }
 
     namedItem(name) {
@@ -5429,7 +5405,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].namedItem(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].namedItem(...args));
     }
 
     get length() {
@@ -5439,7 +5415,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"length\\"];
+      return esValue[implSymbol][\\"length\\"];
     }
   }
   Object.defineProperties(URLSearchParamsCollection.prototype, {
@@ -5449,10 +5425,10 @@ exports.install = function install(globalObject) {
     [Symbol.toStringTag]: { value: \\"URLSearchParamsCollection\\", configurable: true },
     [Symbol.iterator]: { value: Array.prototype[Symbol.iterator], configurable: true, writable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = URLSearchParamsCollection;
+  globalObject[ctorRegistrySymbol][interfaceName] = URLSearchParamsCollection;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -5502,11 +5478,11 @@ const proxyHandler = {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyIndices]) {
+    for (const key of target[implSymbol][utils.supportedPropertyIndices]) {
       keys.add(\`\${key}\`);
     }
 
-    for (const key of target[impl][utils.supportedPropertyNames]) {
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
       if (!(key in target)) {
         keys.add(\`\${key}\`);
       }
@@ -5526,7 +5502,7 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      const indexedValue = target[impl].item(index);
+      const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         return {
           writable: false,
@@ -5538,7 +5514,7 @@ const proxyHandler = {
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[impl].namedItem(P);
+    const namedValue = target[implSymbol].namedItem(P);
 
     if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
       return {
@@ -5565,7 +5541,7 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      const indexedValue = target[impl].item(index);
+      const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         ownDesc = {
           writable: false,
@@ -5617,7 +5593,7 @@ const proxyHandler = {
       return false;
     }
     if (!utils.hasOwn(target, P)) {
-      const creating = !(target[impl].namedItem(P) !== null);
+      const creating = !(target[implSymbol].namedItem(P) !== null);
       if (!creating) {
         return false;
       }
@@ -5632,10 +5608,10 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      return !(target[impl].item(index) !== undefined);
+      return !(target[implSymbol].item(index) !== undefined);
     }
 
-    if (target[impl].namedItem(P) !== null && !(P in target)) {
+    if (target[implSymbol].namedItem(P) !== null && !(P in target)) {
       return false;
     }
 
@@ -5658,14 +5634,13 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 const URLSearchParamsCollection = require(\\"./URLSearchParamsCollection.js\\");
 
 const interfaceName = \\"URLSearchParamsCollection2\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -5678,11 +5653,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"URLSearchParamsCollection2\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"URLSearchParamsCollection2\\"];
   if (ctor === undefined) {
     throw new Error(
       \\"Internal error: constructor URLSearchParamsCollection2 is not installed on the passed global object\\"
@@ -5704,16 +5679,16 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
   obj = new Proxy(obj, proxyHandler);
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -5733,10 +5708,10 @@ exports.install = function install(globalObject) {
     [Symbol.toStringTag]: { value: \\"URLSearchParamsCollection2\\", configurable: true },
     [Symbol.iterator]: { value: Array.prototype[Symbol.iterator], configurable: true, writable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = URLSearchParamsCollection2;
+  globalObject[ctorRegistrySymbol][interfaceName] = URLSearchParamsCollection2;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -5786,11 +5761,11 @@ const proxyHandler = {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyIndices]) {
+    for (const key of target[implSymbol][utils.supportedPropertyIndices]) {
       keys.add(\`\${key}\`);
     }
 
-    for (const key of target[impl][utils.supportedPropertyNames]) {
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
       if (!(key in target)) {
         keys.add(\`\${key}\`);
       }
@@ -5810,7 +5785,7 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      const indexedValue = target[impl].item(index);
+      const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         return {
           writable: false,
@@ -5822,7 +5797,7 @@ const proxyHandler = {
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[impl].namedItem(P);
+    const namedValue = target[implSymbol].namedItem(P);
 
     if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
       return {
@@ -5850,11 +5825,11 @@ const proxyHandler = {
           context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
         });
 
-        const creating = !(target[impl].namedItem(P) !== null);
+        const creating = !(target[implSymbol].namedItem(P) !== null);
         if (creating) {
-          target[impl][utils.namedSetNew](P, namedValue);
+          target[implSymbol][utils.namedSetNew](P, namedValue);
         } else {
-          target[impl][utils.namedSetExisting](P, namedValue);
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
         }
 
         return true;
@@ -5864,7 +5839,7 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      const indexedValue = target[impl].item(index);
+      const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         ownDesc = {
           writable: false,
@@ -5926,11 +5901,11 @@ const proxyHandler = {
         context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
       });
 
-      const creating = !(target[impl].namedItem(P) !== null);
+      const creating = !(target[implSymbol].namedItem(P) !== null);
       if (creating) {
-        target[impl][utils.namedSetNew](P, namedValue);
+        target[implSymbol][utils.namedSetNew](P, namedValue);
       } else {
-        target[impl][utils.namedSetExisting](P, namedValue);
+        target[implSymbol][utils.namedSetExisting](P, namedValue);
       }
 
       return true;
@@ -5945,10 +5920,10 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      return !(target[impl].item(index) !== undefined);
+      return !(target[implSymbol].item(index) !== undefined);
     }
 
-    if (target[impl].namedItem(P) !== null && !(P in target)) {
+    if (target[implSymbol].namedItem(P) !== null && !(P in target)) {
       return false;
     }
 
@@ -5970,13 +5945,12 @@ exports[`with processors UnderscoredProperties.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"UnderscoredProperties\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -5989,11 +5963,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"UnderscoredProperties\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"UnderscoredProperties\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor UnderscoredProperties is not installed on the passed global object\\");
   }
@@ -6011,14 +5985,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -6063,7 +6037,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].operation(...args);
+      return esValue[implSymbol].operation(...args);
     }
 
     get attribute() {
@@ -6073,7 +6047,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"attribute\\"];
+      return esValue[implSymbol][\\"attribute\\"];
     }
 
     set attribute(V) {
@@ -6087,7 +6061,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'attribute' property on 'UnderscoredProperties': The provided value\\"
       });
 
-      esValue[impl][\\"attribute\\"] = V;
+      esValue[implSymbol][\\"attribute\\"] = V;
     }
 
     static static(void_) {
@@ -6119,10 +6093,10 @@ exports.install = function install(globalObject) {
     static: { enumerable: true },
     const: { value: 42, enumerable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = UnderscoredProperties;
+  globalObject[ctorRegistrySymbol][interfaceName] = UnderscoredProperties;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -6141,13 +6115,12 @@ exports[`with processors Unforgeable.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Unforgeable\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -6160,11 +6133,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Unforgeable\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Unforgeable\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Unforgeable is not installed on the passed global object\\");
   }
@@ -6202,7 +6175,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           });
           args.push(curArg);
         }
-        return esValue[impl].assign(...args);
+        return esValue[implSymbol].assign(...args);
       },
       get href() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -6211,7 +6184,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"href\\"];
+        return esValue[implSymbol][\\"href\\"];
       },
       set href(V) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -6224,7 +6197,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           context: \\"Failed to set the 'href' property on 'Unforgeable': The provided value\\"
         });
 
-        esValue[impl][\\"href\\"] = V;
+        esValue[implSymbol][\\"href\\"] = V;
       },
       toString() {
         const esValue = this;
@@ -6232,7 +6205,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"href\\"];
+        return esValue[implSymbol][\\"href\\"];
       },
       get origin() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -6241,7 +6214,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"origin\\"];
+        return esValue[implSymbol][\\"origin\\"];
       },
       get protocol() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -6250,7 +6223,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"protocol\\"];
+        return esValue[implSymbol][\\"protocol\\"];
       },
       set protocol(V) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -6263,7 +6236,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           context: \\"Failed to set the 'protocol' property on 'Unforgeable': The provided value\\"
         });
 
-        esValue[impl][\\"protocol\\"] = V;
+        esValue[implSymbol][\\"protocol\\"] = V;
       }
     })
   );
@@ -6280,14 +6253,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -6301,10 +6274,10 @@ exports.install = function install(globalObject) {
   Object.defineProperties(Unforgeable.prototype, {
     [Symbol.toStringTag]: { value: \\"Unforgeable\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Unforgeable;
+  globalObject[ctorRegistrySymbol][interfaceName] = Unforgeable;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -6323,13 +6296,12 @@ exports[`with processors UnforgeableMap.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"UnforgeableMap\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -6342,11 +6314,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"UnforgeableMap\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"UnforgeableMap\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor UnforgeableMap is not installed on the passed global object\\");
   }
@@ -6370,7 +6342,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"a\\"];
+        return esValue[implSymbol][\\"a\\"];
       }
     })
   );
@@ -6381,16 +6353,16 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
   obj = new Proxy(obj, proxyHandler);
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -6404,10 +6376,10 @@ exports.install = function install(globalObject) {
   Object.defineProperties(UnforgeableMap.prototype, {
     [Symbol.toStringTag]: { value: \\"UnforgeableMap\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = UnforgeableMap;
+  globalObject[ctorRegistrySymbol][interfaceName] = UnforgeableMap;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -6457,7 +6429,7 @@ const proxyHandler = {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyNames]) {
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
       if (!(key in target)) {
         keys.add(\`\${key}\`);
       }
@@ -6475,8 +6447,8 @@ const proxyHandler = {
     }
     let ignoreNamedProps = false;
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-      const namedValue = target[impl][utils.namedGet](P);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
 
       return {
         writable: true,
@@ -6501,11 +6473,11 @@ const proxyHandler = {
           context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
         });
 
-        const creating = !target[impl][utils.supportsPropertyName](P);
+        const creating = !target[implSymbol][utils.supportsPropertyName](P);
         if (creating) {
-          target[impl][utils.namedSetNew](P, namedValue);
+          target[implSymbol][utils.namedSetNew](P, namedValue);
         } else {
-          target[impl][utils.namedSetExisting](P, namedValue);
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
         }
 
         return true;
@@ -6561,11 +6533,11 @@ const proxyHandler = {
           context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
         });
 
-        const creating = !target[impl][utils.supportsPropertyName](P);
+        const creating = !target[implSymbol][utils.supportsPropertyName](P);
         if (creating) {
-          target[impl][utils.namedSetNew](P, namedValue);
+          target[implSymbol][utils.namedSetNew](P, namedValue);
         } else {
-          target[impl][utils.namedSetExisting](P, namedValue);
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
         }
 
         return true;
@@ -6579,7 +6551,7 @@ const proxyHandler = {
       return Reflect.deleteProperty(target, P);
     }
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
       return false;
     }
 
@@ -6601,13 +6573,12 @@ exports[`with processors Unscopable.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Unscopable\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -6620,11 +6591,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Unscopable\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Unscopable\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Unscopable is not installed on the passed global object\\");
   }
@@ -6642,14 +6613,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -6667,7 +6638,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"unscopableTest\\"];
+      return esValue[implSymbol][\\"unscopableTest\\"];
     }
 
     set unscopableTest(V) {
@@ -6681,7 +6652,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'unscopableTest' property on 'Unscopable': The provided value\\"
       });
 
-      esValue[impl][\\"unscopableTest\\"] = V;
+      esValue[implSymbol][\\"unscopableTest\\"] = V;
     }
 
     get unscopableMixin() {
@@ -6691,7 +6662,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"unscopableMixin\\"];
+      return esValue[implSymbol][\\"unscopableMixin\\"];
     }
 
     set unscopableMixin(V) {
@@ -6705,7 +6676,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'unscopableMixin' property on 'Unscopable': The provided value\\"
       });
 
-      esValue[impl][\\"unscopableMixin\\"] = V;
+      esValue[implSymbol][\\"unscopableMixin\\"] = V;
     }
   }
   Object.defineProperties(Unscopable.prototype, {
@@ -6717,10 +6688,10 @@ exports.install = function install(globalObject) {
       configurable: true
     }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Unscopable;
+  globalObject[ctorRegistrySymbol][interfaceName] = Unscopable;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -6740,13 +6711,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Variadic\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -6759,11 +6729,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Variadic\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Variadic\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Variadic is not installed on the passed global object\\");
   }
@@ -6781,14 +6751,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -6812,7 +6782,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].simple1(...args);
+      return esValue[implSymbol].simple1(...args);
     }
 
     simple2(first) {
@@ -6839,7 +6809,7 @@ exports.install = function install(globalObject) {
         curArg = URL.convert(curArg, { context: \\"Failed to execute 'simple2' on 'Variadic': parameter \\" + (i + 1) });
         args.push(curArg);
       }
-      return esValue[impl].simple2(...args);
+      return esValue[implSymbol].simple2(...args);
     }
 
     overloaded1() {
@@ -6872,7 +6842,7 @@ exports.install = function install(globalObject) {
           }
         }
       }
-      return esValue[impl].overloaded1(...args);
+      return esValue[implSymbol].overloaded1(...args);
     }
 
     overloaded2(first) {
@@ -6947,7 +6917,7 @@ exports.install = function install(globalObject) {
           }
         }
       }
-      return esValue[impl].overloaded2(...args);
+      return esValue[implSymbol].overloaded2(...args);
     }
   }
   Object.defineProperties(Variadic.prototype, {
@@ -6957,10 +6927,10 @@ exports.install = function install(globalObject) {
     overloaded2: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"Variadic\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Variadic;
+  globalObject[ctorRegistrySymbol][interfaceName] = Variadic;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -6979,13 +6949,12 @@ exports[`with processors ZeroArgConstructor.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"ZeroArgConstructor\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -6998,11 +6967,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"ZeroArgConstructor\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"ZeroArgConstructor\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor ZeroArgConstructor is not installed on the passed global object\\");
   }
@@ -7020,14 +6989,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -7041,10 +7010,10 @@ exports.install = function install(globalObject) {
   Object.defineProperties(ZeroArgConstructor.prototype, {
     [Symbol.toStringTag]: { value: \\"ZeroArgConstructor\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = ZeroArgConstructor;
+  globalObject[ctorRegistrySymbol][interfaceName] = ZeroArgConstructor;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -7063,13 +7032,12 @@ exports[`without processors BufferSourceTypes.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"BufferSourceTypes\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -7082,11 +7050,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"BufferSourceTypes\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"BufferSourceTypes\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor BufferSourceTypes is not installed on the passed global object\\");
   }
@@ -7104,14 +7072,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -7147,7 +7115,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].bs(...args);
+      return esValue[implSymbol].bs(...args);
     }
 
     ab(ab) {
@@ -7171,7 +7139,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].ab(...args);
+      return esValue[implSymbol].ab(...args);
     }
 
     abv(abv) {
@@ -7198,7 +7166,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].abv(...args);
+      return esValue[implSymbol].abv(...args);
     }
 
     u8a(u8) {
@@ -7222,7 +7190,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].u8a(...args);
+      return esValue[implSymbol].u8a(...args);
     }
 
     abUnion(ab) {
@@ -7249,7 +7217,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].abUnion(...args);
+      return esValue[implSymbol].abUnion(...args);
     }
 
     u8aUnion(ab) {
@@ -7276,7 +7244,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].u8aUnion(...args);
+      return esValue[implSymbol].u8aUnion(...args);
     }
   }
   Object.defineProperties(BufferSourceTypes.prototype, {
@@ -7288,10 +7256,10 @@ exports.install = function install(globalObject) {
     u8aUnion: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"BufferSourceTypes\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = BufferSourceTypes;
+  globalObject[ctorRegistrySymbol][interfaceName] = BufferSourceTypes;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -7310,13 +7278,12 @@ exports[`without processors CEReactions.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"CEReactions\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -7329,11 +7296,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"CEReactions\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"CEReactions\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor CEReactions is not installed on the passed global object\\");
   }
@@ -7351,7 +7318,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
@@ -7365,9 +7332,9 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
     obj = new Proxy(obj, proxyHandler);
   }
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -7384,7 +7351,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].method();
+      return esValue[implSymbol].method();
     }
 
     get attr() {
@@ -7394,7 +7361,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"attr\\"];
+      return esValue[implSymbol][\\"attr\\"];
     }
 
     set attr(V) {
@@ -7408,7 +7375,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'attr' property on 'CEReactions': The provided value\\"
       });
 
-      esValue[impl][\\"attr\\"] = V;
+      esValue[implSymbol][\\"attr\\"] = V;
     }
   }
   Object.defineProperties(CEReactions.prototype, {
@@ -7416,10 +7383,10 @@ exports.install = function install(globalObject) {
     attr: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"CEReactions\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = CEReactions;
+  globalObject[ctorRegistrySymbol][interfaceName] = CEReactions;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -7474,7 +7441,7 @@ class ProxyHandler {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyNames]) {
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
       if (!(key in target)) {
         keys.add(\`\${key}\`);
       }
@@ -7492,8 +7459,8 @@ class ProxyHandler {
     }
     let ignoreNamedProps = false;
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-      const namedValue = target[impl][utils.namedGet](P);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
 
       return {
         writable: true,
@@ -7520,11 +7487,11 @@ class ProxyHandler {
           context: \\"Failed to set the '\\" + P + \\"' property on 'CEReactions': The provided value\\"
         });
 
-        const creating = !target[impl][utils.supportsPropertyName](P);
+        const creating = !target[implSymbol][utils.supportsPropertyName](P);
         if (creating) {
-          target[impl][utils.namedSetNew](P, namedValue);
+          target[implSymbol][utils.namedSetNew](P, namedValue);
         } else {
-          target[impl][utils.namedSetExisting](P, namedValue);
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
         }
 
         return true;
@@ -7581,11 +7548,11 @@ class ProxyHandler {
         context: \\"Failed to set the '\\" + P + \\"' property on 'CEReactions': The provided value\\"
       });
 
-      const creating = !target[impl][utils.supportsPropertyName](P);
+      const creating = !target[implSymbol][utils.supportsPropertyName](P);
       if (creating) {
-        target[impl][utils.namedSetNew](P, namedValue);
+        target[implSymbol][utils.namedSetNew](P, namedValue);
       } else {
-        target[impl][utils.namedSetExisting](P, namedValue);
+        target[implSymbol][utils.namedSetExisting](P, namedValue);
       }
 
       return true;
@@ -7600,8 +7567,8 @@ class ProxyHandler {
 
     const globalObject = this._globalObject;
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
-      target[impl][utils.namedDelete](P);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      target[implSymbol][utils.namedDelete](P);
       return true;
     }
 
@@ -7623,13 +7590,12 @@ exports[`without processors DOMImplementation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"DOMImplementation\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -7642,11 +7608,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"DOMImplementation\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"DOMImplementation\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor DOMImplementation is not installed on the passed global object\\");
   }
@@ -7664,14 +7630,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -7717,7 +7683,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].createDocumentType(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].createDocumentType(...args));
     }
 
     createDocument(namespace, qualifiedName) {
@@ -7766,7 +7732,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].createDocument(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].createDocument(...args));
     }
 
     createHTMLDocument() {
@@ -7784,7 +7750,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].createHTMLDocument(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].createHTMLDocument(...args));
     }
 
     hasFeature() {
@@ -7793,7 +7759,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].hasFeature();
+      return esValue[implSymbol].hasFeature();
     }
   }
   Object.defineProperties(DOMImplementation.prototype, {
@@ -7803,10 +7769,10 @@ exports.install = function install(globalObject) {
     hasFeature: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"DOMImplementation\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = DOMImplementation;
+  globalObject[ctorRegistrySymbol][interfaceName] = DOMImplementation;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -7904,13 +7870,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const Dictionary = require(\\"./Dictionary.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"DictionaryConvert\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -7923,11 +7888,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"DictionaryConvert\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"DictionaryConvert\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor DictionaryConvert is not installed on the passed global object\\");
   }
@@ -7945,14 +7910,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -7983,17 +7948,17 @@ exports.install = function install(globalObject) {
         curArg = Dictionary.convert(curArg, { context: \\"Failed to execute 'op' on 'DictionaryConvert': parameter 2\\" });
         args.push(curArg);
       }
-      return esValue[impl].op(...args);
+      return esValue[implSymbol].op(...args);
     }
   }
   Object.defineProperties(DictionaryConvert.prototype, {
     op: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"DictionaryConvert\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = DictionaryConvert;
+  globalObject[ctorRegistrySymbol][interfaceName] = DictionaryConvert;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -8013,13 +7978,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const RequestDestination = require(\\"./RequestDestination.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Enum\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -8032,11 +7996,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Enum\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Enum\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Enum is not installed on the passed global object\\");
   }
@@ -8054,14 +8018,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -8089,7 +8053,7 @@ exports.install = function install(globalObject) {
         curArg = RequestDestination.convert(curArg, { context: \\"Failed to execute 'op' on 'Enum': parameter 1\\" });
         args.push(curArg);
       }
-      return esValue[impl].op(...args);
+      return esValue[implSymbol].op(...args);
     }
 
     get attr() {
@@ -8099,7 +8063,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return utils.tryWrapperForImpl(esValue[impl][\\"attr\\"]);
+      return utils.tryWrapperForImpl(esValue[implSymbol][\\"attr\\"]);
     }
 
     set attr(V) {
@@ -8114,7 +8078,7 @@ exports.install = function install(globalObject) {
         return;
       }
 
-      esValue[impl][\\"attr\\"] = V;
+      esValue[implSymbol][\\"attr\\"] = V;
     }
   }
   Object.defineProperties(Enum.prototype, {
@@ -8122,10 +8086,10 @@ exports.install = function install(globalObject) {
     attr: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"Enum\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Enum;
+  globalObject[ctorRegistrySymbol][interfaceName] = Enum;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -8144,13 +8108,12 @@ exports[`without processors Global.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Global\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -8163,11 +8126,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Global\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Global\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Global is not installed on the passed global object\\");
   }
@@ -8190,7 +8153,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl].op();
+        return esValue[implSymbol].op();
       },
       unforgeableOp() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -8198,7 +8161,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl].unforgeableOp();
+        return esValue[implSymbol].unforgeableOp();
       },
       get attr() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -8207,7 +8170,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"attr\\"];
+        return esValue[implSymbol][\\"attr\\"];
       },
       set attr(V) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -8220,7 +8183,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           context: \\"Failed to set the 'attr' property on 'Global': The provided value\\"
         });
 
-        esValue[impl][\\"attr\\"] = V;
+        esValue[implSymbol][\\"attr\\"] = V;
       },
       get unforgeableAttr() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -8229,7 +8192,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"unforgeableAttr\\"];
+        return esValue[implSymbol][\\"unforgeableAttr\\"];
       },
       set unforgeableAttr(V) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -8242,7 +8205,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           context: \\"Failed to set the 'unforgeableAttr' property on 'Global': The provided value\\"
         });
 
-        esValue[impl][\\"unforgeableAttr\\"] = V;
+        esValue[implSymbol][\\"unforgeableAttr\\"] = V;
       },
       get length() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -8251,7 +8214,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"length\\"];
+        return esValue[implSymbol][\\"length\\"];
       },
       set length(V) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -8264,7 +8227,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           context: \\"Failed to set the 'length' property on 'Global': The provided value\\"
         });
 
-        esValue[impl][\\"length\\"] = V;
+        esValue[implSymbol][\\"length\\"] = V;
       },
       [Symbol.iterator]: Array.prototype[Symbol.iterator],
       keys: Array.prototype.keys,
@@ -8284,14 +8247,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -8320,10 +8283,10 @@ exports.install = function install(globalObject) {
   }
   Object.defineProperties(Global.prototype, { [Symbol.toStringTag]: { value: \\"Global\\", configurable: true } });
   Object.defineProperties(Global, { staticOp: { enumerable: true }, staticAttr: { enumerable: true } });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Global;
+  globalObject[ctorRegistrySymbol][interfaceName] = Global;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -8342,13 +8305,12 @@ exports[`without processors HTMLConstructor.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"HTMLConstructor\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -8361,11 +8323,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"HTMLConstructor\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"HTMLConstructor\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor HTMLConstructor is not installed on the passed global object\\");
   }
@@ -8383,14 +8345,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -8404,10 +8366,10 @@ exports.install = function install(globalObject) {
   Object.defineProperties(HTMLConstructor.prototype, {
     [Symbol.toStringTag]: { value: \\"HTMLConstructor\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = HTMLConstructor;
+  globalObject[ctorRegistrySymbol][interfaceName] = HTMLConstructor;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -8426,13 +8388,12 @@ exports[`without processors LegacyArrayClass.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"LegacyArrayClass\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -8445,11 +8406,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"LegacyArrayClass\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"LegacyArrayClass\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor LegacyArrayClass is not installed on the passed global object\\");
   }
@@ -8467,14 +8428,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -8492,7 +8453,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"length\\"];
+      return esValue[implSymbol][\\"length\\"];
     }
   }
   Object.setPrototypeOf(LegacyArrayClass.prototype, Array.prototype);
@@ -8500,10 +8461,10 @@ exports.install = function install(globalObject) {
     length: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"LegacyArrayClass\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = LegacyArrayClass;
+  globalObject[ctorRegistrySymbol][interfaceName] = LegacyArrayClass;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -8522,13 +8483,12 @@ exports[`without processors MixedIn.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"MixedIn\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -8541,11 +8501,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"MixedIn\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"MixedIn\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor MixedIn is not installed on the passed global object\\");
   }
@@ -8563,14 +8523,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -8587,7 +8547,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].mixedInOp();
+      return esValue[implSymbol].mixedInOp();
     }
 
     ifaceMixinOp() {
@@ -8596,7 +8556,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].ifaceMixinOp();
+      return esValue[implSymbol].ifaceMixinOp();
     }
 
     get mixedInAttr() {
@@ -8606,7 +8566,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"mixedInAttr\\"];
+      return esValue[implSymbol][\\"mixedInAttr\\"];
     }
 
     set mixedInAttr(V) {
@@ -8620,7 +8580,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'mixedInAttr' property on 'MixedIn': The provided value\\"
       });
 
-      esValue[impl][\\"mixedInAttr\\"] = V;
+      esValue[implSymbol][\\"mixedInAttr\\"] = V;
     }
 
     get ifaceMixinAttr() {
@@ -8630,7 +8590,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"ifaceMixinAttr\\"];
+      return esValue[implSymbol][\\"ifaceMixinAttr\\"];
     }
 
     set ifaceMixinAttr(V) {
@@ -8644,7 +8604,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'ifaceMixinAttr' property on 'MixedIn': The provided value\\"
       });
 
-      esValue[impl][\\"ifaceMixinAttr\\"] = V;
+      esValue[implSymbol][\\"ifaceMixinAttr\\"] = V;
     }
   }
   Object.defineProperties(MixedIn.prototype, {
@@ -8660,10 +8620,10 @@ exports.install = function install(globalObject) {
     mixedInConst: { value: 43, enumerable: true },
     ifaceMixinConst: { value: 42, enumerable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = MixedIn;
+  globalObject[ctorRegistrySymbol][interfaceName] = MixedIn;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -8683,13 +8643,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Overloads\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -8702,11 +8661,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Overloads\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Overloads\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Overloads is not installed on the passed global object\\");
   }
@@ -8724,14 +8683,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -8830,7 +8789,7 @@ exports.install = function install(globalObject) {
             args.push(curArg);
           }
       }
-      return utils.tryWrapperForImpl(esValue[impl].compatible(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].compatible(...args));
     }
 
     incompatible1(arg1) {
@@ -8867,7 +8826,7 @@ exports.install = function install(globalObject) {
           }
         }
       }
-      return esValue[impl].incompatible1(...args);
+      return esValue[implSymbol].incompatible1(...args);
     }
 
     incompatible2(arg1) {
@@ -8910,7 +8869,7 @@ exports.install = function install(globalObject) {
             args.push(curArg);
           }
       }
-      return esValue[impl].incompatible2(...args);
+      return esValue[implSymbol].incompatible2(...args);
     }
 
     incompatible3(arg1) {
@@ -9045,7 +9004,7 @@ exports.install = function install(globalObject) {
             args.push(curArg);
           }
       }
-      return esValue[impl].incompatible3(...args);
+      return esValue[implSymbol].incompatible3(...args);
     }
   }
   Object.defineProperties(Overloads.prototype, {
@@ -9055,10 +9014,10 @@ exports.install = function install(globalObject) {
     incompatible3: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"Overloads\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Overloads;
+  globalObject[ctorRegistrySymbol][interfaceName] = Overloads;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -9077,13 +9036,12 @@ exports[`without processors PromiseTypes.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"PromiseTypes\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -9096,11 +9054,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"PromiseTypes\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"PromiseTypes\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor PromiseTypes is not installed on the passed global object\\");
   }
@@ -9118,14 +9076,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -9158,7 +9116,7 @@ exports.install = function install(globalObject) {
         );
         args.push(curArg);
       }
-      return esValue[impl].voidPromiseConsumer(...args);
+      return esValue[implSymbol].voidPromiseConsumer(...args);
     }
 
     promiseConsumer(p) {
@@ -9189,7 +9147,7 @@ exports.install = function install(globalObject) {
         );
         args.push(curArg);
       }
-      return esValue[impl].promiseConsumer(...args);
+      return esValue[implSymbol].promiseConsumer(...args);
     }
   }
   Object.defineProperties(PromiseTypes.prototype, {
@@ -9197,10 +9155,10 @@ exports.install = function install(globalObject) {
     promiseConsumer: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"PromiseTypes\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = PromiseTypes;
+  globalObject[ctorRegistrySymbol][interfaceName] = PromiseTypes;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -9219,13 +9177,12 @@ exports[`without processors Reflect.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Reflect\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -9238,11 +9195,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Reflect\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Reflect\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Reflect is not installed on the passed global object\\");
   }
@@ -9260,14 +9217,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -9285,7 +9242,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"reflectedBoolean\\"];
+      return esValue[implSymbol][\\"reflectedBoolean\\"];
     }
 
     set reflectedBoolean(V) {
@@ -9299,7 +9256,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectedBoolean' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl][\\"reflectedBoolean\\"] = V;
+      esValue[implSymbol][\\"reflectedBoolean\\"] = V;
     }
 
     get reflectedDOMString() {
@@ -9309,7 +9266,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"reflectedDOMString\\"];
+      return esValue[implSymbol][\\"reflectedDOMString\\"];
     }
 
     set reflectedDOMString(V) {
@@ -9323,7 +9280,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectedDOMString' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl][\\"reflectedDOMString\\"] = V;
+      esValue[implSymbol][\\"reflectedDOMString\\"] = V;
     }
 
     get reflectedLong() {
@@ -9333,7 +9290,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"reflectedLong\\"];
+      return esValue[implSymbol][\\"reflectedLong\\"];
     }
 
     set reflectedLong(V) {
@@ -9347,7 +9304,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectedLong' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl][\\"reflectedLong\\"] = V;
+      esValue[implSymbol][\\"reflectedLong\\"] = V;
     }
 
     get reflectedUnsignedLong() {
@@ -9357,7 +9314,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"reflectedUnsignedLong\\"];
+      return esValue[implSymbol][\\"reflectedUnsignedLong\\"];
     }
 
     set reflectedUnsignedLong(V) {
@@ -9371,7 +9328,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectedUnsignedLong' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl][\\"reflectedUnsignedLong\\"] = V;
+      esValue[implSymbol][\\"reflectedUnsignedLong\\"] = V;
     }
 
     get reflectedUSVStringURL() {
@@ -9381,7 +9338,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"reflectedUSVStringURL\\"];
+      return esValue[implSymbol][\\"reflectedUSVStringURL\\"];
     }
 
     set reflectedUSVStringURL(V) {
@@ -9395,7 +9352,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectedUSVStringURL' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl][\\"reflectedUSVStringURL\\"] = V;
+      esValue[implSymbol][\\"reflectedUSVStringURL\\"] = V;
     }
 
     get reflectionTest() {
@@ -9405,7 +9362,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"reflectionTest\\"];
+      return esValue[implSymbol][\\"reflectionTest\\"];
     }
 
     set reflectionTest(V) {
@@ -9419,7 +9376,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectionTest' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl][\\"reflectionTest\\"] = V;
+      esValue[implSymbol][\\"reflectionTest\\"] = V;
     }
 
     get withUnderscore() {
@@ -9429,7 +9386,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"withUnderscore\\"];
+      return esValue[implSymbol][\\"withUnderscore\\"];
     }
 
     set withUnderscore(V) {
@@ -9443,7 +9400,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'withUnderscore' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl][\\"withUnderscore\\"] = V;
+      esValue[implSymbol][\\"withUnderscore\\"] = V;
     }
   }
   Object.defineProperties(Reflect.prototype, {
@@ -9456,10 +9413,10 @@ exports.install = function install(globalObject) {
     withUnderscore: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"Reflect\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Reflect;
+  globalObject[ctorRegistrySymbol][interfaceName] = Reflect;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -9512,13 +9469,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"SeqAndRec\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -9531,11 +9487,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"SeqAndRec\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"SeqAndRec\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor SeqAndRec is not installed on the passed global object\\");
   }
@@ -9553,14 +9509,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -9613,7 +9569,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].recordConsumer(...args);
+      return esValue[implSymbol].recordConsumer(...args);
     }
 
     recordConsumer2(rec) {
@@ -9658,7 +9614,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].recordConsumer2(...args);
+      return esValue[implSymbol].recordConsumer2(...args);
     }
 
     sequenceConsumer(seq) {
@@ -9695,7 +9651,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].sequenceConsumer(...args);
+      return esValue[implSymbol].sequenceConsumer(...args);
     }
 
     sequenceConsumer2(seq) {
@@ -9730,7 +9686,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].sequenceConsumer2(...args);
+      return esValue[implSymbol].sequenceConsumer2(...args);
     }
 
     frozenArrayConsumer(arr) {
@@ -9768,7 +9724,7 @@ exports.install = function install(globalObject) {
         curArg = Object.freeze(curArg);
         args.push(curArg);
       }
-      return esValue[impl].frozenArrayConsumer(...args);
+      return esValue[implSymbol].frozenArrayConsumer(...args);
     }
   }
   Object.defineProperties(SeqAndRec.prototype, {
@@ -9779,10 +9735,10 @@ exports.install = function install(globalObject) {
     frozenArrayConsumer: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"SeqAndRec\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = SeqAndRec;
+  globalObject[ctorRegistrySymbol][interfaceName] = SeqAndRec;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -9801,13 +9757,12 @@ exports[`without processors Static.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Static\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -9820,11 +9775,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Static\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Static\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Static is not installed on the passed global object\\");
   }
@@ -9842,14 +9797,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -9866,7 +9821,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].def();
+      return esValue[implSymbol].def();
     }
 
     get abc() {
@@ -9876,7 +9831,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"abc\\"];
+      return esValue[implSymbol][\\"abc\\"];
     }
 
     set abc(V) {
@@ -9888,7 +9843,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"DOMString\\"](V, { context: \\"Failed to set the 'abc' property on 'Static': The provided value\\" });
 
-      esValue[impl][\\"abc\\"] = V;
+      esValue[implSymbol][\\"abc\\"] = V;
     }
 
     static def() {
@@ -9913,10 +9868,10 @@ exports.install = function install(globalObject) {
     [Symbol.toStringTag]: { value: \\"Static\\", configurable: true }
   });
   Object.defineProperties(Static, { def: { enumerable: true }, abc: { enumerable: true } });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Static;
+  globalObject[ctorRegistrySymbol][interfaceName] = Static;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -9935,13 +9890,12 @@ exports[`without processors Storage.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Storage\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -9954,11 +9908,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Storage\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Storage\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Storage is not installed on the passed global object\\");
   }
@@ -9976,16 +9930,16 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
   obj = new Proxy(obj, proxyHandler);
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -10013,7 +9967,7 @@ exports.install = function install(globalObject) {
         curArg = conversions[\\"unsigned long\\"](curArg, { context: \\"Failed to execute 'key' on 'Storage': parameter 1\\" });
         args.push(curArg);
       }
-      return esValue[impl].key(...args);
+      return esValue[implSymbol].key(...args);
     }
 
     getItem(key) {
@@ -10033,7 +9987,7 @@ exports.install = function install(globalObject) {
         curArg = conversions[\\"DOMString\\"](curArg, { context: \\"Failed to execute 'getItem' on 'Storage': parameter 1\\" });
         args.push(curArg);
       }
-      return esValue[impl].getItem(...args);
+      return esValue[implSymbol].getItem(...args);
     }
 
     setItem(key, value) {
@@ -10058,7 +10012,7 @@ exports.install = function install(globalObject) {
         curArg = conversions[\\"DOMString\\"](curArg, { context: \\"Failed to execute 'setItem' on 'Storage': parameter 2\\" });
         args.push(curArg);
       }
-      return esValue[impl].setItem(...args);
+      return esValue[implSymbol].setItem(...args);
     }
 
     removeItem(key) {
@@ -10080,7 +10034,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].removeItem(...args);
+      return esValue[implSymbol].removeItem(...args);
     }
 
     clear() {
@@ -10089,7 +10043,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].clear();
+      return esValue[implSymbol].clear();
     }
 
     get length() {
@@ -10099,7 +10053,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"length\\"];
+      return esValue[implSymbol][\\"length\\"];
     }
   }
   Object.defineProperties(Storage.prototype, {
@@ -10111,10 +10065,10 @@ exports.install = function install(globalObject) {
     length: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"Storage\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Storage;
+  globalObject[ctorRegistrySymbol][interfaceName] = Storage;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -10164,7 +10118,7 @@ const proxyHandler = {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyNames]) {
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
       if (!(key in target)) {
         keys.add(\`\${key}\`);
       }
@@ -10182,8 +10136,8 @@ const proxyHandler = {
     }
     let ignoreNamedProps = false;
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-      const namedValue = target[impl].getItem(P);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+      const namedValue = target[implSymbol].getItem(P);
 
       return {
         writable: true,
@@ -10208,7 +10162,7 @@ const proxyHandler = {
           context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
         });
 
-        target[impl].setItem(P, namedValue);
+        target[implSymbol].setItem(P, namedValue);
 
         return true;
       }
@@ -10262,7 +10216,7 @@ const proxyHandler = {
         context: \\"Failed to set the '\\" + P + \\"' property on 'Storage': The provided value\\"
       });
 
-      target[impl].setItem(P, namedValue);
+      target[implSymbol].setItem(P, namedValue);
 
       return true;
     }
@@ -10274,8 +10228,8 @@ const proxyHandler = {
       return Reflect.deleteProperty(target, P);
     }
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
-      target[impl].removeItem(P);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      target[implSymbol].removeItem(P);
       return true;
     }
 
@@ -10297,13 +10251,12 @@ exports[`without processors StringifierAttribute.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"StringifierAttribute\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -10316,11 +10269,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"StringifierAttribute\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"StringifierAttribute\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor StringifierAttribute is not installed on the passed global object\\");
   }
@@ -10338,14 +10291,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -10363,7 +10316,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"attr\\"];
+      return esValue[implSymbol][\\"attr\\"];
     }
 
     toString() {
@@ -10372,7 +10325,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"attr\\"];
+      return esValue[implSymbol][\\"attr\\"];
     }
   }
   Object.defineProperties(StringifierAttribute.prototype, {
@@ -10380,10 +10333,10 @@ exports.install = function install(globalObject) {
     toString: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"StringifierAttribute\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = StringifierAttribute;
+  globalObject[ctorRegistrySymbol][interfaceName] = StringifierAttribute;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -10402,13 +10355,12 @@ exports[`without processors StringifierDefaultOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"StringifierDefaultOperation\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -10421,11 +10373,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"StringifierDefaultOperation\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"StringifierDefaultOperation\\"];
   if (ctor === undefined) {
     throw new Error(
       \\"Internal error: constructor StringifierDefaultOperation is not installed on the passed global object\\"
@@ -10445,14 +10397,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -10469,17 +10421,17 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].toString();
+      return esValue[implSymbol].toString();
     }
   }
   Object.defineProperties(StringifierDefaultOperation.prototype, {
     toString: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"StringifierDefaultOperation\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = StringifierDefaultOperation;
+  globalObject[ctorRegistrySymbol][interfaceName] = StringifierDefaultOperation;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -10498,13 +10450,12 @@ exports[`without processors StringifierNamedOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"StringifierNamedOperation\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -10517,11 +10468,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"StringifierNamedOperation\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"StringifierNamedOperation\\"];
   if (ctor === undefined) {
     throw new Error(
       \\"Internal error: constructor StringifierNamedOperation is not installed on the passed global object\\"
@@ -10541,14 +10492,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -10565,7 +10516,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].operation();
+      return esValue[implSymbol].operation();
     }
 
     toString() {
@@ -10574,7 +10525,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].operation();
+      return esValue[implSymbol].operation();
     }
   }
   Object.defineProperties(StringifierNamedOperation.prototype, {
@@ -10582,10 +10533,10 @@ exports.install = function install(globalObject) {
     toString: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"StringifierNamedOperation\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = StringifierNamedOperation;
+  globalObject[ctorRegistrySymbol][interfaceName] = StringifierNamedOperation;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -10604,13 +10555,12 @@ exports[`without processors StringifierOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"StringifierOperation\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -10623,11 +10573,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"StringifierOperation\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"StringifierOperation\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor StringifierOperation is not installed on the passed global object\\");
   }
@@ -10645,14 +10595,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -10669,17 +10619,17 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].toString();
+      return esValue[implSymbol].toString();
     }
   }
   Object.defineProperties(StringifierOperation.prototype, {
     toString: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"StringifierOperation\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = StringifierOperation;
+  globalObject[ctorRegistrySymbol][interfaceName] = StringifierOperation;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -10700,13 +10650,12 @@ const utils = require(\\"./utils.js\\");
 
 const RequestDestination = require(\\"./RequestDestination.js\\");
 const URL = require(\\"./URL.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"TypedefsAndUnions\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -10719,11 +10668,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"TypedefsAndUnions\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"TypedefsAndUnions\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor TypedefsAndUnions is not installed on the passed global object\\");
   }
@@ -10741,14 +10690,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -10787,7 +10736,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].numOrStrConsumer(...args);
+      return esValue[implSymbol].numOrStrConsumer(...args);
     }
 
     numOrEnumConsumer(a) {
@@ -10821,7 +10770,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].numOrEnumConsumer(...args);
+      return esValue[implSymbol].numOrEnumConsumer(...args);
     }
 
     numOrStrOrNullConsumer(a) {
@@ -10858,7 +10807,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].numOrStrOrNullConsumer(...args);
+      return esValue[implSymbol].numOrStrOrNullConsumer(...args);
     }
 
     numOrStrOrURLOrNullConsumer(a) {
@@ -10897,7 +10846,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].numOrStrOrURLOrNullConsumer(...args);
+      return esValue[implSymbol].numOrStrOrURLOrNullConsumer(...args);
     }
 
     urlMapInnerConsumer(a) {
@@ -10944,7 +10893,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].urlMapInnerConsumer(...args);
+      return esValue[implSymbol].urlMapInnerConsumer(...args);
     }
 
     urlMapConsumer(a) {
@@ -10995,7 +10944,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].urlMapConsumer(...args);
+      return esValue[implSymbol].urlMapConsumer(...args);
     }
 
     bufferSourceOrURLConsumer(b) {
@@ -11026,7 +10975,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].bufferSourceOrURLConsumer(...args);
+      return esValue[implSymbol].bufferSourceOrURLConsumer(...args);
     }
 
     arrayBufferViewOrURLMapConsumer(b) {
@@ -11093,7 +11042,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].arrayBufferViewOrURLMapConsumer(...args);
+      return esValue[implSymbol].arrayBufferViewOrURLMapConsumer(...args);
     }
 
     arrayBufferViewDupConsumer(b) {
@@ -11121,7 +11070,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].arrayBufferViewDupConsumer(...args);
+      return esValue[implSymbol].arrayBufferViewDupConsumer(...args);
     }
 
     get buf() {
@@ -11131,7 +11080,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return utils.tryWrapperForImpl(esValue[impl][\\"buf\\"]);
+      return utils.tryWrapperForImpl(esValue[implSymbol][\\"buf\\"]);
     }
 
     set buf(V) {
@@ -11152,7 +11101,7 @@ exports.install = function install(globalObject) {
             \\" is not of any supported type.\\"
         );
       }
-      esValue[impl][\\"buf\\"] = V;
+      esValue[implSymbol][\\"buf\\"] = V;
     }
 
     get time() {
@@ -11162,7 +11111,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"time\\"];
+      return esValue[implSymbol][\\"time\\"];
     }
 
     set time(V) {
@@ -11176,7 +11125,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'time' property on 'TypedefsAndUnions': The provided value\\"
       });
 
-      esValue[impl][\\"time\\"] = V;
+      esValue[implSymbol][\\"time\\"] = V;
     }
   }
   Object.defineProperties(TypedefsAndUnions.prototype, {
@@ -11193,10 +11142,10 @@ exports.install = function install(globalObject) {
     time: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"TypedefsAndUnions\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = TypedefsAndUnions;
+  globalObject[ctorRegistrySymbol][interfaceName] = TypedefsAndUnions;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -11215,13 +11164,12 @@ exports[`without processors URL.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"URL\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -11234,11 +11182,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"URL\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"URL\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor URL is not installed on the passed global object\\");
   }
@@ -11256,14 +11204,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -11298,7 +11246,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].toJSON();
+      return esValue[implSymbol].toJSON();
     }
 
     get href() {
@@ -11308,7 +11256,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"href\\"];
+      return esValue[implSymbol][\\"href\\"];
     }
 
     set href(V) {
@@ -11320,7 +11268,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'href' property on 'URL': The provided value\\" });
 
-      esValue[impl][\\"href\\"] = V;
+      esValue[implSymbol][\\"href\\"] = V;
     }
 
     toString() {
@@ -11329,7 +11277,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"href\\"];
+      return esValue[implSymbol][\\"href\\"];
     }
 
     get origin() {
@@ -11339,7 +11287,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"origin\\"];
+      return esValue[implSymbol][\\"origin\\"];
     }
 
     get protocol() {
@@ -11349,7 +11297,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"protocol\\"];
+      return esValue[implSymbol][\\"protocol\\"];
     }
 
     set protocol(V) {
@@ -11363,7 +11311,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'protocol' property on 'URL': The provided value\\"
       });
 
-      esValue[impl][\\"protocol\\"] = V;
+      esValue[implSymbol][\\"protocol\\"] = V;
     }
 
     get username() {
@@ -11373,7 +11321,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"username\\"];
+      return esValue[implSymbol][\\"username\\"];
     }
 
     set username(V) {
@@ -11387,7 +11335,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'username' property on 'URL': The provided value\\"
       });
 
-      esValue[impl][\\"username\\"] = V;
+      esValue[implSymbol][\\"username\\"] = V;
     }
 
     get password() {
@@ -11397,7 +11345,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"password\\"];
+      return esValue[implSymbol][\\"password\\"];
     }
 
     set password(V) {
@@ -11411,7 +11359,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'password' property on 'URL': The provided value\\"
       });
 
-      esValue[impl][\\"password\\"] = V;
+      esValue[implSymbol][\\"password\\"] = V;
     }
 
     get host() {
@@ -11421,7 +11369,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"host\\"];
+      return esValue[implSymbol][\\"host\\"];
     }
 
     set host(V) {
@@ -11433,7 +11381,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'host' property on 'URL': The provided value\\" });
 
-      esValue[impl][\\"host\\"] = V;
+      esValue[implSymbol][\\"host\\"] = V;
     }
 
     get hostname() {
@@ -11443,7 +11391,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"hostname\\"];
+      return esValue[implSymbol][\\"hostname\\"];
     }
 
     set hostname(V) {
@@ -11457,7 +11405,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'hostname' property on 'URL': The provided value\\"
       });
 
-      esValue[impl][\\"hostname\\"] = V;
+      esValue[implSymbol][\\"hostname\\"] = V;
     }
 
     get port() {
@@ -11467,7 +11415,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"port\\"];
+      return esValue[implSymbol][\\"port\\"];
     }
 
     set port(V) {
@@ -11479,7 +11427,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'port' property on 'URL': The provided value\\" });
 
-      esValue[impl][\\"port\\"] = V;
+      esValue[implSymbol][\\"port\\"] = V;
     }
 
     get pathname() {
@@ -11489,7 +11437,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"pathname\\"];
+      return esValue[implSymbol][\\"pathname\\"];
     }
 
     set pathname(V) {
@@ -11503,7 +11451,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'pathname' property on 'URL': The provided value\\"
       });
 
-      esValue[impl][\\"pathname\\"] = V;
+      esValue[implSymbol][\\"pathname\\"] = V;
     }
 
     get search() {
@@ -11513,7 +11461,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"search\\"];
+      return esValue[implSymbol][\\"search\\"];
     }
 
     set search(V) {
@@ -11525,7 +11473,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'search' property on 'URL': The provided value\\" });
 
-      esValue[impl][\\"search\\"] = V;
+      esValue[implSymbol][\\"search\\"] = V;
     }
 
     get searchParams() {
@@ -11536,7 +11484,7 @@ exports.install = function install(globalObject) {
       }
 
       return utils.getSameObject(this, \\"searchParams\\", () => {
-        return utils.tryWrapperForImpl(esValue[impl][\\"searchParams\\"]);
+        return utils.tryWrapperForImpl(esValue[implSymbol][\\"searchParams\\"]);
       });
     }
 
@@ -11547,7 +11495,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"hash\\"];
+      return esValue[implSymbol][\\"hash\\"];
     }
 
     set hash(V) {
@@ -11559,7 +11507,7 @@ exports.install = function install(globalObject) {
 
       V = conversions[\\"USVString\\"](V, { context: \\"Failed to set the 'hash' property on 'URL': The provided value\\" });
 
-      esValue[impl][\\"hash\\"] = V;
+      esValue[implSymbol][\\"hash\\"] = V;
     }
   }
   Object.defineProperties(URL.prototype, {
@@ -11579,10 +11527,10 @@ exports.install = function install(globalObject) {
     hash: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"URL\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = URL;
+  globalObject[ctorRegistrySymbol][interfaceName] = URL;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -11601,13 +11549,12 @@ exports[`without processors URLList.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"URLList\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -11620,11 +11567,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"URLList\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"URLList\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor URLList is not installed on the passed global object\\");
   }
@@ -11642,16 +11589,16 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
   obj = new Proxy(obj, proxyHandler);
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -11681,7 +11628,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].item(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].item(...args));
     }
 
     get length() {
@@ -11691,7 +11638,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"length\\"];
+      return esValue[implSymbol][\\"length\\"];
     }
   }
   Object.defineProperties(URLList.prototype, {
@@ -11704,10 +11651,10 @@ exports.install = function install(globalObject) {
     entries: { value: Array.prototype.entries, configurable: true, enumerable: true, writable: true },
     forEach: { value: Array.prototype.forEach, configurable: true, enumerable: true, writable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = URLList;
+  globalObject[ctorRegistrySymbol][interfaceName] = URLList;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -11757,7 +11704,7 @@ const proxyHandler = {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyIndices]) {
+    for (const key of target[implSymbol][utils.supportedPropertyIndices]) {
       keys.add(\`\${key}\`);
     }
 
@@ -11776,8 +11723,8 @@ const proxyHandler = {
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
 
-      if (target[impl][utils.supportsPropertyIndex](index)) {
-        const indexedValue = target[impl].item(index);
+      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
+        const indexedValue = target[implSymbol].item(index);
         return {
           writable: false,
           enumerable: true,
@@ -11803,8 +11750,8 @@ const proxyHandler = {
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
 
-      if (target[impl][utils.supportsPropertyIndex](index)) {
-        const indexedValue = target[impl].item(index);
+      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
+        const indexedValue = target[implSymbol].item(index);
         ownDesc = {
           writable: false,
           enumerable: true,
@@ -11865,7 +11812,7 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      return !target[impl][utils.supportsPropertyIndex](index);
+      return !target[implSymbol][utils.supportsPropertyIndex](index);
     }
 
     return Reflect.deleteProperty(target, P);
@@ -11886,8 +11833,7 @@ exports[`without processors URLSearchParams.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"URLSearchParams\\";
 
@@ -11896,7 +11842,7 @@ const IteratorPrototype = Object.create(utils.IteratorPrototype, {
     value: function next() {
       const internal = this[utils.iterInternalSymbol];
       const { target, kind, index } = internal;
-      const values = Array.from(target[impl]);
+      const values = Array.from(target[implSymbol]);
       const len = values.length;
       if (index >= len) {
         return { value: undefined, done: true };
@@ -11931,7 +11877,7 @@ const IteratorPrototype = Object.create(utils.IteratorPrototype, {
 });
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -11953,11 +11899,11 @@ exports.createDefaultIterator = function createDefaultIterator(target, kind) {
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"URLSearchParams\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"URLSearchParams\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor URLSearchParams is not installed on the passed global object\\");
   }
@@ -11975,14 +11921,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -12101,7 +12047,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].append(...args);
+      return esValue[implSymbol].append(...args);
     }
 
     delete(name) {
@@ -12125,7 +12071,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].delete(...args);
+      return esValue[implSymbol].delete(...args);
     }
 
     get(name) {
@@ -12149,7 +12095,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].get(...args);
+      return esValue[implSymbol].get(...args);
     }
 
     getAll(name) {
@@ -12173,7 +12119,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].getAll(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].getAll(...args));
     }
 
     has(name) {
@@ -12197,7 +12143,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].has(...args);
+      return esValue[implSymbol].has(...args);
     }
 
     set(name, value) {
@@ -12228,7 +12174,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].set(...args);
+      return esValue[implSymbol].set(...args);
     }
 
     sort() {
@@ -12237,7 +12183,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].sort();
+      return esValue[implSymbol].sort();
     }
 
     toString() {
@@ -12246,7 +12192,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].toString();
+      return esValue[implSymbol].toString();
     }
 
     keys() {
@@ -12283,12 +12229,12 @@ exports.install = function install(globalObject) {
         );
       }
       const thisArg = arguments[1];
-      let pairs = Array.from(this[impl]);
+      let pairs = Array.from(this[implSymbol]);
       let i = 0;
       while (i < pairs.length) {
         const [key, value] = pairs[i].map(utils.tryWrapperForImpl);
         callback.call(thisArg, value, key, this);
-        pairs = Array.from(this[impl]);
+        pairs = Array.from(this[implSymbol]);
         i++;
       }
     }
@@ -12309,10 +12255,10 @@ exports.install = function install(globalObject) {
     [Symbol.toStringTag]: { value: \\"URLSearchParams\\", configurable: true },
     [Symbol.iterator]: { value: URLSearchParams.prototype.entries, configurable: true, writable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = URLSearchParams;
+  globalObject[ctorRegistrySymbol][interfaceName] = URLSearchParams;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -12331,13 +12277,12 @@ exports[`without processors URLSearchParamsCollection.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"URLSearchParamsCollection\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -12350,11 +12295,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"URLSearchParamsCollection\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"URLSearchParamsCollection\\"];
   if (ctor === undefined) {
     throw new Error(
       \\"Internal error: constructor URLSearchParamsCollection is not installed on the passed global object\\"
@@ -12374,16 +12319,16 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
   obj = new Proxy(obj, proxyHandler);
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -12415,7 +12360,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].item(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].item(...args));
     }
 
     namedItem(name) {
@@ -12439,7 +12384,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(esValue[impl].namedItem(...args));
+      return utils.tryWrapperForImpl(esValue[implSymbol].namedItem(...args));
     }
 
     get length() {
@@ -12449,7 +12394,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"length\\"];
+      return esValue[implSymbol][\\"length\\"];
     }
   }
   Object.defineProperties(URLSearchParamsCollection.prototype, {
@@ -12459,10 +12404,10 @@ exports.install = function install(globalObject) {
     [Symbol.toStringTag]: { value: \\"URLSearchParamsCollection\\", configurable: true },
     [Symbol.iterator]: { value: Array.prototype[Symbol.iterator], configurable: true, writable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = URLSearchParamsCollection;
+  globalObject[ctorRegistrySymbol][interfaceName] = URLSearchParamsCollection;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -12512,11 +12457,11 @@ const proxyHandler = {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyIndices]) {
+    for (const key of target[implSymbol][utils.supportedPropertyIndices]) {
       keys.add(\`\${key}\`);
     }
 
-    for (const key of target[impl][utils.supportedPropertyNames]) {
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
       if (!(key in target)) {
         keys.add(\`\${key}\`);
       }
@@ -12536,7 +12481,7 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      const indexedValue = target[impl].item(index);
+      const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         return {
           writable: false,
@@ -12548,7 +12493,7 @@ const proxyHandler = {
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[impl].namedItem(P);
+    const namedValue = target[implSymbol].namedItem(P);
 
     if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
       return {
@@ -12575,7 +12520,7 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      const indexedValue = target[impl].item(index);
+      const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         ownDesc = {
           writable: false,
@@ -12627,7 +12572,7 @@ const proxyHandler = {
       return false;
     }
     if (!utils.hasOwn(target, P)) {
-      const creating = !(target[impl].namedItem(P) !== null);
+      const creating = !(target[implSymbol].namedItem(P) !== null);
       if (!creating) {
         return false;
       }
@@ -12642,10 +12587,10 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      return !(target[impl].item(index) !== undefined);
+      return !(target[implSymbol].item(index) !== undefined);
     }
 
-    if (target[impl].namedItem(P) !== null && !(P in target)) {
+    if (target[implSymbol].namedItem(P) !== null && !(P in target)) {
       return false;
     }
 
@@ -12668,14 +12613,13 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 const URLSearchParamsCollection = require(\\"./URLSearchParamsCollection.js\\");
 
 const interfaceName = \\"URLSearchParamsCollection2\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -12688,11 +12632,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"URLSearchParamsCollection2\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"URLSearchParamsCollection2\\"];
   if (ctor === undefined) {
     throw new Error(
       \\"Internal error: constructor URLSearchParamsCollection2 is not installed on the passed global object\\"
@@ -12714,16 +12658,16 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
   obj = new Proxy(obj, proxyHandler);
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -12743,10 +12687,10 @@ exports.install = function install(globalObject) {
     [Symbol.toStringTag]: { value: \\"URLSearchParamsCollection2\\", configurable: true },
     [Symbol.iterator]: { value: Array.prototype[Symbol.iterator], configurable: true, writable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = URLSearchParamsCollection2;
+  globalObject[ctorRegistrySymbol][interfaceName] = URLSearchParamsCollection2;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -12796,11 +12740,11 @@ const proxyHandler = {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyIndices]) {
+    for (const key of target[implSymbol][utils.supportedPropertyIndices]) {
       keys.add(\`\${key}\`);
     }
 
-    for (const key of target[impl][utils.supportedPropertyNames]) {
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
       if (!(key in target)) {
         keys.add(\`\${key}\`);
       }
@@ -12820,7 +12764,7 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      const indexedValue = target[impl].item(index);
+      const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         return {
           writable: false,
@@ -12832,7 +12776,7 @@ const proxyHandler = {
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[impl].namedItem(P);
+    const namedValue = target[implSymbol].namedItem(P);
 
     if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
       return {
@@ -12860,11 +12804,11 @@ const proxyHandler = {
           context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
         });
 
-        const creating = !(target[impl].namedItem(P) !== null);
+        const creating = !(target[implSymbol].namedItem(P) !== null);
         if (creating) {
-          target[impl][utils.namedSetNew](P, namedValue);
+          target[implSymbol][utils.namedSetNew](P, namedValue);
         } else {
-          target[impl][utils.namedSetExisting](P, namedValue);
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
         }
 
         return true;
@@ -12874,7 +12818,7 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      const indexedValue = target[impl].item(index);
+      const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         ownDesc = {
           writable: false,
@@ -12936,11 +12880,11 @@ const proxyHandler = {
         context: \\"Failed to set the '\\" + P + \\"' property on 'URLSearchParamsCollection2': The provided value\\"
       });
 
-      const creating = !(target[impl].namedItem(P) !== null);
+      const creating = !(target[implSymbol].namedItem(P) !== null);
       if (creating) {
-        target[impl][utils.namedSetNew](P, namedValue);
+        target[implSymbol][utils.namedSetNew](P, namedValue);
       } else {
-        target[impl][utils.namedSetExisting](P, namedValue);
+        target[implSymbol][utils.namedSetExisting](P, namedValue);
       }
 
       return true;
@@ -12955,10 +12899,10 @@ const proxyHandler = {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
-      return !(target[impl].item(index) !== undefined);
+      return !(target[implSymbol].item(index) !== undefined);
     }
 
-    if (target[impl].namedItem(P) !== null && !(P in target)) {
+    if (target[implSymbol].namedItem(P) !== null && !(P in target)) {
       return false;
     }
 
@@ -12980,13 +12924,12 @@ exports[`without processors UnderscoredProperties.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"UnderscoredProperties\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -12999,11 +12942,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"UnderscoredProperties\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"UnderscoredProperties\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor UnderscoredProperties is not installed on the passed global object\\");
   }
@@ -13021,14 +12964,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -13073,7 +13016,7 @@ exports.install = function install(globalObject) {
         }
         args.push(curArg);
       }
-      return esValue[impl].operation(...args);
+      return esValue[implSymbol].operation(...args);
     }
 
     get attribute() {
@@ -13083,7 +13026,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"attribute\\"];
+      return esValue[implSymbol][\\"attribute\\"];
     }
 
     set attribute(V) {
@@ -13097,7 +13040,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'attribute' property on 'UnderscoredProperties': The provided value\\"
       });
 
-      esValue[impl][\\"attribute\\"] = V;
+      esValue[implSymbol][\\"attribute\\"] = V;
     }
 
     static static(void_) {
@@ -13129,10 +13072,10 @@ exports.install = function install(globalObject) {
     static: { enumerable: true },
     const: { value: 42, enumerable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = UnderscoredProperties;
+  globalObject[ctorRegistrySymbol][interfaceName] = UnderscoredProperties;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -13151,13 +13094,12 @@ exports[`without processors Unforgeable.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Unforgeable\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -13170,11 +13112,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Unforgeable\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Unforgeable\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Unforgeable is not installed on the passed global object\\");
   }
@@ -13212,7 +13154,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           });
           args.push(curArg);
         }
-        return esValue[impl].assign(...args);
+        return esValue[implSymbol].assign(...args);
       },
       get href() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -13221,7 +13163,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"href\\"];
+        return esValue[implSymbol][\\"href\\"];
       },
       set href(V) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -13234,7 +13176,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           context: \\"Failed to set the 'href' property on 'Unforgeable': The provided value\\"
         });
 
-        esValue[impl][\\"href\\"] = V;
+        esValue[implSymbol][\\"href\\"] = V;
       },
       toString() {
         const esValue = this;
@@ -13242,7 +13184,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"href\\"];
+        return esValue[implSymbol][\\"href\\"];
       },
       get origin() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -13251,7 +13193,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"origin\\"];
+        return esValue[implSymbol][\\"origin\\"];
       },
       get protocol() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -13260,7 +13202,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"protocol\\"];
+        return esValue[implSymbol][\\"protocol\\"];
       },
       set protocol(V) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -13273,7 +13215,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           context: \\"Failed to set the 'protocol' property on 'Unforgeable': The provided value\\"
         });
 
-        esValue[impl][\\"protocol\\"] = V;
+        esValue[implSymbol][\\"protocol\\"] = V;
       }
     })
   );
@@ -13290,14 +13232,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -13311,10 +13253,10 @@ exports.install = function install(globalObject) {
   Object.defineProperties(Unforgeable.prototype, {
     [Symbol.toStringTag]: { value: \\"Unforgeable\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Unforgeable;
+  globalObject[ctorRegistrySymbol][interfaceName] = Unforgeable;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -13333,13 +13275,12 @@ exports[`without processors UnforgeableMap.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"UnforgeableMap\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -13352,11 +13293,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"UnforgeableMap\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"UnforgeableMap\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor UnforgeableMap is not installed on the passed global object\\");
   }
@@ -13380,7 +13321,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
           throw new TypeError(\\"Illegal invocation\\");
         }
 
-        return esValue[impl][\\"a\\"];
+        return esValue[implSymbol][\\"a\\"];
       }
     })
   );
@@ -13391,16 +13332,16 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
   obj = new Proxy(obj, proxyHandler);
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -13414,10 +13355,10 @@ exports.install = function install(globalObject) {
   Object.defineProperties(UnforgeableMap.prototype, {
     [Symbol.toStringTag]: { value: \\"UnforgeableMap\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = UnforgeableMap;
+  globalObject[ctorRegistrySymbol][interfaceName] = UnforgeableMap;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -13467,7 +13408,7 @@ const proxyHandler = {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[impl][utils.supportedPropertyNames]) {
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
       if (!(key in target)) {
         keys.add(\`\${key}\`);
       }
@@ -13485,8 +13426,8 @@ const proxyHandler = {
     }
     let ignoreNamedProps = false;
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-      const namedValue = target[impl][utils.namedGet](P);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
 
       return {
         writable: true,
@@ -13511,11 +13452,11 @@ const proxyHandler = {
           context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
         });
 
-        const creating = !target[impl][utils.supportsPropertyName](P);
+        const creating = !target[implSymbol][utils.supportsPropertyName](P);
         if (creating) {
-          target[impl][utils.namedSetNew](P, namedValue);
+          target[implSymbol][utils.namedSetNew](P, namedValue);
         } else {
-          target[impl][utils.namedSetExisting](P, namedValue);
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
         }
 
         return true;
@@ -13571,11 +13512,11 @@ const proxyHandler = {
           context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
         });
 
-        const creating = !target[impl][utils.supportsPropertyName](P);
+        const creating = !target[implSymbol][utils.supportsPropertyName](P);
         if (creating) {
-          target[impl][utils.namedSetNew](P, namedValue);
+          target[implSymbol][utils.namedSetNew](P, namedValue);
         } else {
-          target[impl][utils.namedSetExisting](P, namedValue);
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
         }
 
         return true;
@@ -13589,7 +13530,7 @@ const proxyHandler = {
       return Reflect.deleteProperty(target, P);
     }
 
-    if (target[impl][utils.supportsPropertyName](P) && !(P in target)) {
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
       return false;
     }
 
@@ -13611,13 +13552,12 @@ exports[`without processors Unscopable.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Unscopable\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -13630,11 +13570,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Unscopable\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Unscopable\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Unscopable is not installed on the passed global object\\");
   }
@@ -13652,14 +13592,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -13677,7 +13617,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"unscopableTest\\"];
+      return esValue[implSymbol][\\"unscopableTest\\"];
     }
 
     set unscopableTest(V) {
@@ -13691,7 +13631,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'unscopableTest' property on 'Unscopable': The provided value\\"
       });
 
-      esValue[impl][\\"unscopableTest\\"] = V;
+      esValue[implSymbol][\\"unscopableTest\\"] = V;
     }
 
     get unscopableMixin() {
@@ -13701,7 +13641,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl][\\"unscopableMixin\\"];
+      return esValue[implSymbol][\\"unscopableMixin\\"];
     }
 
     set unscopableMixin(V) {
@@ -13715,7 +13655,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'unscopableMixin' property on 'Unscopable': The provided value\\"
       });
 
-      esValue[impl][\\"unscopableMixin\\"] = V;
+      esValue[implSymbol][\\"unscopableMixin\\"] = V;
     }
   }
   Object.defineProperties(Unscopable.prototype, {
@@ -13727,10 +13667,10 @@ exports.install = function install(globalObject) {
       configurable: true
     }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Unscopable;
+  globalObject[ctorRegistrySymbol][interfaceName] = Unscopable;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -13750,13 +13690,12 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"Variadic\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -13769,11 +13708,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"Variadic\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"Variadic\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor Variadic is not installed on the passed global object\\");
   }
@@ -13791,14 +13730,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -13822,7 +13761,7 @@ exports.install = function install(globalObject) {
         });
         args.push(curArg);
       }
-      return esValue[impl].simple1(...args);
+      return esValue[implSymbol].simple1(...args);
     }
 
     simple2(first) {
@@ -13849,7 +13788,7 @@ exports.install = function install(globalObject) {
         curArg = URL.convert(curArg, { context: \\"Failed to execute 'simple2' on 'Variadic': parameter \\" + (i + 1) });
         args.push(curArg);
       }
-      return esValue[impl].simple2(...args);
+      return esValue[implSymbol].simple2(...args);
     }
 
     overloaded1() {
@@ -13882,7 +13821,7 @@ exports.install = function install(globalObject) {
           }
         }
       }
-      return esValue[impl].overloaded1(...args);
+      return esValue[implSymbol].overloaded1(...args);
     }
 
     overloaded2(first) {
@@ -13957,7 +13896,7 @@ exports.install = function install(globalObject) {
           }
         }
       }
-      return esValue[impl].overloaded2(...args);
+      return esValue[implSymbol].overloaded2(...args);
     }
   }
   Object.defineProperties(Variadic.prototype, {
@@ -13967,10 +13906,10 @@ exports.install = function install(globalObject) {
     overloaded2: { enumerable: true },
     [Symbol.toStringTag]: { value: \\"Variadic\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = Variadic;
+  globalObject[ctorRegistrySymbol][interfaceName] = Variadic;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
@@ -13989,13 +13928,12 @@ exports[`without processors ZeroArgConstructor.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const impl = utils.implSymbol;
-const ctorRegistry = utils.ctorRegistrySymbol;
+const { implSymbol, ctorRegistrySymbol } = utils;
 
 const interfaceName = \\"ZeroArgConstructor\\";
 
 exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, impl) && obj[impl] instanceof Impl.implementation;
+  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = function isImpl(obj) {
   return utils.isObject(obj) && obj instanceof Impl.implementation;
@@ -14008,11 +13946,11 @@ exports.convert = function convert(obj, { context = \\"The provided value\\" } =
 };
 
 exports.create = function create(globalObject, constructorArgs, privateData) {
-  if (globalObject[ctorRegistry] === undefined) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
 
-  const ctor = globalObject[ctorRegistry][\\"ZeroArgConstructor\\"];
+  const ctor = globalObject[ctorRegistrySymbol][\\"ZeroArgConstructor\\"];
   if (ctor === undefined) {
     throw new Error(\\"Internal error: constructor ZeroArgConstructor is not installed on the passed global object\\");
   }
@@ -14030,14 +13968,14 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   privateData.wrapper = obj;
 
   exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, impl, {
+  Object.defineProperty(obj, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[impl][utils.wrapperSymbol] = obj;
+  obj[implSymbol][utils.wrapperSymbol] = obj;
   if (Impl.init) {
-    Impl.init(obj[impl], privateData);
+    Impl.init(obj[implSymbol], privateData);
   }
   return obj;
 };
@@ -14051,10 +13989,10 @@ exports.install = function install(globalObject) {
   Object.defineProperties(ZeroArgConstructor.prototype, {
     [Symbol.toStringTag]: { value: \\"ZeroArgConstructor\\", configurable: true }
   });
-  if (globalObject[ctorRegistry] === undefined) {
-    globalObject[ctorRegistry] = Object.create(null);
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
   }
-  globalObject[ctorRegistry][interfaceName] = ZeroArgConstructor;
+  globalObject[ctorRegistrySymbol][interfaceName] = ZeroArgConstructor;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -6,7 +6,8 @@ exports[`with processors BufferSourceTypes.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"BufferSourceTypes\\";
 
@@ -253,7 +254,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const CEReactions = require(\\"../CEReactions.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"CEReactions\\";
 
@@ -595,7 +597,8 @@ exports[`with processors DOMImplementation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"DOMImplementation\\";
 
@@ -875,7 +878,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const Dictionary = require(\\"./Dictionary.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"DictionaryConvert\\";
 
@@ -983,7 +987,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const RequestDestination = require(\\"./RequestDestination.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Enum\\";
 
@@ -1113,7 +1118,8 @@ exports[`with processors Global.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Global\\";
 
@@ -1311,7 +1317,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const HTMLConstructor_HTMLConstructor = require(\\"../HTMLConstructor.js\\").HTMLConstructor;
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"HTMLConstructor\\";
 
@@ -1394,7 +1401,8 @@ exports[`with processors LegacyArrayClass.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"LegacyArrayClass\\";
 
@@ -1489,7 +1497,8 @@ exports[`with processors MixedIn.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"MixedIn\\";
 
@@ -1649,7 +1658,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Overloads\\";
 
@@ -2042,7 +2052,8 @@ exports[`with processors PromiseTypes.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"PromiseTypes\\";
 
@@ -2184,7 +2195,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const whatwg_url = require(\\"whatwg-url\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Reflect\\";
 
@@ -2490,7 +2502,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"SeqAndRec\\";
 
@@ -2778,7 +2791,8 @@ exports[`with processors Static.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Static\\";
 
@@ -2911,7 +2925,8 @@ exports[`with processors Storage.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Storage\\";
 
@@ -3272,7 +3287,8 @@ exports[`with processors StringifierAttribute.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierAttribute\\";
 
@@ -3376,7 +3392,8 @@ exports[`with processors StringifierDefaultOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierDefaultOperation\\";
 
@@ -3471,7 +3488,8 @@ exports[`with processors StringifierNamedOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierNamedOperation\\";
 
@@ -3576,7 +3594,8 @@ exports[`with processors StringifierOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierOperation\\";
 
@@ -3671,7 +3690,8 @@ const utils = require(\\"./utils.js\\");
 
 const RequestDestination = require(\\"./RequestDestination.js\\");
 const URL = require(\\"./URL.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"TypedefsAndUnions\\";
 
@@ -4185,7 +4205,8 @@ exports[`with processors URL.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URL\\";
 
@@ -4570,7 +4591,8 @@ exports[`with processors URLList.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URLList\\";
 
@@ -4854,7 +4876,8 @@ exports[`with processors URLSearchParams.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URLSearchParams\\";
 
@@ -5298,7 +5321,8 @@ exports[`with processors URLSearchParamsCollection.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URLSearchParamsCollection\\";
 
@@ -5634,7 +5658,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const URLSearchParamsCollection = require(\\"./URLSearchParamsCollection.js\\");
 
 const interfaceName = \\"URLSearchParamsCollection2\\";
@@ -5945,7 +5970,8 @@ exports[`with processors UnderscoredProperties.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"UnderscoredProperties\\";
 
@@ -6115,7 +6141,8 @@ exports[`with processors Unforgeable.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Unforgeable\\";
 
@@ -6296,7 +6323,8 @@ exports[`with processors UnforgeableMap.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"UnforgeableMap\\";
 
@@ -6573,7 +6601,8 @@ exports[`with processors Unscopable.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Unscopable\\";
 
@@ -6711,7 +6740,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Variadic\\";
 
@@ -6949,7 +6979,8 @@ exports[`with processors ZeroArgConstructor.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"ZeroArgConstructor\\";
 
@@ -7032,7 +7063,8 @@ exports[`without processors BufferSourceTypes.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"BufferSourceTypes\\";
 
@@ -7278,7 +7310,8 @@ exports[`without processors CEReactions.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"CEReactions\\";
 
@@ -7590,7 +7623,8 @@ exports[`without processors DOMImplementation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"DOMImplementation\\";
 
@@ -7870,7 +7904,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const Dictionary = require(\\"./Dictionary.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"DictionaryConvert\\";
 
@@ -7978,7 +8013,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const RequestDestination = require(\\"./RequestDestination.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Enum\\";
 
@@ -8108,7 +8144,8 @@ exports[`without processors Global.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Global\\";
 
@@ -8305,7 +8342,8 @@ exports[`without processors HTMLConstructor.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"HTMLConstructor\\";
 
@@ -8388,7 +8426,8 @@ exports[`without processors LegacyArrayClass.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"LegacyArrayClass\\";
 
@@ -8483,7 +8522,8 @@ exports[`without processors MixedIn.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"MixedIn\\";
 
@@ -8643,7 +8683,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Overloads\\";
 
@@ -9036,7 +9077,8 @@ exports[`without processors PromiseTypes.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"PromiseTypes\\";
 
@@ -9177,7 +9219,8 @@ exports[`without processors Reflect.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Reflect\\";
 
@@ -9469,7 +9512,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"SeqAndRec\\";
 
@@ -9757,7 +9801,8 @@ exports[`without processors Static.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Static\\";
 
@@ -9890,7 +9935,8 @@ exports[`without processors Storage.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Storage\\";
 
@@ -10251,7 +10297,8 @@ exports[`without processors StringifierAttribute.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierAttribute\\";
 
@@ -10355,7 +10402,8 @@ exports[`without processors StringifierDefaultOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierDefaultOperation\\";
 
@@ -10450,7 +10498,8 @@ exports[`without processors StringifierNamedOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierNamedOperation\\";
 
@@ -10555,7 +10604,8 @@ exports[`without processors StringifierOperation.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierOperation\\";
 
@@ -10650,7 +10700,8 @@ const utils = require(\\"./utils.js\\");
 
 const RequestDestination = require(\\"./RequestDestination.js\\");
 const URL = require(\\"./URL.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"TypedefsAndUnions\\";
 
@@ -11164,7 +11215,8 @@ exports[`without processors URL.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URL\\";
 
@@ -11549,7 +11601,8 @@ exports[`without processors URLList.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URLList\\";
 
@@ -11833,7 +11886,8 @@ exports[`without processors URLSearchParams.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URLSearchParams\\";
 
@@ -12277,7 +12331,8 @@ exports[`without processors URLSearchParamsCollection.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URLSearchParamsCollection\\";
 
@@ -12613,7 +12668,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const URLSearchParamsCollection = require(\\"./URLSearchParamsCollection.js\\");
 
 const interfaceName = \\"URLSearchParamsCollection2\\";
@@ -12924,7 +12980,8 @@ exports[`without processors UnderscoredProperties.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"UnderscoredProperties\\";
 
@@ -13094,7 +13151,8 @@ exports[`without processors Unforgeable.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Unforgeable\\";
 
@@ -13275,7 +13333,8 @@ exports[`without processors UnforgeableMap.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"UnforgeableMap\\";
 
@@ -13552,7 +13611,8 @@ exports[`without processors Unscopable.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Unscopable\\";
 
@@ -13690,7 +13750,8 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Variadic\\";
 
@@ -13928,7 +13989,8 @@ exports[`without processors ZeroArgConstructor.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
-const { implSymbol, ctorRegistrySymbol } = utils;
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"ZeroArgConstructor\\";
 

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -2261,7 +2261,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      return esValue[impl].hasAttributeNS(null, \\"reflectedboolean\\");
+      return esValue[implSymbol].hasAttributeNS(null, \\"reflectedboolean\\");
     }
 
     set reflectedBoolean(V) {
@@ -2276,9 +2276,9 @@ exports.install = function install(globalObject) {
       });
 
       if (V) {
-        esValue[impl].setAttributeNS(null, \\"reflectedboolean\\", \\"\\");
+        esValue[implSymbol].setAttributeNS(null, \\"reflectedboolean\\", \\"\\");
       } else {
-        esValue[impl].removeAttributeNS(null, \\"reflectedboolean\\");
+        esValue[implSymbol].removeAttributeNS(null, \\"reflectedboolean\\");
       }
     }
 
@@ -2289,7 +2289,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      const value = esValue[impl].getAttributeNS(null, \\"reflecteddomstring\\");
+      const value = esValue[implSymbol].getAttributeNS(null, \\"reflecteddomstring\\");
       return value === null ? \\"\\" : value;
     }
 
@@ -2304,7 +2304,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectedDOMString' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl].setAttributeNS(null, \\"reflecteddomstring\\", V);
+      esValue[implSymbol].setAttributeNS(null, \\"reflecteddomstring\\", V);
     }
 
     get reflectedLong() {
@@ -2314,7 +2314,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      const value = parseInt(esValue[impl].getAttributeNS(null, \\"reflectedlong\\"));
+      const value = parseInt(esValue[implSymbol].getAttributeNS(null, \\"reflectedlong\\"));
       return isNaN(value) || value < -2147483648 || value > 2147483647 ? 0 : value;
     }
 
@@ -2329,7 +2329,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectedLong' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl].setAttributeNS(null, \\"reflectedlong\\", String(V));
+      esValue[implSymbol].setAttributeNS(null, \\"reflectedlong\\", String(V));
     }
 
     get reflectedUnsignedLong() {
@@ -2339,7 +2339,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      const value = parseInt(esValue[impl].getAttributeNS(null, \\"reflectedunsignedlong\\"));
+      const value = parseInt(esValue[implSymbol].getAttributeNS(null, \\"reflectedunsignedlong\\"));
       return isNaN(value) || value < 0 || value > 2147483647 ? 0 : value;
     }
 
@@ -2354,7 +2354,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectedUnsignedLong' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl].setAttributeNS(null, \\"reflectedunsignedlong\\", String(V > 2147483647 ? 0 : V));
+      esValue[implSymbol].setAttributeNS(null, \\"reflectedunsignedlong\\", String(V > 2147483647 ? 0 : V));
     }
 
     get reflectedUSVStringURL() {
@@ -2364,7 +2364,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      const value = esValue[impl].getAttributeNS(null, \\"reflectedusvstringurl\\");
+      const value = esValue[implSymbol].getAttributeNS(null, \\"reflectedusvstringurl\\");
       if (value === null) {
         return \\"\\";
       }
@@ -2383,7 +2383,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectedUSVStringURL' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl].setAttributeNS(null, \\"reflectedusvstringurl\\", V);
+      esValue[implSymbol].setAttributeNS(null, \\"reflectedusvstringurl\\", V);
     }
 
     get reflectionTest() {
@@ -2393,7 +2393,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      const value = esValue[impl].getAttributeNS(null, \\"reflection\\");
+      const value = esValue[implSymbol].getAttributeNS(null, \\"reflection\\");
       return value === null ? \\"\\" : value;
     }
 
@@ -2408,7 +2408,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'reflectionTest' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl].setAttributeNS(null, \\"reflection\\", V);
+      esValue[implSymbol].setAttributeNS(null, \\"reflection\\", V);
     }
 
     get withUnderscore() {
@@ -2418,7 +2418,7 @@ exports.install = function install(globalObject) {
         throw new TypeError(\\"Illegal invocation\\");
       }
 
-      const value = esValue[impl].getAttributeNS(null, \\"with-underscore\\");
+      const value = esValue[implSymbol].getAttributeNS(null, \\"with-underscore\\");
       return value === null ? \\"\\" : value;
     }
 
@@ -2433,7 +2433,7 @@ exports.install = function install(globalObject) {
         context: \\"Failed to set the 'withUnderscore' property on 'Reflect': The provided value\\"
       });
 
-      esValue[impl].setAttributeNS(null, \\"with-underscore\\", V);
+      esValue[implSymbol].setAttributeNS(null, \\"with-underscore\\", V);
     }
   }
   Object.defineProperties(Reflect.prototype, {


### PR DESCRIPTION
I’ve waited with opening this until after <https://github.com/jsdom/webidl2js/pull/166> was done to avoid merge conflicts.

This frees up the `impl` variable for use in <https://github.com/jsdom/webidl2js/pull/158> and also makes it clearer that the current `impl` variable refers to `implSymbol`.