### PR TITLE
Implement support for callback functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ webidl2js is implementing an ever-growing subset of the Web IDL specification. S
 - `[Clamp]`
 - `[EnforceRange]`
 - `[Exposed]` (temporarily defaulting to `[Exposed=Window]`)
+- `[LegacyTreatNonObjectAsNull]`
 - `[LegacyUnenumerableNamedProperties]`
 - `[LegacyWindowAlias]`
 - `[NoInterfaceObject]`
@@ -498,7 +499,6 @@ Notable missing features include:
 - `[LenientThis]`
 - `[NamedConstructor]`
 - `[SecureContext]`
-- `[TreatNonObjectAsNull]`
 
 ## Nonstandard extended attributes
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ webidl2js is implementing an ever-growing subset of the Web IDL specification. S
 - Enumeration types
 - Union types
 - Callback interfaces
-- Callback function types, somewhat
+- Callback functions
 - Nullable types
 - `sequence<>` types
 - `record<>` types

--- a/lib/constructs/callback-function.js
+++ b/lib/constructs/callback-function.js
@@ -17,13 +17,14 @@ class CallbackFunction {
     this.str = null;
 
     this.requires = new utils.RequiresMap(ctx);
+
+    this.legacyTreatNonObjectAsNull = Boolean(utils.getExtAttr(idl.extAttrs, "LegacyTreatNonObjectAsNull"));
   }
 
   generateConversion() {
-    const { idl } = this;
+    const { idl, legacyTreatNonObjectAsNull } = this;
     const isAsync = idl.idlType.generic === "Promise";
 
-    const legacyTreatNonObjectAsNull = Boolean(utils.getExtAttr(idl.extAttrs, "LegacyTreatNonObjectAsNull"));
     const assertCallable = legacyTreatNonObjectAsNull ? "" : `
       if (typeof value !== "function") {
         throw new TypeError(context + " is not a function");

--- a/lib/constructs/callback-function.js
+++ b/lib/constructs/callback-function.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const conversions = require("webidl-conversions");
+
 const utils = require("../utils.js");
 const Types = require("../types.js");
 
@@ -40,47 +42,77 @@ class CallbackFunction {
 
     // This is a simplification of https://heycam.github.io/webidl/#web-idl-arguments-list-converting that currently
     // fits our needs.
-    const maxArgs = idl.arguments.some(arg => arg.variadic) ? Infinity : idl.arguments.length;
-    let minArgs = 0;
-    for (const arg of idl.arguments) {
-      if (arg.optional || arg.variadic) {
-        break;
-      }
-
-      minArgs++;
-    }
-
     let argsToES = "";
-    if (maxArgs > 0) {
-      argsToES += `
-        for (let i = 0; i < ${Number.isFinite(maxArgs) ? `Math.min(args.length, ${maxArgs})` : "args.length"}; i++) {
-          args[i] = utils.tryWrapperForImpl(args[i]);
+    let inputArgs = "";
+    let applyArgs = "[]";
+
+    if (idl.arguments.length > 0) {
+      if (idl.arguments.every(arg => !arg.optional && !arg.variadic)) {
+        const argNames = idl.arguments.map(arg => arg.name);
+        inputArgs = argNames.join(", ");
+        applyArgs = `[${inputArgs}]`;
+
+        for (const arg of idl.arguments) {
+          const argName = arg.name;
+          if (arg.idlType.union ?
+            arg.idlType.idlType.some(type => !conversions[type]) :
+            !conversions[arg.idlType.idlType]) {
+            argsToES += `
+              ${argName} = utils.tryWrapperForImpl(${argName});
+            `;
+          }
         }
-      `;
+      } else {
+        const maxArgs = idl.arguments.some(arg => arg.variadic) ? Infinity : idl.arguments.length;
+        let minArgs = 0;
 
-      if (minArgs > 0) {
-        argsToES += `
-          if (args.length < ${minArgs}) {
-            for (let i = args.length; i < ${minArgs}; i++) {
-              args[i] = undefined;
+        for (const arg of idl.arguments) {
+          if (arg.optional || arg.variadic) {
+            break;
+          }
+
+          minArgs++;
+        }
+
+        if (maxArgs > 0) {
+          inputArgs = "...args";
+          applyArgs = "args";
+
+          const maxArgsLoop = Number.isFinite(maxArgs) ?
+            `Math.min(args.length, ${maxArgs})` :
+            "args.length";
+
+          argsToES += `
+            for (let i = 0; i < ${maxArgsLoop}; i++) {
+              args[i] = utils.tryWrapperForImpl(args[i]);
             }
-          }
-        `;
-      }
+          `;
 
-      if (Number.isFinite(maxArgs)) {
-        argsToES += `
-          ${minArgs > 0 ? "else" : ""} if (args.length > ${maxArgs}) {
-            args.length = ${maxArgs};
+          if (minArgs > 0) {
+            argsToES += `
+              if (args.length < ${minArgs}) {
+                for (let i = args.length; i < ${minArgs}; i++) {
+                  args[i] = undefined;
+                }
+              }
+            `;
           }
-        `;
+
+          if (Number.isFinite(maxArgs)) {
+            argsToES += `
+              ${minArgs > 0 ? "else" : ""} if (args.length > ${maxArgs}) {
+                args.length = ${maxArgs};
+              }
+            `;
+          }
+        }
       }
     }
 
     this.str += `
       exports.convert = (value, { context = "The provided value" } = {}) => {
         ${assertCallable}
-        function invokeTheCallbackFunction(${maxArgs > 0 ? "...args" : ""}) {
+        function invokeTheCallbackFunction(${inputArgs}) {
           const thisArg = utils.tryWrapperForImpl(this);
           let callResult;
     `;
@@ -99,7 +131,7 @@ class CallbackFunction {
 
     this.str += `
             ${argsToES}
-            callResult = Reflect.apply(value, thisArg, ${maxArgs > 0 ? "args" : "[]"});
+            callResult = Reflect.apply(value, thisArg, ${applyArgs});
     `;
 
     if (treatNonObjectAsNull) {
@@ -125,9 +157,9 @@ class CallbackFunction {
     // `[TreatNonObjctAsNull]` and `isAsync` don't apply to
     // https://heycam.github.io/webidl/#construct-a-callback-function.
     this.str += `
-    invokeTheCallbackFunction.construct = (${maxArgs > 0 ? "...args" : ""}) => {
+        invokeTheCallbackFunction.construct = (${inputArgs}) => {
           ${argsToES}
-          let callResult = Reflect.construct(value, ${maxArgs > 0 ? "args" : "[]"});
+          let callResult = Reflect.construct(value, ${applyArgs});
           ${returnIDL}
         };
     `;

--- a/lib/constructs/callback-function.js
+++ b/lib/constructs/callback-function.js
@@ -23,8 +23,8 @@ class CallbackFunction {
     const { idl } = this;
     const isAsync = idl.idlType.generic === "Promise";
 
-    const treatNonObjectAsNull = Boolean(utils.getExtAttr(idl.extAttrs, "TreatNonObjectAsNull"));
-    const assertCallable = treatNonObjectAsNull ? "" : `
+    const legacyTreatNonObjectAsNull = Boolean(utils.getExtAttr(idl.extAttrs, "LegacyTreatNonObjectAsNull"));
+    const assertCallable = legacyTreatNonObjectAsNull ? "" : `
       if (typeof value !== "function") {
         throw new TypeError(context + " is not a function");
       }
@@ -55,7 +55,7 @@ class CallbackFunction {
         for (const arg of idl.arguments) {
           const argName = arg.name;
           if (arg.idlType.union ?
-            arg.idlType.idlType.some(type => !conversions[type]) :
+            arg.idlType.idlType.some(type => !conversions[type.idlType]) :
             !conversions[arg.idlType.idlType]) {
             argsToES += `
               ${argName} = utils.tryWrapperForImpl(${argName});
@@ -123,7 +123,7 @@ class CallbackFunction {
       `;
     }
 
-    if (treatNonObjectAsNull) {
+    if (legacyTreatNonObjectAsNull) {
       this.str += `
             if (typeof value === "function") {
       `;
@@ -134,7 +134,7 @@ class CallbackFunction {
             callResult = Reflect.apply(value, thisArg, ${applyArgs});
     `;
 
-    if (treatNonObjectAsNull) {
+    if (legacyTreatNonObjectAsNull) {
       this.str += "}";
     }
 

--- a/lib/constructs/callback-function.js
+++ b/lib/constructs/callback-function.js
@@ -114,6 +114,10 @@ class CallbackFunction {
       exports.convert = (value, { context = "The provided value" } = {}) => {
         ${assertCallable}
         function invokeTheCallbackFunction(${inputArgs}) {
+          if (new.target !== undefined) {
+            throw new Error("Internal error: invokeTheCallbackFunction is not a constructor");
+          }
+
           const thisArg = utils.tryWrapperForImpl(this);
           let callResult;
     `;

--- a/lib/constructs/callback-function.js
+++ b/lib/constructs/callback-function.js
@@ -1,0 +1,173 @@
+"use strict";
+
+const utils = require("../utils.js");
+const Types = require("../types.js");
+
+class CallbackFunction {
+  /**
+   * @param {import("../context.js")} ctx
+   * @param {import("webidl2").CallbackType} idl
+   */
+  constructor(ctx, idl) {
+    this.ctx = ctx;
+    this.idl = idl;
+    this.name = idl.name;
+    this.str = null;
+
+    this.requires = new utils.RequiresMap(ctx);
+  }
+
+  generateConversion() {
+    const { idl } = this;
+    const isAsync = idl.idlType.generic === "Promise";
+
+    const treatNonObjectAsNull = Boolean(utils.getExtAttr(idl.extAttrs, "TreatNonObjectAsNull"));
+    const assertCallable = treatNonObjectAsNull ? "" : `
+      if (typeof value !== "function") {
+        throw new TypeError(context + " is not a function");
+      }
+    `;
+
+    let returnIDL = "";
+    if (idl.idlType.idlType !== "void") {
+      const conv = Types.generateTypeConversion(this.ctx, "callResult", idl.idlType, [], this.name, "context");
+      this.requires.merge(conv.requires);
+      returnIDL = `
+        ${conv.body}
+        return callResult;
+      `;
+    }
+
+    // This is a simplification of https://heycam.github.io/webidl/#web-idl-arguments-list-converting that currently
+    // fits our needs.
+    const maxArgs = idl.arguments.some(arg => arg.variadic) ? Infinity : idl.arguments.length;
+    let minArgs = 0;
+    for (const arg of idl.arguments) {
+      if (arg.optional || arg.variadic) {
+        break;
+      }
+
+      minArgs++;
+    }
+
+    let argsToES = "";
+    if (maxArgs > 0) {
+      argsToES += `
+        for (let i = 0; i < ${Number.isFinite(maxArgs) ? `Math.min(args.length, ${maxArgs})` : "args.length"}; i++) {
+          args[i] = utils.tryWrapperForImpl(args[i]);
+        }
+      `;
+
+      if (minArgs > 0) {
+        argsToES += `
+          if (args.length < ${minArgs}) {
+            for (let i = args.length; i < ${minArgs}; i++) {
+              args[i] = undefined;
+            }
+          }
+        `;
+      }
+
+      if (Number.isFinite(maxArgs)) {
+        argsToES += `
+          ${minArgs > 0 ? "else" : ""} if (args.length > ${maxArgs}) {
+            args.length = ${maxArgs};
+          }
+        `;
+      }
+    }
+
+    this.str += `
+      exports.convert = (value, { context = "The provided value" } = {}) => {
+        ${assertCallable}
+        function invokeTheCallbackFunction(${maxArgs > 0 ? "...args" : ""}) {
+          const thisArg = utils.tryWrapperForImpl(this);
+          let callResult;
+    `;
+
+    if (isAsync) {
+      this.str += `
+          try {
+      `;
+    }
+
+    if (treatNonObjectAsNull) {
+      this.str += `
+            if (typeof value === "function") {
+      `;
+    }
+
+    this.str += `
+            ${argsToES}
+            callResult = Reflect.apply(value, thisArg, ${maxArgs > 0 ? "args" : "[]"});
+    `;
+
+    if (treatNonObjectAsNull) {
+      this.str += "}";
+    }
+
+    this.str += `
+            ${returnIDL}
+    `;
+
+    if (isAsync) {
+      this.str += `
+          } catch (err) {
+            return Promise.reject(err);
+          }
+      `;
+    }
+
+    this.str += `
+        };
+    `;
+
+    // `[TreatNonObjctAsNull]` and `isAsync` don't apply to
+    // https://heycam.github.io/webidl/#construct-a-callback-function.
+    this.str += `
+    invokeTheCallbackFunction.construct = (${maxArgs > 0 ? "...args" : ""}) => {
+          ${argsToES}
+          let callResult = Reflect.construct(value, ${maxArgs > 0 ? "args" : "[]"});
+          ${returnIDL}
+        };
+    `;
+
+    // The wrapperSymbol ensures that if the callback function is used as a return value, that it exposes
+    // the original callback back. I.e. it implements the conversion from IDL to JS value in
+    // https://heycam.github.io/webidl/#es-callback-function.
+    //
+    // The objectReference is used to implement spec text such as that discussed in
+    // https://github.com/whatwg/dom/issues/842.
+    this.str += `
+        invokeTheCallbackFunction[utils.wrapperSymbol] = value;
+        invokeTheCallbackFunction.objectReference = value;
+
+        return invokeTheCallbackFunction;
+      };
+    `;
+  }
+
+  generateRequires() {
+    this.str = `
+      ${this.requires.generate()}
+
+      ${this.str}
+    `;
+  }
+
+  generate() {
+    this.generateConversion();
+
+    this.generateRequires();
+  }
+
+  toString() {
+    this.str = "";
+    this.generate();
+    return this.str;
+  }
+}
+
+CallbackFunction.prototype.type = "callback";
+
+module.exports = CallbackFunction;

--- a/lib/constructs/iterable.js
+++ b/lib/constructs/iterable.js
@@ -29,6 +29,8 @@ class Iterable {
 
   generate() {
     const whence = this.interface.defaultWhence;
+    const requires = new utils.RequiresMap(this.ctx);
+
     if (this.isPair) {
       this.generateFunction("keys", "key");
       this.generateFunction("values", "value");
@@ -42,10 +44,9 @@ class Iterable {
           throw new TypeError("Failed to execute 'forEach' on '${this.name}': 1 argument required, " +
                               "but only 0 present.");
         }
-        if (typeof callback !== "function") {
-          throw new TypeError("Failed to execute 'forEach' on '${this.name}': The callback provided " +
-                              "as parameter 1 is not a function.");
-        }
+        callback = ${requires.addRelative("Function")}.convert(callback, {
+          context: "Failed to execute 'forEach' on '${this.name}': The callback provided as parameter 1"
+        });
         const thisArg = arguments[1];
         let pairs = Array.from(this[implSymbol]);
         let i = 0;
@@ -64,9 +65,7 @@ class Iterable {
       // @@iterator is added in Interface class.
     }
 
-    return {
-      requires: new utils.RequiresMap(this.ctx)
-    };
+    return { requires };
   }
 }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,13 +1,17 @@
 "use strict";
 const webidl = require("webidl2");
+const CallbackFunction = require("./constructs/callback-function.js");
 const Typedef = require("./constructs/typedef");
 
-const builtinTypedefs = webidl.parse(`
+const builtinTypes = webidl.parse(`
   typedef (Int8Array or Int16Array or Int32Array or
            Uint8Array or Uint16Array or Uint32Array or Uint8ClampedArray or
            Float32Array or Float64Array or DataView) ArrayBufferView;
   typedef (ArrayBufferView or ArrayBuffer) BufferSource;
   typedef unsigned long long DOMTimeStamp;
+
+  callback Function = any (any... arguments);
+  callback VoidFunction = void ();
 `);
 
 function defaultProcessor(code) {
@@ -20,7 +24,7 @@ class Context {
     processCEReactions = defaultProcessor,
     processHTMLConstructor = defaultProcessor,
     processReflect = null,
-    options
+    options = { suppressErrors: false }
   } = {}) {
     this.implSuffix = implSuffix;
     this.processCEReactions = processCEReactions;
@@ -36,11 +40,19 @@ class Context {
     this.interfaces = new Map();
     this.interfaceMixins = new Map();
     this.callbackInterfaces = new Map();
+    this.callbackFunctions = new Map();
     this.dictionaries = new Map();
     this.enumerations = new Map();
 
-    for (const typedef of builtinTypedefs) {
-      this.typedefs.set(typedef.name, new Typedef(this, typedef));
+    for (const idl of builtinTypes) {
+      switch (idl.type) {
+        case "typedef":
+          this.typedefs.set(idl.name, new Typedef(this, idl));
+          break;
+        case "callback":
+          this.callbackFunctions.set(idl.name, new CallbackFunction(this, idl));
+          break;
+      }
     }
   }
 
@@ -53,6 +65,9 @@ class Context {
     }
     if (this.callbackInterfaces.has(name)) {
       return "callback interface";
+    }
+    if (this.callbackFunctions.has(name)) {
+      return "callback";
     }
     if (this.dictionaries.has(name)) {
       return "dictionary";

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -11,6 +11,7 @@ const Typedef = require("./constructs/typedef");
 const Interface = require("./constructs/interface");
 const InterfaceMixin = require("./constructs/interface-mixin");
 const CallbackInterface = require("./constructs/callback-interface.js");
+const CallbackFunction = require("./constructs/callback-function");
 const Dictionary = require("./constructs/dictionary");
 const Enumeration = require("./constructs/enumeration");
 
@@ -84,7 +85,15 @@ class Transformer {
     }));
 
     this.ctx.initialize();
-    const { interfaces, interfaceMixins, callbackInterfaces, dictionaries, enumerations, typedefs } = this.ctx;
+    const {
+      interfaces,
+      interfaceMixins,
+      callbackInterfaces,
+      callbackFunctions,
+      dictionaries,
+      enumerations,
+      typedefs
+    } = this.ctx;
 
     // first we're gathering all full interfaces and ignore partial ones
     for (const file of parsed) {
@@ -112,6 +121,10 @@ class Transformer {
           case "callback interface":
             obj = new CallbackInterface(this.ctx, instruction);
             callbackInterfaces.set(obj.name, obj);
+            break;
+          case "callback":
+            obj = new CallbackFunction(this.ctx, instruction);
+            callbackFunctions.set(obj.name, obj);
             break;
           case "includes":
             break; // handled later
@@ -198,7 +211,7 @@ class Transformer {
     const utilsText = await fs.readFile(path.resolve(__dirname, "output/utils.js"));
     await fs.writeFile(this.utilPath, utilsText);
 
-    const { interfaces, callbackInterfaces, dictionaries, enumerations } = this.ctx;
+    const { interfaces, callbackInterfaces, callbackFunctions, dictionaries, enumerations } = this.ctx;
 
     let relativeUtils = path.relative(outputDir, this.utilPath).replace(/\\/g, "/");
     if (relativeUtils[0] !== ".") {
@@ -228,7 +241,7 @@ class Transformer {
       await fs.writeFile(path.join(outputDir, obj.name + ".js"), source);
     }
 
-    for (const obj of [...callbackInterfaces.values(), ...dictionaries.values()]) {
+    for (const obj of [...callbackInterfaces.values(), ...callbackFunctions.values(), ...dictionaries.values()]) {
       let source = obj.toString();
 
       source = `

--- a/lib/types.js
+++ b/lib/types.js
@@ -26,7 +26,7 @@ function mergeExtAttrs(a = [], b = []) {
 }
 
 // Types of types that generate an output file.
-const resolvedTypes = new Set(["callback interface", "dictionary", "enumeration", "interface"]);
+const resolvedTypes = new Set(["callback", "callback interface", "dictionary", "enumeration", "interface"]);
 
 function resolveType(ctx, idlType, stack = []) {
   if (resolvedMap.has(idlType)) {
@@ -113,7 +113,12 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
   } else if (idlType.generic === "FrozenArray") {
     // frozen array type
     generateFrozenArray();
-  } else if (conversions[idlType.idlType]) {
+  } else if (
+    // TODO: Revert once `Function` and `VoidFunction` are removed from `webidl-conversions`:
+    idlType.idlType !== "Function" &&
+    idlType.idlType !== "VoidFunction" &&
+    conversions[idlType.idlType]
+  ) {
     // string or number type compatible with webidl-conversions
     generateGeneric(`conversions["${idlType.idlType}"]`);
   } else if (resolvedTypes.has(ctx.typeOf(idlType.idlType))) {
@@ -201,11 +206,14 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
       output.push(`if (${condition}) {}`);
     }
 
-    if (union.callback || union.object) {
-      output.push(`if (typeof ${name} === "function") {}`);
-    }
-
-    if (union.sequenceLike || union.dictionary || union.record || union.object || union.callbackInterface) {
+    if (
+      union.sequenceLike ||
+      union.dictionary ||
+      union.record ||
+      union.object ||
+      union.callback ||
+      union.callbackInterface
+    ) {
       let code = `if (utils.isObject(${name})) {`;
 
       if (union.sequenceLike) {
@@ -225,6 +233,11 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
       } else if (union.record) {
         const conv = generateTypeConversion(ctx, name, union.record, [], parentName,
           `${errPrefix} + " record"`);
+        requires.merge(conv.requires);
+        code += conv.body;
+      } else if (union.callback) {
+        const conv = generateTypeConversion(ctx, name, union.callback, [], parentName,
+          `${errPrefix} + " callback function"`);
         requires.merge(conv.requires);
         code += conv.body;
       } else if (union.callbackInterface) {
@@ -402,7 +415,7 @@ function extractUnionInfo(ctx, idlType, errPrefix) {
     numeric: null,
     boolean: null,
     // Callback function, not interface
-    callback: false,
+    callback: null,
     dictionary: null,
     callbackInterface: null,
     interfaces: new Set(),
@@ -470,15 +483,14 @@ function extractUnionInfo(ctx, idlType, errPrefix) {
       seen.object = true;
     } else if (item.idlType === "boolean") {
       seen.boolean = item;
-    } else if (item.idlType === "Function") {
-      // TODO: add full support for callback functions
+    } else if (ctx.callbackFunctions.has(item.idlType)) {
       if (seen.object) {
         error("Callback functions are not distinguishable with object type");
       }
       if (seen.dictionaryLike) {
         error("Callback functions are not distinguishable with dictionary-like types");
       }
-      seen.callback = true;
+      seen.callback = item.idlType;
     } else if (ctx.dictionaries.has(item.idlType)) {
       if (seen.object) {
         error("Dictionary-like types are not distinguishable with object type");

--- a/lib/types.js
+++ b/lib/types.js
@@ -91,11 +91,20 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
   const extAttrs = idlType.extAttrs !== undefined ? [...idlType.extAttrs, ...argAttrs] : argAttrs;
 
   if (idlType.nullable) {
-    str += `
-      if (${name} === null || ${name} === undefined) {
-        ${name} = null;
-      } else {
-    `;
+    const callbackFunction = ctx.callbackFunctions.get(idlType.idlType);
+    if (callbackFunction !== undefined && callbackFunction.legacyTreatNonObjectAsNull) {
+      str += `
+        if (!utils.isObject(${name})) {
+          ${name} = null;
+        } else {
+      `;
+    } else {
+      str += `
+        if (${name} === null || ${name} === undefined) {
+          ${name} = null;
+        } else {
+      `;
+    }
   }
 
   if (idlType.union) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -131,7 +131,7 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
     // string or number type compatible with webidl-conversions
     generateGeneric(`conversions["${idlType.idlType}"]`);
   } else if (resolvedTypes.has(ctx.typeOf(idlType.idlType))) {
-    // callback interfaces, dictionaries, enumerations, and interfaces
+    // callback functions, callback interfaces, dictionaries, enumerations, and interfaces
     let fn;
     // Avoid requiring the interface itself
     if (idlType.idlType !== parentName) {
@@ -215,14 +215,24 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
       output.push(`if (${condition}) {}`);
     }
 
-    if (
-      union.sequenceLike ||
-      union.dictionary ||
-      union.record ||
-      union.object ||
-      union.callback ||
-      union.callbackInterface
-    ) {
+    if (union.callbackFunction || union.object) {
+      let code = `if (typeof ${name} === "function") {`;
+
+      if (union.callbackFunction) {
+        const conv = generateTypeConversion(ctx, name, union.callbackFunction, [], parentName,
+          `${errPrefix} + " callback function"`);
+        requires.merge(conv.requires);
+        code += conv.body;
+      } else if (union.object) {
+        // noop
+      }
+
+      code += "}";
+
+      output.push(code);
+    }
+
+    if (union.sequenceLike || union.dictionary || union.record || union.object || union.callbackInterface) {
       let code = `if (utils.isObject(${name})) {`;
 
       if (union.sequenceLike) {
@@ -242,11 +252,6 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
       } else if (union.record) {
         const conv = generateTypeConversion(ctx, name, union.record, [], parentName,
           `${errPrefix} + " record"`);
-        requires.merge(conv.requires);
-        code += conv.body;
-      } else if (union.callback) {
-        const conv = generateTypeConversion(ctx, name, union.callback, [], parentName,
-          `${errPrefix} + " callback function"`);
         requires.merge(conv.requires);
         code += conv.body;
       } else if (union.callbackInterface) {
@@ -423,8 +428,7 @@ function extractUnionInfo(ctx, idlType, errPrefix) {
     string: null,
     numeric: null,
     boolean: null,
-    // Callback function, not interface
-    callback: null,
+    callbackFunction: null,
     dictionary: null,
     callbackInterface: null,
     interfaces: new Set(),
@@ -443,7 +447,7 @@ function extractUnionInfo(ctx, idlType, errPrefix) {
       if (seen.object) {
         error("Dictionary-like types are not distinguishable with object type");
       }
-      if (seen.callback) {
+      if (seen.callbackFunction) {
         error("Dictionary-like types are not distinguishable with callback functions");
       }
       if (seen.dictionaryLike) {
@@ -480,7 +484,7 @@ function extractUnionInfo(ctx, idlType, errPrefix) {
       if (seen.interfaceLike) {
         error("Object type is not distinguishable with interface-like types");
       }
-      if (seen.callback) {
+      if (seen.callbackFunction) {
         error("Object type is not distinguishable with callback functions");
       }
       if (seen.dictionaryLike) {
@@ -499,12 +503,12 @@ function extractUnionInfo(ctx, idlType, errPrefix) {
       if (seen.dictionaryLike) {
         error("Callback functions are not distinguishable with dictionary-like types");
       }
-      seen.callback = item.idlType;
+      seen.callbackFunction = item.idlType;
     } else if (ctx.dictionaries.has(item.idlType)) {
       if (seen.object) {
         error("Dictionary-like types are not distinguishable with object type");
       }
-      if (seen.callback) {
+      if (seen.callbackFunction) {
         error("Dictionary-like types are not distinguishable with callback functions");
       }
       if (seen.dictionaryLike) {
@@ -515,7 +519,7 @@ function extractUnionInfo(ctx, idlType, errPrefix) {
       if (seen.object) {
         error("Dictionary-like types are not distinguishable with object type");
       }
-      if (seen.callback) {
+      if (seen.callbackFunction) {
         error("Dictionary-like types are not distinguishable with callback functions");
       }
       if (seen.dictionaryLike) {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -12,6 +12,10 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
   }
 
   function invokeTheCallbackFunction(...args) {
+    if (new.target !== undefined) {
+      throw new Error(\\"Internal error: invokeTheCallbackFunction is not a constructor\\");
+    }
+
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
@@ -58,6 +62,10 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
   }
 
   function invokeTheCallbackFunction() {
+    if (new.target !== undefined) {
+      throw new Error(\\"Internal error: invokeTheCallbackFunction is not a constructor\\");
+    }
+
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
@@ -88,6 +96,10 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
   }
 
   function invokeTheCallbackFunction() {
+    if (new.target !== undefined) {
+      throw new Error(\\"Internal error: invokeTheCallbackFunction is not a constructor\\");
+    }
+
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
@@ -6841,6 +6853,10 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
   }
 
   function invokeTheCallbackFunction(url, string) {
+    if (new.target !== undefined) {
+      throw new Error(\\"Internal error: invokeTheCallbackFunction is not a constructor\\");
+    }
+
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
@@ -6879,6 +6895,10 @@ const utils = require(\\"./utils.js\\");
 
 exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
   function invokeTheCallbackFunction(url) {
+    if (new.target !== undefined) {
+      throw new Error(\\"Internal error: invokeTheCallbackFunction is not a constructor\\");
+    }
+
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
@@ -7648,7 +7668,7 @@ exports.install = (globalObject, globalNames) => {
         throw new TypeError(\\"Illegal invocation\\");
       }
       if (arguments.length < 1) {
-        throw new TypeError(\\"Failed to execute 'forEach' on 'iterable': 1 argument required, but only 0 present.\\");
+        throw new TypeError(\\"Failed to execute 'forEach' on 'iterable': 1 argument required, \\" + \\"but only 0 present.\\");
       }
       callback = Function.convert(callback, {
         context: \\"Failed to execute 'forEach' on 'iterable': The callback provided as parameter 1\\"
@@ -9157,6 +9177,10 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
   }
 
   function invokeTheCallbackFunction() {
+    if (new.target !== undefined) {
+      throw new Error(\\"Internal error: invokeTheCallbackFunction is not a constructor\\");
+    }
+
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
@@ -15853,6 +15877,10 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
   }
 
   function invokeTheCallbackFunction(url, string) {
+    if (new.target !== undefined) {
+      throw new Error(\\"Internal error: invokeTheCallbackFunction is not a constructor\\");
+    }
+
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
@@ -15891,6 +15919,10 @@ const utils = require(\\"./utils.js\\");
 
 exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
   function invokeTheCallbackFunction(url) {
+    if (new.target !== undefined) {
+      throw new Error(\\"Internal error: invokeTheCallbackFunction is not a constructor\\");
+    }
+
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
@@ -16660,7 +16692,7 @@ exports.install = (globalObject, globalNames) => {
         throw new TypeError(\\"Illegal invocation\\");
       }
       if (arguments.length < 1) {
-        throw new TypeError(\\"Failed to execute 'forEach' on 'iterable': 1 argument required, but only 0 present.\\");
+        throw new TypeError(\\"Failed to execute 'forEach' on 'iterable': 1 argument required, \\" + \\"but only 0 present.\\");
       }
       callback = Function.convert(callback, {
         context: \\"Failed to execute 'forEach' on 'iterable': The callback provided as parameter 1\\"

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -76,6 +76,62 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
 "
 `;
 
+exports[`with processors AsyncCallbackFunction.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (typeof value !== \\"function\\") {
+    throw new TypeError(context + \\" is not a function\\");
+  }
+
+  function invokeTheCallbackFunction() {
+    const thisArg = utils.tryWrapperForImpl(this);
+    let callResult;
+
+    try {
+      callResult = Reflect.apply(value, thisArg, []);
+
+      callResult = Promise.resolve(callResult).then(
+        value => {
+          value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
+
+          return value;
+        },
+        reason => reason
+      );
+
+      return callResult;
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  }
+
+  invokeTheCallbackFunction.construct = () => {
+    let callResult = Reflect.construct(value, []);
+
+    callResult = Promise.resolve(callResult).then(
+      value => {
+        value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
+
+        return value;
+      },
+      reason => reason
+    );
+
+    return callResult;
+  };
+
+  invokeTheCallbackFunction[utils.wrapperSymbol] = value;
+  invokeTheCallbackFunction.objectReference = value;
+
+  return invokeTheCallbackFunction;
+};
+"
+`;
+
 exports[`with processors AsyncCallbackInterface.webidl 1`] = `
 "\\"use strict\\";
 
@@ -5415,43 +5471,23 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
     throw new TypeError(context + \\" is not a function\\");
   }
 
-  function invokeTheCallbackFunction(...args) {
+  function invokeTheCallbackFunction(url, string) {
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
-    for (let i = 0; i < Math.min(args.length, 2); i++) {
-      args[i] = utils.tryWrapperForImpl(args[i]);
-    }
+    url = utils.tryWrapperForImpl(url);
 
-    if (args.length < 2) {
-      for (let i = args.length; i < 2; i++) {
-        args[i] = undefined;
-      }
-    } else if (args.length > 2) {
-      args.length = 2;
-    }
-
-    callResult = Reflect.apply(value, thisArg, args);
+    callResult = Reflect.apply(value, thisArg, [url, string]);
 
     callResult = URL.convert(callResult, { context: context });
 
     return callResult;
   }
 
-  invokeTheCallbackFunction.construct = (...args) => {
-    for (let i = 0; i < Math.min(args.length, 2); i++) {
-      args[i] = utils.tryWrapperForImpl(args[i]);
-    }
+  invokeTheCallbackFunction.construct = (url, string) => {
+    url = utils.tryWrapperForImpl(url);
 
-    if (args.length < 2) {
-      for (let i = args.length; i < 2; i++) {
-        args[i] = undefined;
-      }
-    } else if (args.length > 2) {
-      args.length = 2;
-    }
-
-    let callResult = Reflect.construct(value, args);
+    let callResult = Reflect.construct(value, [url, string]);
 
     callResult = URL.convert(callResult, { context: context });
 
@@ -5473,24 +5509,14 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
-  function invokeTheCallbackFunction(...args) {
+  function invokeTheCallbackFunction(url) {
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
     if (typeof value === \\"function\\") {
-      for (let i = 0; i < Math.min(args.length, 1); i++) {
-        args[i] = utils.tryWrapperForImpl(args[i]);
-      }
+      url = utils.tryWrapperForImpl(url);
 
-      if (args.length < 1) {
-        for (let i = args.length; i < 1; i++) {
-          args[i] = undefined;
-        }
-      } else if (args.length > 1) {
-        args.length = 1;
-      }
-
-      callResult = Reflect.apply(value, thisArg, args);
+      callResult = Reflect.apply(value, thisArg, [url]);
     }
 
     callResult = conversions[\\"any\\"](callResult, { context: context });
@@ -5498,20 +5524,10 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
     return callResult;
   }
 
-  invokeTheCallbackFunction.construct = (...args) => {
-    for (let i = 0; i < Math.min(args.length, 1); i++) {
-      args[i] = utils.tryWrapperForImpl(args[i]);
-    }
+  invokeTheCallbackFunction.construct = url => {
+    url = utils.tryWrapperForImpl(url);
 
-    if (args.length < 1) {
-      for (let i = args.length; i < 1; i++) {
-        args[i] = undefined;
-      }
-    } else if (args.length > 1) {
-      args.length = 1;
-    }
-
-    let callResult = Reflect.construct(value, args);
+    let callResult = Reflect.construct(value, [url]);
 
     callResult = conversions[\\"any\\"](callResult, { context: context });
 
@@ -8046,6 +8062,62 @@ exports.install = (globalObject, globalNames) => {
 };
 
 const Impl = require(\\"../implementations/ZeroArgConstructor.js\\");
+"
+`;
+
+exports[`without processors AsyncCallbackFunction.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (typeof value !== \\"function\\") {
+    throw new TypeError(context + \\" is not a function\\");
+  }
+
+  function invokeTheCallbackFunction() {
+    const thisArg = utils.tryWrapperForImpl(this);
+    let callResult;
+
+    try {
+      callResult = Reflect.apply(value, thisArg, []);
+
+      callResult = Promise.resolve(callResult).then(
+        value => {
+          value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
+
+          return value;
+        },
+        reason => reason
+      );
+
+      return callResult;
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  }
+
+  invokeTheCallbackFunction.construct = () => {
+    let callResult = Reflect.construct(value, []);
+
+    callResult = Promise.resolve(callResult).then(
+      value => {
+        value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
+
+        return value;
+      },
+      reason => reason
+    );
+
+    return callResult;
+  };
+
+  invokeTheCallbackFunction[utils.wrapperSymbol] = value;
+  invokeTheCallbackFunction.objectReference = value;
+
+  return invokeTheCallbackFunction;
+};
 "
 `;
 
@@ -13341,43 +13413,23 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
     throw new TypeError(context + \\" is not a function\\");
   }
 
-  function invokeTheCallbackFunction(...args) {
+  function invokeTheCallbackFunction(url, string) {
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
-    for (let i = 0; i < Math.min(args.length, 2); i++) {
-      args[i] = utils.tryWrapperForImpl(args[i]);
-    }
+    url = utils.tryWrapperForImpl(url);
 
-    if (args.length < 2) {
-      for (let i = args.length; i < 2; i++) {
-        args[i] = undefined;
-      }
-    } else if (args.length > 2) {
-      args.length = 2;
-    }
-
-    callResult = Reflect.apply(value, thisArg, args);
+    callResult = Reflect.apply(value, thisArg, [url, string]);
 
     callResult = URL.convert(callResult, { context: context });
 
     return callResult;
   }
 
-  invokeTheCallbackFunction.construct = (...args) => {
-    for (let i = 0; i < Math.min(args.length, 2); i++) {
-      args[i] = utils.tryWrapperForImpl(args[i]);
-    }
+  invokeTheCallbackFunction.construct = (url, string) => {
+    url = utils.tryWrapperForImpl(url);
 
-    if (args.length < 2) {
-      for (let i = args.length; i < 2; i++) {
-        args[i] = undefined;
-      }
-    } else if (args.length > 2) {
-      args.length = 2;
-    }
-
-    let callResult = Reflect.construct(value, args);
+    let callResult = Reflect.construct(value, [url, string]);
 
     callResult = URL.convert(callResult, { context: context });
 
@@ -13399,24 +13451,14 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
-  function invokeTheCallbackFunction(...args) {
+  function invokeTheCallbackFunction(url) {
     const thisArg = utils.tryWrapperForImpl(this);
     let callResult;
 
     if (typeof value === \\"function\\") {
-      for (let i = 0; i < Math.min(args.length, 1); i++) {
-        args[i] = utils.tryWrapperForImpl(args[i]);
-      }
+      url = utils.tryWrapperForImpl(url);
 
-      if (args.length < 1) {
-        for (let i = args.length; i < 1; i++) {
-          args[i] = undefined;
-        }
-      } else if (args.length > 1) {
-        args.length = 1;
-      }
-
-      callResult = Reflect.apply(value, thisArg, args);
+      callResult = Reflect.apply(value, thisArg, [url]);
     }
 
     callResult = conversions[\\"any\\"](callResult, { context: context });
@@ -13424,20 +13466,10 @@ exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
     return callResult;
   }
 
-  invokeTheCallbackFunction.construct = (...args) => {
-    for (let i = 0; i < Math.min(args.length, 1); i++) {
-      args[i] = utils.tryWrapperForImpl(args[i]);
-    }
+  invokeTheCallbackFunction.construct = url => {
+    url = utils.tryWrapperForImpl(url);
 
-    if (args.length < 1) {
-      for (let i = args.length; i < 1; i++) {
-        args[i] = undefined;
-      }
-    } else if (args.length > 1) {
-      args.length = 1;
-    }
-
-    let callResult = Reflect.construct(value, args);
+    let callResult = Reflect.construct(value, [url]);
 
     callResult = conversions[\\"any\\"](callResult, { context: context });
 

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,5 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`built-in types Function 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (typeof value !== \\"function\\") {
+    throw new TypeError(context + \\" is not a function\\");
+  }
+
+  function invokeTheCallbackFunction(...args) {
+    const thisArg = utils.tryWrapperForImpl(this);
+    let callResult;
+
+    for (let i = 0; i < args.length; i++) {
+      args[i] = utils.tryWrapperForImpl(args[i]);
+    }
+
+    callResult = Reflect.apply(value, thisArg, args);
+
+    callResult = conversions[\\"any\\"](callResult, { context: context });
+
+    return callResult;
+  }
+
+  invokeTheCallbackFunction.construct = (...args) => {
+    for (let i = 0; i < args.length; i++) {
+      args[i] = utils.tryWrapperForImpl(args[i]);
+    }
+
+    let callResult = Reflect.construct(value, args);
+
+    callResult = conversions[\\"any\\"](callResult, { context: context });
+
+    return callResult;
+  };
+
+  invokeTheCallbackFunction[utils.wrapperSymbol] = value;
+  invokeTheCallbackFunction.objectReference = value;
+
+  return invokeTheCallbackFunction;
+};
+"
+`;
+
+exports[`built-in types VoidFunction 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (typeof value !== \\"function\\") {
+    throw new TypeError(context + \\" is not a function\\");
+  }
+
+  function invokeTheCallbackFunction() {
+    const thisArg = utils.tryWrapperForImpl(this);
+    let callResult;
+
+    callResult = Reflect.apply(value, thisArg, []);
+  }
+
+  invokeTheCallbackFunction.construct = () => {
+    let callResult = Reflect.construct(value, []);
+  };
+
+  invokeTheCallbackFunction[utils.wrapperSymbol] = value;
+  invokeTheCallbackFunction.objectReference = value;
+
+  return invokeTheCallbackFunction;
+};
+"
+`;
+
 exports[`with processors AsyncCallbackInterface.webidl 1`] = `
 "\\"use strict\\";
 
@@ -650,6 +726,84 @@ class ProxyHandler {
 }
 
 const Impl = require(\\"../implementations/CEReactions.js\\");
+"
+`;
+
+exports[`with processors CallbackUsage.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const Function = require(\\"./Function.js\\");
+const URLCallback = require(\\"./URLCallback.js\\");
+const URLHandlerNonNull = require(\\"./URLHandlerNonNull.js\\");
+const VoidFunction = require(\\"./VoidFunction.js\\");
+
+exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}) => {
+  {
+    const key = \\"function\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = Function.convert(value, { context: context + \\" has member function that\\" });
+
+      ret[key] = value;
+    }
+  }
+
+  {
+    const key = \\"urlCallback\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = URLCallback.convert(value, { context: context + \\" has member urlCallback that\\" });
+
+      ret[key] = value;
+    }
+  }
+
+  {
+    const key = \\"urlHandler\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      if (value === null || value === undefined) {
+        value = null;
+      } else {
+        value = URLHandlerNonNull.convert(value, { context: context + \\" has member urlHandler that\\" });
+      }
+      ret[key] = value;
+    }
+  }
+
+  {
+    const key = \\"urlHandlerNonNull\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = URLHandlerNonNull.convert(value, { context: context + \\" has member urlHandlerNonNull that\\" });
+
+      ret[key] = value;
+    }
+  }
+
+  {
+    const key = \\"voidFunction\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = VoidFunction.convert(value, { context: context + \\" has member voidFunction that\\" });
+
+      ret[key] = value;
+    }
+  }
+};
+
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (obj !== undefined && typeof obj !== \\"object\\" && typeof obj !== \\"function\\") {
+    throw new TypeError(\`\${context} is not an object.\`);
+  }
+
+  const ret = Object.create(null);
+  exports._convertInherit(obj, ret, { context });
+  return ret;
+};
 "
 `;
 
@@ -5248,6 +5402,130 @@ const Impl = require(\\"../implementations/URL.js\\");
 "
 `;
 
+exports[`with processors URLCallback.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const URL = require(\\"./URL.js\\");
+
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (typeof value !== \\"function\\") {
+    throw new TypeError(context + \\" is not a function\\");
+  }
+
+  function invokeTheCallbackFunction(...args) {
+    const thisArg = utils.tryWrapperForImpl(this);
+    let callResult;
+
+    for (let i = 0; i < Math.min(args.length, 2); i++) {
+      args[i] = utils.tryWrapperForImpl(args[i]);
+    }
+
+    if (args.length < 2) {
+      for (let i = args.length; i < 2; i++) {
+        args[i] = undefined;
+      }
+    } else if (args.length > 2) {
+      args.length = 2;
+    }
+
+    callResult = Reflect.apply(value, thisArg, args);
+
+    callResult = URL.convert(callResult, { context: context });
+
+    return callResult;
+  }
+
+  invokeTheCallbackFunction.construct = (...args) => {
+    for (let i = 0; i < Math.min(args.length, 2); i++) {
+      args[i] = utils.tryWrapperForImpl(args[i]);
+    }
+
+    if (args.length < 2) {
+      for (let i = args.length; i < 2; i++) {
+        args[i] = undefined;
+      }
+    } else if (args.length > 2) {
+      args.length = 2;
+    }
+
+    let callResult = Reflect.construct(value, args);
+
+    callResult = URL.convert(callResult, { context: context });
+
+    return callResult;
+  };
+
+  invokeTheCallbackFunction[utils.wrapperSymbol] = value;
+  invokeTheCallbackFunction.objectReference = value;
+
+  return invokeTheCallbackFunction;
+};
+"
+`;
+
+exports[`with processors URLHandlerNonNull.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  function invokeTheCallbackFunction(...args) {
+    const thisArg = utils.tryWrapperForImpl(this);
+    let callResult;
+
+    if (typeof value === \\"function\\") {
+      for (let i = 0; i < Math.min(args.length, 1); i++) {
+        args[i] = utils.tryWrapperForImpl(args[i]);
+      }
+
+      if (args.length < 1) {
+        for (let i = args.length; i < 1; i++) {
+          args[i] = undefined;
+        }
+      } else if (args.length > 1) {
+        args.length = 1;
+      }
+
+      callResult = Reflect.apply(value, thisArg, args);
+    }
+
+    callResult = conversions[\\"any\\"](callResult, { context: context });
+
+    return callResult;
+  }
+
+  invokeTheCallbackFunction.construct = (...args) => {
+    for (let i = 0; i < Math.min(args.length, 1); i++) {
+      args[i] = utils.tryWrapperForImpl(args[i]);
+    }
+
+    if (args.length < 1) {
+      for (let i = args.length; i < 1; i++) {
+        args[i] = undefined;
+      }
+    } else if (args.length > 1) {
+      args.length = 1;
+    }
+
+    let callResult = Reflect.construct(value, args);
+
+    callResult = conversions[\\"any\\"](callResult, { context: context });
+
+    return callResult;
+  };
+
+  invokeTheCallbackFunction[utils.wrapperSymbol] = value;
+  invokeTheCallbackFunction.objectReference = value;
+
+  return invokeTheCallbackFunction;
+};
+"
+`;
+
 exports[`with processors URLList.webidl 1`] = `
 "\\"use strict\\";
 
@@ -8390,6 +8668,84 @@ class ProxyHandler {
 }
 
 const Impl = require(\\"../implementations/CEReactions.js\\");
+"
+`;
+
+exports[`without processors CallbackUsage.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const Function = require(\\"./Function.js\\");
+const URLCallback = require(\\"./URLCallback.js\\");
+const URLHandlerNonNull = require(\\"./URLHandlerNonNull.js\\");
+const VoidFunction = require(\\"./VoidFunction.js\\");
+
+exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}) => {
+  {
+    const key = \\"function\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = Function.convert(value, { context: context + \\" has member function that\\" });
+
+      ret[key] = value;
+    }
+  }
+
+  {
+    const key = \\"urlCallback\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = URLCallback.convert(value, { context: context + \\" has member urlCallback that\\" });
+
+      ret[key] = value;
+    }
+  }
+
+  {
+    const key = \\"urlHandler\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      if (value === null || value === undefined) {
+        value = null;
+      } else {
+        value = URLHandlerNonNull.convert(value, { context: context + \\" has member urlHandler that\\" });
+      }
+      ret[key] = value;
+    }
+  }
+
+  {
+    const key = \\"urlHandlerNonNull\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = URLHandlerNonNull.convert(value, { context: context + \\" has member urlHandlerNonNull that\\" });
+
+      ret[key] = value;
+    }
+  }
+
+  {
+    const key = \\"voidFunction\\";
+    let value = obj === undefined || obj === null ? undefined : obj[key];
+    if (value !== undefined) {
+      value = VoidFunction.convert(value, { context: context + \\" has member voidFunction that\\" });
+
+      ret[key] = value;
+    }
+  }
+};
+
+exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
+  if (obj !== undefined && typeof obj !== \\"object\\" && typeof obj !== \\"function\\") {
+    throw new TypeError(\`\${context} is not an object.\`);
+  }
+
+  const ret = Object.create(null);
+  exports._convertInherit(obj, ret, { context });
+  return ret;
+};
 "
 `;
 
@@ -12969,6 +13325,130 @@ exports.install = (globalObject, globalNames) => {
 };
 
 const Impl = require(\\"../implementations/URL.js\\");
+"
+`;
+
+exports[`without processors URLCallback.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const URL = require(\\"./URL.js\\");
+
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (typeof value !== \\"function\\") {
+    throw new TypeError(context + \\" is not a function\\");
+  }
+
+  function invokeTheCallbackFunction(...args) {
+    const thisArg = utils.tryWrapperForImpl(this);
+    let callResult;
+
+    for (let i = 0; i < Math.min(args.length, 2); i++) {
+      args[i] = utils.tryWrapperForImpl(args[i]);
+    }
+
+    if (args.length < 2) {
+      for (let i = args.length; i < 2; i++) {
+        args[i] = undefined;
+      }
+    } else if (args.length > 2) {
+      args.length = 2;
+    }
+
+    callResult = Reflect.apply(value, thisArg, args);
+
+    callResult = URL.convert(callResult, { context: context });
+
+    return callResult;
+  }
+
+  invokeTheCallbackFunction.construct = (...args) => {
+    for (let i = 0; i < Math.min(args.length, 2); i++) {
+      args[i] = utils.tryWrapperForImpl(args[i]);
+    }
+
+    if (args.length < 2) {
+      for (let i = args.length; i < 2; i++) {
+        args[i] = undefined;
+      }
+    } else if (args.length > 2) {
+      args.length = 2;
+    }
+
+    let callResult = Reflect.construct(value, args);
+
+    callResult = URL.convert(callResult, { context: context });
+
+    return callResult;
+  };
+
+  invokeTheCallbackFunction[utils.wrapperSymbol] = value;
+  invokeTheCallbackFunction.objectReference = value;
+
+  return invokeTheCallbackFunction;
+};
+"
+`;
+
+exports[`without processors URLHandlerNonNull.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  function invokeTheCallbackFunction(...args) {
+    const thisArg = utils.tryWrapperForImpl(this);
+    let callResult;
+
+    if (typeof value === \\"function\\") {
+      for (let i = 0; i < Math.min(args.length, 1); i++) {
+        args[i] = utils.tryWrapperForImpl(args[i]);
+      }
+
+      if (args.length < 1) {
+        for (let i = args.length; i < 1; i++) {
+          args[i] = undefined;
+        }
+      } else if (args.length > 1) {
+        args.length = 1;
+      }
+
+      callResult = Reflect.apply(value, thisArg, args);
+    }
+
+    callResult = conversions[\\"any\\"](callResult, { context: context });
+
+    return callResult;
+  }
+
+  invokeTheCallbackFunction.construct = (...args) => {
+    for (let i = 0; i < Math.min(args.length, 1); i++) {
+      args[i] = utils.tryWrapperForImpl(args[i]);
+    }
+
+    if (args.length < 1) {
+      for (let i = args.length; i < 1; i++) {
+        args[i] = undefined;
+      }
+    } else if (args.length > 1) {
+      args.length = 1;
+    }
+
+    let callResult = Reflect.construct(value, args);
+
+    callResult = conversions[\\"any\\"](callResult, { context: context });
+
+    return callResult;
+  };
+
+  invokeTheCallbackFunction[utils.wrapperSymbol] = value;
+  invokeTheCallbackFunction.objectReference = value;
+
+  return invokeTheCallbackFunction;
+};
 "
 `;
 

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -869,7 +869,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"urlHandler\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      if (value === null || value === undefined) {
+      if (!utils.isObject(value)) {
         value = null;
       } else {
         value = URLHandlerNonNull.convert(value, { context: context + \\" has member 'urlHandler' that\\" });
@@ -9444,7 +9444,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"urlHandler\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      if (value === null || value === undefined) {
+      if (!utils.isObject(value)) {
         value = null;
       } else {
         value = URLHandlerNonNull.convert(value, { context: context + \\" has member 'urlHandler' that\\" });

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -7231,6 +7231,7 @@ exports[`with processors URLSearchParams.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
+const Function = require(\\"./Function.js\\");
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -7647,13 +7648,11 @@ exports.install = (globalObject, globalNames) => {
         throw new TypeError(\\"Illegal invocation\\");
       }
       if (arguments.length < 1) {
-        throw new TypeError(\\"Failed to execute 'forEach' on 'iterable': 1 argument required, \\" + \\"but only 0 present.\\");
+        throw new TypeError(\\"Failed to execute 'forEach' on 'iterable': 1 argument required, but only 0 present.\\");
       }
-      if (typeof callback !== \\"function\\") {
-        throw new TypeError(
-          \\"Failed to execute 'forEach' on 'iterable': The callback provided \\" + \\"as parameter 1 is not a function.\\"
-        );
-      }
+      callback = Function.convert(callback, {
+        context: \\"Failed to execute 'forEach' on 'iterable': The callback provided as parameter 1\\"
+      });
       const thisArg = arguments[1];
       let pairs = Array.from(this[implSymbol]);
       let i = 0;
@@ -16244,6 +16243,7 @@ exports[`without processors URLSearchParams.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
+const Function = require(\\"./Function.js\\");
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -16660,13 +16660,11 @@ exports.install = (globalObject, globalNames) => {
         throw new TypeError(\\"Illegal invocation\\");
       }
       if (arguments.length < 1) {
-        throw new TypeError(\\"Failed to execute 'forEach' on 'iterable': 1 argument required, \\" + \\"but only 0 present.\\");
+        throw new TypeError(\\"Failed to execute 'forEach' on 'iterable': 1 argument required, but only 0 present.\\");
       }
-      if (typeof callback !== \\"function\\") {
-        throw new TypeError(
-          \\"Failed to execute 'forEach' on 'iterable': The callback provided \\" + \\"as parameter 1 is not a function.\\"
-        );
-      }
+      callback = Function.convert(callback, {
+        context: \\"Failed to execute 'forEach' on 'iterable': The callback provided as parameter 1\\"
+      });
       const thisArg = arguments[1];
       let pairs = Array.from(this[implSymbol]);
       let i = 0;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -849,7 +849,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"function\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = Function.convert(value, { context: context + \\" has member function that\\" });
+      value = Function.convert(value, { context: context + \\" has member 'function' that\\" });
 
       ret[key] = value;
     }
@@ -859,7 +859,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"urlCallback\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = URLCallback.convert(value, { context: context + \\" has member urlCallback that\\" });
+      value = URLCallback.convert(value, { context: context + \\" has member 'urlCallback' that\\" });
 
       ret[key] = value;
     }
@@ -872,7 +872,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
       if (value === null || value === undefined) {
         value = null;
       } else {
-        value = URLHandlerNonNull.convert(value, { context: context + \\" has member urlHandler that\\" });
+        value = URLHandlerNonNull.convert(value, { context: context + \\" has member 'urlHandler' that\\" });
       }
       ret[key] = value;
     }
@@ -882,7 +882,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"urlHandlerNonNull\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = URLHandlerNonNull.convert(value, { context: context + \\" has member urlHandlerNonNull that\\" });
+      value = URLHandlerNonNull.convert(value, { context: context + \\" has member 'urlHandlerNonNull' that\\" });
 
       ret[key] = value;
     }
@@ -892,7 +892,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"voidFunction\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = VoidFunction.convert(value, { context: context + \\" has member voidFunction that\\" });
+      value = VoidFunction.convert(value, { context: context + \\" has member 'voidFunction' that\\" });
 
       ret[key] = value;
     }
@@ -9424,7 +9424,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"function\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = Function.convert(value, { context: context + \\" has member function that\\" });
+      value = Function.convert(value, { context: context + \\" has member 'function' that\\" });
 
       ret[key] = value;
     }
@@ -9434,7 +9434,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"urlCallback\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = URLCallback.convert(value, { context: context + \\" has member urlCallback that\\" });
+      value = URLCallback.convert(value, { context: context + \\" has member 'urlCallback' that\\" });
 
       ret[key] = value;
     }
@@ -9447,7 +9447,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
       if (value === null || value === undefined) {
         value = null;
       } else {
-        value = URLHandlerNonNull.convert(value, { context: context + \\" has member urlHandler that\\" });
+        value = URLHandlerNonNull.convert(value, { context: context + \\" has member 'urlHandler' that\\" });
       }
       ret[key] = value;
     }
@@ -9457,7 +9457,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"urlHandlerNonNull\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = URLHandlerNonNull.convert(value, { context: context + \\" has member urlHandlerNonNull that\\" });
+      value = URLHandlerNonNull.convert(value, { context: context + \\" has member 'urlHandlerNonNull' that\\" });
 
       ret[key] = value;
     }
@@ -9467,7 +9467,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"voidFunction\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = VoidFunction.convert(value, { context: context + \\" has member voidFunction that\\" });
+      value = VoidFunction.convert(value, { context: context + \\" has member 'voidFunction' that\\" });
 
       ret[key] = value;
     }

--- a/test/cases/AsyncCallbackFunction.webidl
+++ b/test/cases/AsyncCallbackFunction.webidl
@@ -1,0 +1,1 @@
+callback AsyncCallbackFunction = Promise<any> ();

--- a/test/cases/CallbackUsage.webidl
+++ b/test/cases/CallbackUsage.webidl
@@ -1,0 +1,7 @@
+dictionary CallbackUsage {
+  Function function;
+  VoidFunction voidFunction;
+  URLCallback urlCallback;
+  URLHandler urlHandler;
+  URLHandlerNonNull urlHandlerNonNull;
+};

--- a/test/cases/URLCallback.webidl
+++ b/test/cases/URLCallback.webidl
@@ -1,0 +1,1 @@
+callback URLCallback = URL (URL? url, DOMString string);

--- a/test/cases/URLHandlerNonNull.webidl
+++ b/test/cases/URLHandlerNonNull.webidl
@@ -1,0 +1,4 @@
+// Adapted from https://html.spec.whatwg.org/multipage/webappapis.html#eventhandlernonnull.
+[TreatNonObjectAsNull]
+callback URLHandlerNonNull = any (URL url);
+typedef URLHandlerNonNull? URLHandler;

--- a/test/cases/URLHandlerNonNull.webidl
+++ b/test/cases/URLHandlerNonNull.webidl
@@ -1,4 +1,4 @@
 // Adapted from https://html.spec.whatwg.org/multipage/webappapis.html#eventhandlernonnull.
-[TreatNonObjectAsNull]
+[LegacyTreatNonObjectAsNull]
 callback URLHandlerNonNull = any (URL url);
 typedef URLHandlerNonNull? URLHandler;

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,27 @@ const outputDir = path.resolve(__dirname, "output");
 
 const idlFiles = fs.readdirSync(casesDir);
 
+describe("built-in types", () => {
+  beforeAll(() => {
+    const transformer = new Transformer();
+    return transformer.generate(outputDir);
+  });
+
+  test("Function", () => {
+    const outputFile = path.resolve(outputDir, "Function.js");
+    const output = fs.readFileSync(outputFile, { encoding: "utf-8" });
+
+    expect(output).toMatchSnapshot();
+  });
+
+  test("VoidFunction", () => {
+    const outputFile = path.resolve(outputDir, "VoidFunction.js");
+    const output = fs.readFileSync(outputFile, { encoding: "utf-8" });
+
+    expect(output).toMatchSnapshot();
+  });
+});
+
 describe("without processors", () => {
   beforeAll(() => {
     const transformer = new Transformer();


### PR DESCRIPTION
This implements callback functions similarly to how callback interfaces were implemented in <https://github.com/jsdom/webidl2js/pull/172>.

I would’ve preferred if this were included in **WebIDL2JS v16.0**.

## Depends on:

- [ ] <https://github.com/jsdom/webidl2js/pull/219>

---

Supersedes and closes <https://github.com/jsdom/webidl2js/pull/123>

review?(@domenic, @TimothyGu, @Sebmaster)