### PR TITLE
refactor(utils): Avoid re‑assigning `module.exports`

### DIFF
--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -1,18 +1,21 @@
 "use strict";
 
 // Returns "Type(value) is Object" in ES terminology.
-function isObject(value) {
+exports.isObject = value => {
   return typeof value === "object" && value !== null || typeof value === "function";
-}
+};
 
-const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+exports.hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
 
 const wrapperSymbol = Symbol("wrapper");
 const implSymbol = Symbol("impl");
-const sameObjectCaches = Symbol("SameObject caches");
-const ctorRegistrySymbol = Symbol.for("[webidl2js]  constructor registry");
 
-function getSameObject(wrapper, prop, creator) {
+exports.wrapperSymbol = wrapperSymbol;
+exports.implSymbol = implSymbol;
+exports.ctorRegistrySymbol = Symbol.for("[webidl2js]  constructor registry");
+
+const sameObjectCaches = Symbol("SameObject caches");
+exports.getSameObject = (wrapper, prop, creator) => {
   if (!wrapper[sameObjectCaches]) {
     wrapper[sameObjectCaches] = Object.create(null);
   }
@@ -23,7 +26,7 @@ function getSameObject(wrapper, prop, creator) {
 
   wrapper[sameObjectCaches][prop] = creator();
   return wrapper[sameObjectCaches][prop];
-}
+};
 
 function wrapperForImpl(impl) {
   return impl ? impl[wrapperSymbol] : null;
@@ -33,20 +36,22 @@ function implForWrapper(wrapper) {
   return wrapper ? wrapper[implSymbol] : null;
 }
 
-function tryWrapperForImpl(impl) {
+exports.wrapperForImpl = wrapperForImpl;
+exports.tryWrapperForImpl = impl => {
   const wrapper = wrapperForImpl(impl);
   return wrapper ? wrapper : impl;
-}
+};
 
-function tryImplForWrapper(wrapper) {
+exports.implForWrapper = implForWrapper;
+exports.tryImplForWrapper = wrapper => {
   const impl = implForWrapper(wrapper);
   return impl ? impl : wrapper;
-}
+};
 
-const iterInternalSymbol = Symbol("internal");
-const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+exports.iterInternalSymbol = Symbol("internal");
+exports.IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
 
-function isArrayIndexPropName(P) {
+exports.isArrayIndexPropName = P => {
   if (typeof P !== "string") {
     return false;
   }
@@ -59,55 +64,27 @@ function isArrayIndexPropName(P) {
     return false;
   }
   return true;
-}
+};
 
 const byteLengthGetter =
     Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "byteLength").get;
-function isArrayBuffer(value) {
+exports.isArrayBuffer = value => {
   try {
     byteLengthGetter.call(value);
     return true;
   } catch (e) {
     return false;
   }
-}
-
-const supportsPropertyIndex = Symbol("supports property index");
-const supportedPropertyIndices = Symbol("supported property indices");
-const supportsPropertyName = Symbol("supports property name");
-const supportedPropertyNames = Symbol("supported property names");
-const indexedGet = Symbol("indexed property get");
-const indexedSetNew = Symbol("indexed property set new");
-const indexedSetExisting = Symbol("indexed property set existing");
-const namedGet = Symbol("named property get");
-const namedSetNew = Symbol("named property set new");
-const namedSetExisting = Symbol("named property set existing");
-const namedDelete = Symbol("named property delete");
-
-module.exports = exports = {
-  isObject,
-  hasOwn,
-  wrapperSymbol,
-  implSymbol,
-  getSameObject,
-  ctorRegistrySymbol,
-  wrapperForImpl,
-  implForWrapper,
-  tryWrapperForImpl,
-  tryImplForWrapper,
-  iterInternalSymbol,
-  IteratorPrototype,
-  isArrayBuffer,
-  isArrayIndexPropName,
-  supportsPropertyIndex,
-  supportedPropertyIndices,
-  supportsPropertyName,
-  supportedPropertyNames,
-  indexedGet,
-  indexedSetNew,
-  indexedSetExisting,
-  namedGet,
-  namedSetNew,
-  namedSetExisting,
-  namedDelete
 };
+
+exports.supportsPropertyIndex = Symbol("supports property index");
+exports.supportedPropertyIndices = Symbol("supported property indices");
+exports.supportsPropertyName = Symbol("supports property name");
+exports.supportedPropertyNames = Symbol("supported property names");
+exports.indexedGet = Symbol("indexed property get");
+exports.indexedSetNew = Symbol("indexed property set new");
+exports.indexedSetExisting = Symbol("indexed property set existing");
+exports.namedGet = Symbol("named property get");
+exports.namedSetNew = Symbol("named property set new");
+exports.namedSetExisting = Symbol("named property set existing");
+exports.namedDelete = Symbol("named property delete");


### PR DESCRIPTION
This refactors `utils.js` to create properties on `exports`, rather than re‑assigning `module.exports`, which matches the rest of the generated files and all util files in **JSDOM**.

---

review?(@pmdartus)