### PR TITLE
Ensure callback interfaces don’t leak implementation through `thisArg`

### DIFF
--- a/lib/constructs/callback-interface.js
+++ b/lib/constructs/callback-interface.js
@@ -81,7 +81,7 @@ class CallbackInterface {
         }
 
         function callTheUserObjectsOperation(${argNames.join(", ")}) {
-          let thisArg = this;
+          let thisArg = utils.tryWrapperForImpl(this);
           let O = value;
           let X = O;
     `;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -12,7 +12,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   }
 
   function callTheUserObjectsOperation() {
-    let thisArg = this;
+    let thisArg = utils.tryWrapperForImpl(this);
     let O = value;
     let X = O;
 
@@ -1176,7 +1176,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   }
 
   function callTheUserObjectsOperation(event) {
-    let thisArg = this;
+    let thisArg = utils.tryWrapperForImpl(this);
     let O = value;
     let X = O;
 
@@ -1875,7 +1875,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   }
 
   function callTheUserObjectsOperation(node) {
-    let thisArg = this;
+    let thisArg = utils.tryWrapperForImpl(this);
     let O = value;
     let X = O;
 
@@ -7353,7 +7353,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   }
 
   function callTheUserObjectsOperation() {
-    let thisArg = this;
+    let thisArg = utils.tryWrapperForImpl(this);
     let O = value;
     let X = O;
 
@@ -8486,7 +8486,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   }
 
   function callTheUserObjectsOperation(event) {
-    let thisArg = this;
+    let thisArg = utils.tryWrapperForImpl(this);
     let O = value;
     let X = O;
 
@@ -9184,7 +9184,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   }
 
   function callTheUserObjectsOperation(node) {
-    let thisArg = this;
+    let thisArg = utils.tryWrapperForImpl(this);
     let O = value;
     let X = O;
 


### PR DESCRIPTION
I realised I forgot to do this after <https://github.com/jsdom/webidl2js/pull/172> was merged.