### PR TITLE
Implement support for the `[Exposed]` extended attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ webidl2js is implementing an ever-growing subset of the Web IDL specification. S
 - Variadic arguments
 - `[Clamp]`
 - `[EnforceRange]`
+- `[Exposed]`
 - `[LegacyArrayClass]`
 - `[LegacyUnenumerableNamedProperties]`
 - `[LegacyWindowAlias]`

--- a/README.md
+++ b/README.md
@@ -264,9 +264,11 @@ Performs the Web IDL conversion algorithm for this interface, converting _value_
 
 In practice, this means doing a type-check equivalent to `is(value)`, and if it passes, returns the corresponding impl. If the type-check fails, it throws an informative exception. _context_ can be used to describe the provided value in any resulting error message.
 
-#### `install(globalObject)`
+#### `install(globalObject, globalNames)`
 
 This method creates a brand new wrapper constructor and prototype and attach it to the passed `globalObject`. It also registers the created constructor with the `globalObject`'s global constructor registry, which makes `create()`, `createImpl()`, and `setup()` work. (Thus, it is important to invoke `install()` before invoking those methods, as otherwise they will throw.)
+
+The second argument `globalNames` is an array containing the [global names](https://heycam.github.io/webidl/#dfn-global-name) of the interface that `globalObject` implements. This is used for the purposes of deciding which interfaces are [exposed](https://heycam.github.io/webidl/#dfn-exposed). For example, this array should be `["Window"]` for a [`Window`](https://html.spec.whatwg.org/multipage/window-object.html#window) global object. But for a [`DedicatedWorkerGlobalScope`](https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope) global object, this array should be `["Worker", "DedicatedWorker"]`. Note that we do not yet implement [`[SecureContext]`](https://heycam.github.io/webidl/#SecureContext), so the "exposed" check is not fully implemented.
 
 #### `create(globalObject, constructorArgs, privateData)`
 

--- a/README.md
+++ b/README.md
@@ -479,7 +479,6 @@ Notable missing features include:
 - `[AllowShared]`
 - `[Default]` (for `toJSON()` operations)
 - `[Global]`'s various consequences, including the named properties object and `[[SetPrototypeOf]]`
-- `[Exposed]`
 - `[LenientSetter]`
 - `[LenientThis]`
 - `[NamedConstructor]`

--- a/lib/constructs/callback-interface.js
+++ b/lib/constructs/callback-interface.js
@@ -20,6 +20,25 @@ class CallbackInterface {
 
     this._analyzed = false;
     this._outputStaticProperties = new Map();
+
+    const exposed = utils.getExtAttr(this.idl.extAttrs, "Exposed");
+    if (this.idl.members.some(member => member.type === "const") && !exposed) {
+      throw new Error(`Callback interface ${this.name} with defined constants lacks the [Exposed] extended attribute`);
+    }
+
+    if (exposed) {
+      if (!exposed.rhs || (exposed.rhs.type !== "identifier" && exposed.rhs.type !== "identifier-list")) {
+        throw new Error(`[Exposed] must take an identifier or an identifier list in callback interface ${this.name}`);
+      }
+
+      if (exposed.rhs.type === "identifier") {
+        this.exposed = new Set([exposed.rhs.value]);
+      } else {
+        this.exposed = new Set(exposed.rhs.value.map(token => token.value));
+      }
+    } else {
+      this.exposed = new Set();
+    }
   }
 
   _analyzeMembers() {
@@ -178,14 +197,41 @@ class CallbackInterface {
   }
 
   generateInstall() {
+    if (this.constants.size > 0) {
+      this.str += `
+        const exposed = new Set([
+      `;
+
+      for (const globalName of this.exposed) {
+        this.str += `"${globalName}",\n`;
+      }
+
+      this.str += `
+        ]);
+      `;
+    }
+
     this.str += `
-      exports.install = function install(globalObject) {
+      exports.install = (globalObject, globalNames) => {
     `;
 
     if (this.constants.size > 0) {
       const { name } = this;
 
       this.str += `
+        let isExposed = false;
+
+        for (const globalName of globalNames) {
+          if (exposed.has(globalName)) {
+            isExposed = true;
+            break;
+          }
+        }
+
+        if (!isExposed) {
+          return;
+        }
+
         const ${name} = () => {
           throw new TypeError("Illegal invocation");
         };
@@ -233,5 +279,7 @@ class CallbackInterface {
     return this.str;
   }
 }
+
+CallbackInterface.prototype.type = "callback interface";
 
 module.exports = CallbackInterface;

--- a/lib/constructs/callback-interface.js
+++ b/lib/constructs/callback-interface.js
@@ -199,15 +199,7 @@ class CallbackInterface {
   generateInstall() {
     if (this.constants.size > 0) {
       this.str += `
-        const exposed = new Set([
-      `;
-
-      for (const globalName of this.exposed) {
-        this.str += `"${globalName}",\n`;
-      }
-
-      this.str += `
-        ]);
+        const exposed = new Set(${JSON.stringify([...this.exposed])});
       `;
     }
 

--- a/lib/constructs/callback-interface.js
+++ b/lib/constructs/callback-interface.js
@@ -211,16 +211,7 @@ class CallbackInterface {
       const { name } = this;
 
       this.str += `
-        let isExposed = false;
-
-        for (const globalName of globalNames) {
-          if (exposed.has(globalName)) {
-            isExposed = true;
-            break;
-          }
-        }
-
-        if (!isExposed) {
+        if (!globalNames.some(globalName => exposed.has(globalName))) {
           return;
         }
 

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -1466,34 +1466,7 @@ class Interface {
       const exposed = new Set(${JSON.stringify([...this.exposed])});
 
       exports.install = (globalObject, globalNames) => {
-        let isExposed = false;
-    `;
-
-    if (this.legacyWindowAliases) {
-      this.str += "let isWindow = false;\n";
-    }
-
-    this.str += `
-        for (const globalName of globalNames) {
-          if (exposed.has(globalName)) {
-            isExposed = true;
-    `;
-
-    if (this.legacyWindowAliases) {
-      this.str += `
-            if (globalName === "Window") {
-              isWindow = true;
-            }
-      `;
-    } else {
-      this.str += "break;";
-    }
-
-    this.str += `
-          }
-        }
-
-        if (!isExposed) {
+        if (!globalNames.some(globalName => exposed.has(globalName))) {
           return;
         }
     `;
@@ -1532,7 +1505,7 @@ class Interface {
 
       if (this.legacyWindowAliases) {
         this.str += `
-          if (isWindow) {
+          if (globalNames.includes("Window")) {
         `;
 
         for (const legacyWindowAlias of this.legacyWindowAliases) {

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -1463,7 +1463,47 @@ class Interface {
     const { idl, name } = this;
 
     this.str += `
-      exports.install = (globalObject, globalName) => {
+      const exposed = new Set([
+    `;
+
+    for (const globalName of this.exposed) {
+      this.str += `"${globalName}",\n`;
+    }
+
+    this.str += `
+      ]);
+
+      exports.install = (globalObject, globalNames) => {
+        let isExposed = false;
+    `;
+
+    if (this.legacyWindowAliases) {
+      this.str += "let isWindow = false;\n";
+    }
+
+    this.str += `
+        for (const globalName of globalNames) {
+          if (exposed.has(globalName)) {
+            isExposed = true;
+    `;
+
+    if (this.legacyWindowAliases) {
+      this.str += `
+            if (globalName === "Window") {
+              isWindow = true;
+            }
+      `;
+    } else {
+      this.str += "break;";
+    }
+
+    this.str += `
+          }
+        }
+
+        if (!isExposed) {
+          return;
+        }
     `;
 
     if (idl.inheritance) {
@@ -1500,7 +1540,7 @@ class Interface {
 
       if (this.legacyWindowAliases) {
         this.str += `
-          if (globalName === "Window") {
+          if (isWindow) {
         `;
 
         for (const legacyWindowAlias of this.legacyWindowAliases) {

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -1463,15 +1463,7 @@ class Interface {
     const { idl, name } = this;
 
     this.str += `
-      const exposed = new Set([
-    `;
-
-    for (const globalName of this.exposed) {
-      this.str += `"${globalName}",\n`;
-    }
-
-    this.str += `
-      ]);
+      const exposed = new Set(${JSON.stringify([...this.exposed])});
 
       exports.install = (globalObject, globalNames) => {
         let isExposed = false;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -48,7 +48,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   return callTheUserObjectsOperation;
 };
 
-exports.install = function install(globalObject) {};
+exports.install = (globalObject, globalNames) => {};
 "
 `;
 
@@ -111,7 +111,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class BufferSourceTypes {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -368,7 +382,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class CEReactions {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -702,7 +730,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class DOMImplementation {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -904,7 +946,25 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\", \\"Worker\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+  let isWindow = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+
+      if (globalName === \\"Window\\") {
+        isWindow = true;
+      }
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class DOMRect {
     constructor() {
       const args = [];
@@ -1082,7 +1142,7 @@ exports.install = (globalObject, globalName) => {
     value: DOMRect
   });
 
-  if (globalName === \\"Window\\") {
+  if (isWindow) {
     Object.defineProperty(globalObject, \\"SVGRect\\", {
       configurable: true,
       writable: true,
@@ -1233,7 +1293,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class DictionaryConvert {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -1342,7 +1416,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Enum {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -1449,7 +1537,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   return callTheUserObjectsOperation;
 };
 
-exports.install = function install(globalObject) {};
+exports.install = (globalObject, globalNames) => {};
 "
 `;
 
@@ -1513,7 +1601,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\", \\"Worker\\", \\"AudioWorklet\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class EventTarget {
     constructor() {
       return exports.setup(Object.create(new.target.prototype), globalObject, undefined);
@@ -1732,7 +1834,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Global\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Global {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -1832,7 +1948,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class HTMLConstructor {
     constructor() {
       return HTMLConstructor_HTMLConstructor(globalObject, interfaceName);
@@ -1916,7 +2046,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class LegacyArrayClass {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -2012,7 +2156,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class MixedIn {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -2152,7 +2310,22 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   return callTheUserObjectsOperation;
 };
 
-exports.install = function install(globalObject) {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
+
   const NodeFilter = () => {
     throw new TypeError(\\"Illegal invocation\\");
   };
@@ -2245,7 +2418,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Overloads {
     constructor() {
       const args = [];
@@ -2639,7 +2826,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class PromiseTypes {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -2782,7 +2983,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Reflect {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -3089,7 +3304,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class SeqAndRec {
     constructor() {
       return exports.setup(Object.create(new.target.prototype), globalObject, undefined);
@@ -3378,7 +3607,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Static {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -3514,7 +3757,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Storage {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -3874,7 +4131,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class StringifierAttribute {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -3981,7 +4252,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class StringifierDefaultOperation {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -4077,7 +4362,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class StringifierNamedOperation {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -4181,7 +4480,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class StringifierOperation {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -4277,7 +4590,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class TypedefsAndUnions {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -4792,7 +5119,25 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\", \\"Worker\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+  let isWindow = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+
+      if (globalName === \\"Window\\") {
+        isWindow = true;
+      }
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class URL {
     constructor(url) {
       if (arguments.length < 1) {
@@ -5114,7 +5459,7 @@ exports.install = (globalObject, globalName) => {
     value: URL
   });
 
-  if (globalName === \\"Window\\") {
+  if (isWindow) {
     Object.defineProperty(globalObject, \\"webkitURL\\", {
       configurable: true,
       writable: true,
@@ -5188,7 +5533,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class URLList {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -5519,7 +5878,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\", \\"Worker\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class URLSearchParams {
     constructor() {
       const args = [];
@@ -5920,7 +6293,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class URLSearchParamsCollection {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -6260,7 +6647,22 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
+
   if (globalObject.URLSearchParamsCollection === undefined) {
     throw new Error(
       \\"Internal error: attempting to evaluate URLSearchParamsCollection2 before URLSearchParamsCollection\\"
@@ -6565,7 +6967,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class UnderscoredProperties {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -6834,7 +7250,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Unforgeable {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -6937,7 +7367,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class UnforgeableMap {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -7196,7 +7640,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Unscopable {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -7335,7 +7793,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Variadic {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -7574,7 +8046,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class ZeroArgConstructor {
     constructor() {
       return exports.setup(Object.create(new.target.prototype), globalObject, undefined);
@@ -7647,7 +8133,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   return callTheUserObjectsOperation;
 };
 
-exports.install = function install(globalObject) {};
+exports.install = (globalObject, globalNames) => {};
 "
 `;
 
@@ -7710,7 +8196,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class BufferSourceTypes {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -7966,7 +8466,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class CEReactions {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -8270,7 +8784,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class DOMImplementation {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -8472,7 +9000,25 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\", \\"Worker\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+  let isWindow = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+
+      if (globalName === \\"Window\\") {
+        isWindow = true;
+      }
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class DOMRect {
     constructor() {
       const args = [];
@@ -8650,7 +9196,7 @@ exports.install = (globalObject, globalName) => {
     value: DOMRect
   });
 
-  if (globalName === \\"Window\\") {
+  if (isWindow) {
     Object.defineProperty(globalObject, \\"SVGRect\\", {
       configurable: true,
       writable: true,
@@ -8801,7 +9347,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class DictionaryConvert {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -8910,7 +9470,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Enum {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -9017,7 +9591,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   return callTheUserObjectsOperation;
 };
 
-exports.install = function install(globalObject) {};
+exports.install = (globalObject, globalNames) => {};
 "
 `;
 
@@ -9081,7 +9655,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\", \\"Worker\\", \\"AudioWorklet\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class EventTarget {
     constructor() {
       return exports.setup(Object.create(new.target.prototype), globalObject, undefined);
@@ -9300,7 +9888,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Global\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Global {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -9399,7 +10001,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class HTMLConstructor {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -9483,7 +10099,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class LegacyArrayClass {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -9579,7 +10209,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class MixedIn {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -9719,7 +10363,22 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
   return callTheUserObjectsOperation;
 };
 
-exports.install = function install(globalObject) {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
+
   const NodeFilter = () => {
     throw new TypeError(\\"Illegal invocation\\");
   };
@@ -9812,7 +10471,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Overloads {
     constructor() {
       const args = [];
@@ -10206,7 +10879,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class PromiseTypes {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -10348,7 +11035,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Reflect {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -10641,7 +11342,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class SeqAndRec {
     constructor() {
       return exports.setup(Object.create(new.target.prototype), globalObject, undefined);
@@ -10930,7 +11645,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Static {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -11066,7 +11795,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Storage {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -11426,7 +12169,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class StringifierAttribute {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -11533,7 +12290,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class StringifierDefaultOperation {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -11629,7 +12400,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class StringifierNamedOperation {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -11733,7 +12518,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class StringifierOperation {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -11829,7 +12628,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class TypedefsAndUnions {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -12344,7 +13157,25 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\", \\"Worker\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+  let isWindow = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+
+      if (globalName === \\"Window\\") {
+        isWindow = true;
+      }
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class URL {
     constructor(url) {
       if (arguments.length < 1) {
@@ -12666,7 +13497,7 @@ exports.install = (globalObject, globalName) => {
     value: URL
   });
 
-  if (globalName === \\"Window\\") {
+  if (isWindow) {
     Object.defineProperty(globalObject, \\"webkitURL\\", {
       configurable: true,
       writable: true,
@@ -12740,7 +13571,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class URLList {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -13071,7 +13916,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\", \\"Worker\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class URLSearchParams {
     constructor() {
       const args = [];
@@ -13472,7 +14331,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class URLSearchParamsCollection {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -13812,7 +14685,22 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
+
   if (globalObject.URLSearchParamsCollection === undefined) {
     throw new Error(
       \\"Internal error: attempting to evaluate URLSearchParamsCollection2 before URLSearchParamsCollection\\"
@@ -14117,7 +15005,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class UnderscoredProperties {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -14386,7 +15288,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Unforgeable {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -14489,7 +15405,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class UnforgeableMap {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -14748,7 +15678,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Unscopable {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -14887,7 +15831,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class Variadic {
     constructor() {
       throw new TypeError(\\"Illegal constructor\\");
@@ -15126,7 +16084,21 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
   return obj;
 };
 
-exports.install = (globalObject, globalName) => {
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  let isExposed = false;
+
+  for (const globalName of globalNames) {
+    if (exposed.has(globalName)) {
+      isExposed = true;
+      break;
+    }
+  }
+
+  if (!isExposed) {
+    return;
+  }
   class ZeroArgConstructor {
     constructor() {
       return exports.setup(Object.create(new.target.prototype), globalObject, undefined);

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -114,16 +114,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class BufferSourceTypes {
@@ -385,16 +376,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class CEReactions {
@@ -733,16 +715,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class DOMImplementation {
@@ -949,20 +922,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-  let isWindow = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-
-      if (globalName === \\"Window\\") {
-        isWindow = true;
-      }
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class DOMRect {
@@ -1142,7 +1102,7 @@ exports.install = (globalObject, globalNames) => {
     value: DOMRect
   });
 
-  if (isWindow) {
+  if (globalNames.includes(\\"Window\\")) {
     Object.defineProperty(globalObject, \\"SVGRect\\", {
       configurable: true,
       writable: true,
@@ -1296,16 +1256,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class DictionaryConvert {
@@ -1419,16 +1370,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Enum {
@@ -1604,16 +1546,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\", \\"Worker\\", \\"AudioWorklet\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class EventTarget {
@@ -1837,16 +1770,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Global\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Global {
@@ -1951,16 +1875,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class HTMLConstructor {
@@ -2049,16 +1964,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class LegacyArrayClass {
@@ -2159,16 +2065,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class MixedIn {
@@ -2313,16 +2210,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
 
@@ -2421,16 +2309,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Overloads {
@@ -2829,16 +2708,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class PromiseTypes {
@@ -2986,16 +2856,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Reflect {
@@ -3307,16 +3168,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class SeqAndRec {
@@ -3610,16 +3462,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Static {
@@ -3760,16 +3603,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Storage {
@@ -4134,16 +3968,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class StringifierAttribute {
@@ -4255,16 +4080,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class StringifierDefaultOperation {
@@ -4365,16 +4181,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class StringifierNamedOperation {
@@ -4483,16 +4290,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class StringifierOperation {
@@ -4593,16 +4391,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class TypedefsAndUnions {
@@ -5122,20 +4911,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-  let isWindow = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-
-      if (globalName === \\"Window\\") {
-        isWindow = true;
-      }
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class URL {
@@ -5459,7 +5235,7 @@ exports.install = (globalObject, globalNames) => {
     value: URL
   });
 
-  if (isWindow) {
+  if (globalNames.includes(\\"Window\\")) {
     Object.defineProperty(globalObject, \\"webkitURL\\", {
       configurable: true,
       writable: true,
@@ -5536,16 +5312,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class URLList {
@@ -5881,16 +5648,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class URLSearchParams {
@@ -6296,16 +6054,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class URLSearchParamsCollection {
@@ -6650,16 +6399,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
 
@@ -6970,16 +6710,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class UnderscoredProperties {
@@ -7253,16 +6984,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Unforgeable {
@@ -7370,16 +7092,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class UnforgeableMap {
@@ -7643,16 +7356,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Unscopable {
@@ -7796,16 +7500,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Variadic {
@@ -8049,16 +7744,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class ZeroArgConstructor {
@@ -8199,16 +7885,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class BufferSourceTypes {
@@ -8469,16 +8146,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class CEReactions {
@@ -8787,16 +8455,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class DOMImplementation {
@@ -9003,20 +8662,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-  let isWindow = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-
-      if (globalName === \\"Window\\") {
-        isWindow = true;
-      }
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class DOMRect {
@@ -9196,7 +8842,7 @@ exports.install = (globalObject, globalNames) => {
     value: DOMRect
   });
 
-  if (isWindow) {
+  if (globalNames.includes(\\"Window\\")) {
     Object.defineProperty(globalObject, \\"SVGRect\\", {
       configurable: true,
       writable: true,
@@ -9350,16 +8996,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class DictionaryConvert {
@@ -9473,16 +9110,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Enum {
@@ -9658,16 +9286,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\", \\"Worker\\", \\"AudioWorklet\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class EventTarget {
@@ -9891,16 +9510,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Global\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Global {
@@ -10004,16 +9614,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class HTMLConstructor {
@@ -10102,16 +9703,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class LegacyArrayClass {
@@ -10212,16 +9804,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class MixedIn {
@@ -10366,16 +9949,7 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
 
@@ -10474,16 +10048,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Overloads {
@@ -10882,16 +10447,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class PromiseTypes {
@@ -11038,16 +10594,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Reflect {
@@ -11345,16 +10892,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class SeqAndRec {
@@ -11648,16 +11186,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Static {
@@ -11798,16 +11327,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Storage {
@@ -12172,16 +11692,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class StringifierAttribute {
@@ -12293,16 +11804,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class StringifierDefaultOperation {
@@ -12403,16 +11905,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class StringifierNamedOperation {
@@ -12521,16 +12014,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class StringifierOperation {
@@ -12631,16 +12115,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class TypedefsAndUnions {
@@ -13160,20 +12635,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-  let isWindow = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-
-      if (globalName === \\"Window\\") {
-        isWindow = true;
-      }
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class URL {
@@ -13497,7 +12959,7 @@ exports.install = (globalObject, globalNames) => {
     value: URL
   });
 
-  if (isWindow) {
+  if (globalNames.includes(\\"Window\\")) {
     Object.defineProperty(globalObject, \\"webkitURL\\", {
       configurable: true,
       writable: true,
@@ -13574,16 +13036,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class URLList {
@@ -13919,16 +13372,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class URLSearchParams {
@@ -14334,16 +13778,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class URLSearchParamsCollection {
@@ -14688,16 +14123,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
 
@@ -15008,16 +14434,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class UnderscoredProperties {
@@ -15291,16 +14708,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Unforgeable {
@@ -15408,16 +14816,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class UnforgeableMap {
@@ -15681,16 +15080,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Unscopable {
@@ -15834,16 +15224,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class Variadic {
@@ -16087,16 +15468,7 @@ exports.setup = function setup(obj, globalObject, constructorArgs = [], privateD
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
-  let isExposed = false;
-
-  for (const globalName of globalNames) {
-    if (exposed.has(globalName)) {
-      isExposed = true;
-      break;
-    }
-  }
-
-  if (!isExposed) {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
   class ZeroArgConstructor {


### PR DESCRIPTION
Extracted from <https://github.com/jsdom/webidl2js/pull/190> at @TimothyGu’s request in <https://github.com/jsdom/webidl2js/pull/191#pullrequestreview-387619767>.

This also fixes a bug where `install` takes `globalName` instead of `globalNames`.

---

This will free up <https://github.com/jsdom/webidl2js/pull/190> to only handle the creation of `webidl2js‑globals.js`.