### PR TITLE
Add new() export for interfaces

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -157,7 +157,7 @@
     "linebreak-style": ["error", "unix"],
     "lines-around-comment": "off",
     "max-depth": "off",
-    "max-len": ["error", 120, { "ignoreUrls": true }],
+    "max-len": ["error", 120, { "ignoreUrls": true, "ignoreTemplateLiterals": true }],
     "max-nested-callbacks": "off",
     "max-params": "off",
     "max-statements": "off",

--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ Creates a new instance of the wrapper class and corresponding implementation cla
 
 This is useful inside implementation class files, where it is easiest to only deal with impls, not wrappers.
 
+### `new(globalObject)`
+
+Creates a new instance of the wrapper class and corresponding implementation class, but without invoking the implementation class constructor logic. Then returns the implementation class.
+
+This corresponds to the [Web IDL "new" algorithm](https://heycam.github.io/webidl/#new), and is useful when implementing specifications that initialize objects in different ways than their constructors do.
+
 #### `setup(obj, globalObject, constructorArgs, privateData)`
 
 This function is mostly used internally, and almost never should be called by your code. The one exception is if you need to inherit from a wrapper class corresponding to an interface without a `constructor`, from a non-webidl2js-generated class. Then, you can call `SuperClass.setup(this, globalObject, [], privateData)` as a substitute for doing `super()` (which would throw).

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -523,15 +523,15 @@ class Interface {
 
   generateExport() {
     this.str += `
-      exports.is = function is(obj) {
-        return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+      exports.is = value => {
+        return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
       };
-      exports.isImpl = function isImpl(obj) {
-        return utils.isObject(obj) && obj instanceof Impl.implementation;
+      exports.isImpl = value => {
+        return utils.isObject(value) && value instanceof Impl.implementation;
       };
-      exports.convert = function convert(obj, { context = "The provided value" } = {}) {
-        if (exports.is(obj)) {
-          return utils.implForWrapper(obj);
+      exports.convert = (value, { context = "The provided value" } = {}) => {
+        if (exports.is(value)) {
+          return utils.implForWrapper(value);
         }
         throw new TypeError(\`\${context} is not of type '${this.name}'.\`);
       };
@@ -539,7 +539,7 @@ class Interface {
 
     if (this.iterable && this.iterable.isPair) {
       this.str += `
-        exports.createDefaultIterator = function createDefaultIterator(target, kind) {
+        exports.createDefaultIterator = (target, kind) => {
           const iterator = Object.create(IteratorPrototype);
           Object.defineProperty(iterator, utils.iterInternalSymbol, {
             value: { target, kind, index: 0 },
@@ -1125,7 +1125,7 @@ class Interface {
 
   generateIface() {
     this.str += `
-      exports.create = function create(globalObject, constructorArgs, privateData) {
+      function makeWrapper(globalObject) {
         if (globalObject[ctorRegistrySymbol] === undefined) {
           throw new Error('Internal error: invalid global object');
         }
@@ -1135,20 +1135,49 @@ class Interface {
           throw new Error('Internal error: constructor ${this.name} is not installed on the passed global object');
         }
 
-        let obj = Object.create(ctor.prototype);
-        obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-        return obj;
+        return Object.create(ctor.prototype);
+      }
+    `;
+
+    let setWrapperToProxy = ``;
+    if (this.isLegacyPlatformObj) {
+      setWrapperToProxy = `
+        wrapper = new Proxy(wrapper, proxyHandler);`;
+
+      if (this.needsPerGlobalProxyHandler) {
+        this.str += `
+          function makeProxy(wrapper, globalObject) {
+            let proxyHandler = proxyHandlerCache.get(globalObject);
+            if (proxyHandler === undefined) {
+              proxyHandler = new ProxyHandler(globalObject);
+              proxyHandlerCache.set(globalObject, proxyHandler);
+            }
+            return new Proxy(wrapper, proxyHandler);
+          }
+        `;
+
+        setWrapperToProxy = `
+          wrapper = makeProxy(wrapper, globalObject);`;
+      }
+    }
+
+    this.str += `
+      exports.create = (globalObject, constructorArgs, privateData) => {
+        const wrapper = makeWrapper(globalObject);
+        return exports.setup(wrapper, globalObject, constructorArgs, privateData);
       };
-      exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-        const obj = exports.create(globalObject, constructorArgs, privateData);
-        return utils.implForWrapper(obj);
+
+      exports.createImpl = (globalObject, constructorArgs, privateData) => {
+        const wrapper = exports.create(globalObject, constructorArgs, privateData);
+        return utils.implForWrapper(wrapper);
       };
-      exports._internalSetup = function _internalSetup(obj, globalObject) {
+
+      exports._internalSetup = (wrapper, globalObject) => {
     `;
 
     if (this.idl.inheritance) {
       this.str += `
-        ${this.idl.inheritance}._internalSetup(obj, globalObject);
+        ${this.idl.inheritance}._internalSetup(wrapper, globalObject);
       `;
     }
 
@@ -1156,39 +1185,34 @@ class Interface {
 
     this.str += `
       };
-      exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-        privateData.wrapper = obj;
 
-        exports._internalSetup(obj, globalObject);
-        Object.defineProperty(obj, implSymbol, {
+      exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+        privateData.wrapper = wrapper;
+
+        exports._internalSetup(wrapper, globalObject);
+        Object.defineProperty(wrapper, implSymbol, {
           value: new Impl.implementation(globalObject, constructorArgs, privateData),
           configurable: true
         });
-    `;
+        ${setWrapperToProxy}
 
-    if (this.isLegacyPlatformObj) {
-      if (this.needsPerGlobalProxyHandler) {
-        this.str += `
-        {
-          let proxyHandler = proxyHandlerCache.get(globalObject);
-          if (proxyHandler === undefined) {
-            proxyHandler = new ProxyHandler(globalObject);
-            proxyHandlerCache.set(globalObject, proxyHandler);
-          }
-          obj = new Proxy(obj, proxyHandler);
-        }
-        `;
-      } else {
-        this.str += `
-        obj = new Proxy(obj, proxyHandler);
-        `;
-      }
-    }
-
-    this.str += `
-        obj[implSymbol][utils.wrapperSymbol] = obj;
-        return obj;
+        wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+        return wrapper;
       };
+
+      exports.new = globalObject => {
+        const wrapper = makeWrapper(globalObject);
+
+        exports._internalSetup(wrapper, globalObject);
+        Object.defineProperty(wrapper, implSymbol, {
+          value: Object.create(Impl.implementation.prototype),
+          configurable: true
+        });
+        ${setWrapperToProxy}
+
+        wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+        return wrapper[implSymbol];
+      }
     `;
   }
 
@@ -1441,7 +1465,7 @@ class Interface {
     if (methods.length > 0) {
       this.str += `
         Object.defineProperties(
-          obj,
+          wrapper,
           Object.getOwnPropertyDescriptors({ ${methods.join(", ")} })
         );
       `;
@@ -1449,7 +1473,7 @@ class Interface {
     if (propStrs.length > 0) {
       this.str += `
         Object.defineProperties(
-          obj,
+          wrapper,
           { ${propStrs.join(", ")} }
         );
       `;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -63,20 +63,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"BufferSourceTypes\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'BufferSourceTypes'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -86,26 +86,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor BufferSourceTypes is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -313,20 +332,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"CEReactions\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'CEReactions'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -336,35 +355,58 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor CEReactions is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+function makeProxy(wrapper, globalObject) {
+  let proxyHandler = proxyHandlerCache.get(globalObject);
+  if (proxyHandler === undefined) {
+    proxyHandler = new ProxyHandler(globalObject);
+    proxyHandlerCache.set(globalObject, proxyHandler);
+  }
+  return new Proxy(wrapper, proxyHandler);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  {
-    let proxyHandler = proxyHandlerCache.get(globalObject);
-    if (proxyHandler === undefined) {
-      proxyHandler = new ProxyHandler(globalObject);
-      proxyHandlerCache.set(globalObject, proxyHandler);
-    }
-    obj = new Proxy(obj, proxyHandler);
-  }
+  wrapper = makeProxy(wrapper, globalObject);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = makeProxy(wrapper, globalObject);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -658,20 +700,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"DOMImplementation\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'DOMImplementation'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -681,26 +723,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor DOMImplementation is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -862,20 +923,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"DOMRect\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'DOMRect'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -885,26 +946,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor DOMRect is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
@@ -1193,20 +1273,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"DictionaryConvert\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'DictionaryConvert'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -1216,26 +1296,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor DictionaryConvert is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -1304,20 +1403,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Enum\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Enum'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -1327,26 +1426,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Enum is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -1477,20 +1595,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"EventTarget\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'EventTarget'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -1500,26 +1618,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor EventTarget is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\", \\"Worker\\", \\"AudioWorklet\\"]);
@@ -1599,20 +1736,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Global\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Global'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -1622,17 +1759,22 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Global is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
 };
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
 };
-exports._internalSetup = function _internalSetup(obj, globalObject) {
+
+exports._internalSetup = (wrapper, globalObject) => {
   Object.defineProperties(
-    obj,
+    wrapper,
     Object.getOwnPropertyDescriptors({
       op() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -1724,23 +1866,37 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
     })
   );
 
-  Object.defineProperties(obj, {
+  Object.defineProperties(wrapper, {
     unforgeableOp: { configurable: false, writable: false },
     unforgeableAttr: { configurable: false },
     [Symbol.iterator]: { enumerable: false }
   });
 };
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Global\\"]);
@@ -1800,20 +1956,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"HTMLConstructor\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'HTMLConstructor'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -1823,26 +1979,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor HTMLConstructor is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -1886,20 +2061,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"LegacyArrayClass\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'LegacyArrayClass'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -1909,26 +2084,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor LegacyArrayClass is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -1984,20 +2178,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"MixedIn\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'MixedIn'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -2007,26 +2201,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor MixedIn is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -2225,20 +2438,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Overloads\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Overloads'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -2248,26 +2461,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Overloads is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -2621,20 +2853,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"PromiseTypes\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'PromiseTypes'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -2644,26 +2876,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor PromiseTypes is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -2766,20 +3017,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Reflect\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Reflect'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -2789,26 +3040,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Reflect is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -3075,20 +3345,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"SeqAndRec\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'SeqAndRec'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -3098,26 +3368,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor SeqAndRec is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -3366,20 +3655,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Static\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Static'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -3389,26 +3678,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Static is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -3502,20 +3810,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Storage\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Storage'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -3525,28 +3833,49 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Storage is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj = new Proxy(obj, proxyHandler);
+  wrapper = new Proxy(wrapper, proxyHandler);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -3866,20 +4195,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierAttribute\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'StringifierAttribute'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -3889,26 +4218,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor StringifierAttribute is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -3973,20 +4321,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierDefaultOperation\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'StringifierDefaultOperation'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -3998,26 +4346,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     );
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -4071,20 +4438,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierNamedOperation\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'StringifierNamedOperation'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -4096,26 +4463,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     );
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -4179,20 +4565,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierOperation\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'StringifierOperation'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -4202,26 +4588,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor StringifierOperation is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -4277,20 +4682,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"TypedefsAndUnions\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'TypedefsAndUnions'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -4300,26 +4705,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor TypedefsAndUnions is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -4794,20 +5218,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URL\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'URL'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -4817,26 +5241,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor URL is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
@@ -5190,20 +5633,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URLList\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'URLList'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -5213,28 +5656,49 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor URLList is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj = new Proxy(obj, proxyHandler);
+  wrapper = new Proxy(wrapper, proxyHandler);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -5516,20 +5980,20 @@ const IteratorPrototype = Object.create(utils.IteratorPrototype, {
   }
 });
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'URLSearchParams'.\`);
 };
 
-exports.createDefaultIterator = function createDefaultIterator(target, kind) {
+exports.createDefaultIterator = (target, kind) => {
   const iterator = Object.create(IteratorPrototype);
   Object.defineProperty(iterator, utils.iterInternalSymbol, {
     value: { target, kind, index: 0 },
@@ -5538,7 +6002,7 @@ exports.createDefaultIterator = function createDefaultIterator(target, kind) {
   return iterator;
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -5548,26 +6012,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor URLSearchParams is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
@@ -5924,20 +6407,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URLSearchParamsCollection\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'URLSearchParamsCollection'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -5949,28 +6432,49 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     );
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj = new Proxy(obj, proxyHandler);
+  wrapper = new Proxy(wrapper, proxyHandler);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -6264,20 +6768,20 @@ const URLSearchParamsCollection = require(\\"./URLSearchParamsCollection.js\\");
 
 const interfaceName = \\"URLSearchParamsCollection2\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'URLSearchParamsCollection2'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -6289,30 +6793,51 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     );
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {
-  URLSearchParamsCollection._internalSetup(obj, globalObject);
-};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {
+  URLSearchParamsCollection._internalSetup(wrapper, globalObject);
+};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj = new Proxy(obj, proxyHandler);
+  wrapper = new Proxy(wrapper, proxyHandler);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -6578,20 +7103,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"UnderscoredProperties\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'UnderscoredProperties'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -6601,26 +7126,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor UnderscoredProperties is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -6751,20 +7295,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Unforgeable\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Unforgeable'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -6774,17 +7318,22 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Unforgeable is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
 };
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
 };
-exports._internalSetup = function _internalSetup(obj, globalObject) {
+
+exports._internalSetup = (wrapper, globalObject) => {
   Object.defineProperties(
-    obj,
+    wrapper,
     Object.getOwnPropertyDescriptors({
       assign(url) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -6873,7 +7422,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
     })
   );
 
-  Object.defineProperties(obj, {
+  Object.defineProperties(wrapper, {
     assign: { configurable: false, writable: false },
     href: { configurable: false },
     toString: { configurable: false, writable: false },
@@ -6881,17 +7430,31 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
     protocol: { configurable: false }
   });
 };
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -6935,20 +7498,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"UnforgeableMap\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'UnforgeableMap'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -6958,17 +7521,22 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor UnforgeableMap is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
 };
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
 };
-exports._internalSetup = function _internalSetup(obj, globalObject) {
+
+exports._internalSetup = (wrapper, globalObject) => {
   Object.defineProperties(
-    obj,
+    wrapper,
     Object.getOwnPropertyDescriptors({
       get a() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -6982,21 +7550,37 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
     })
   );
 
-  Object.defineProperties(obj, { a: { configurable: false } });
+  Object.defineProperties(wrapper, { a: { configurable: false } });
 };
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj = new Proxy(obj, proxyHandler);
+  wrapper = new Proxy(wrapper, proxyHandler);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -7215,20 +7799,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Unscopable\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Unscopable'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -7238,26 +7822,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Unscopable is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -7356,20 +7959,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Variadic\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Variadic'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -7379,26 +7982,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Variadic is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -7597,20 +8219,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"ZeroArgConstructor\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'ZeroArgConstructor'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -7620,26 +8242,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor ZeroArgConstructor is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -7735,20 +8376,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"BufferSourceTypes\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'BufferSourceTypes'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -7758,26 +8399,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor BufferSourceTypes is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -7984,20 +8644,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"CEReactions\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'CEReactions'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -8007,35 +8667,58 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor CEReactions is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+function makeProxy(wrapper, globalObject) {
+  let proxyHandler = proxyHandlerCache.get(globalObject);
+  if (proxyHandler === undefined) {
+    proxyHandler = new ProxyHandler(globalObject);
+    proxyHandlerCache.set(globalObject, proxyHandler);
+  }
+  return new Proxy(wrapper, proxyHandler);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  {
-    let proxyHandler = proxyHandlerCache.get(globalObject);
-    if (proxyHandler === undefined) {
-      proxyHandler = new ProxyHandler(globalObject);
-      proxyHandlerCache.set(globalObject, proxyHandler);
-    }
-    obj = new Proxy(obj, proxyHandler);
-  }
+  wrapper = makeProxy(wrapper, globalObject);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = makeProxy(wrapper, globalObject);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -8299,20 +8982,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"DOMImplementation\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'DOMImplementation'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -8322,26 +9005,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor DOMImplementation is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -8503,20 +9205,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"DOMRect\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'DOMRect'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -8526,26 +9228,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor DOMRect is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
@@ -8834,20 +9555,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"DictionaryConvert\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'DictionaryConvert'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -8857,26 +9578,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor DictionaryConvert is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -8945,20 +9685,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Enum\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Enum'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -8968,26 +9708,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Enum is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -9118,20 +9877,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"EventTarget\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'EventTarget'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -9141,26 +9900,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor EventTarget is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\", \\"Worker\\", \\"AudioWorklet\\"]);
@@ -9240,20 +10018,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Global\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Global'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -9263,17 +10041,22 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Global is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
 };
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
 };
-exports._internalSetup = function _internalSetup(obj, globalObject) {
+
+exports._internalSetup = (wrapper, globalObject) => {
   Object.defineProperties(
-    obj,
+    wrapper,
     Object.getOwnPropertyDescriptors({
       op() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -9365,23 +10148,37 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
     })
   );
 
-  Object.defineProperties(obj, {
+  Object.defineProperties(wrapper, {
     unforgeableOp: { configurable: false, writable: false },
     unforgeableAttr: { configurable: false },
     [Symbol.iterator]: { enumerable: false }
   });
 };
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Global\\"]);
@@ -9440,20 +10237,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"HTMLConstructor\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'HTMLConstructor'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -9463,26 +10260,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor HTMLConstructor is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -9526,20 +10342,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"LegacyArrayClass\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'LegacyArrayClass'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -9549,26 +10365,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor LegacyArrayClass is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -9624,20 +10459,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"MixedIn\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'MixedIn'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -9647,26 +10482,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor MixedIn is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -9865,20 +10719,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Overloads\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Overloads'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -9888,26 +10742,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Overloads is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -10261,20 +11134,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"PromiseTypes\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'PromiseTypes'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -10284,26 +11157,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor PromiseTypes is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -10405,20 +11297,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Reflect\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Reflect'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -10428,26 +11320,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Reflect is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -10700,20 +11611,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"SeqAndRec\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'SeqAndRec'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -10723,26 +11634,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor SeqAndRec is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -10991,20 +11921,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Static\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Static'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -11014,26 +11944,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Static is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -11127,20 +12076,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Storage\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Storage'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -11150,28 +12099,49 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Storage is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj = new Proxy(obj, proxyHandler);
+  wrapper = new Proxy(wrapper, proxyHandler);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -11491,20 +12461,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierAttribute\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'StringifierAttribute'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -11514,26 +12484,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor StringifierAttribute is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -11598,20 +12587,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierDefaultOperation\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'StringifierDefaultOperation'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -11623,26 +12612,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     );
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -11696,20 +12704,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierNamedOperation\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'StringifierNamedOperation'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -11721,26 +12729,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     );
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -11804,20 +12831,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"StringifierOperation\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'StringifierOperation'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -11827,26 +12854,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor StringifierOperation is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -11902,20 +12948,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"TypedefsAndUnions\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'TypedefsAndUnions'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -11925,26 +12971,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor TypedefsAndUnions is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -12419,20 +13484,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URL\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'URL'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -12442,26 +13507,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor URL is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
@@ -12815,20 +13899,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URLList\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'URLList'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -12838,28 +13922,49 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor URLList is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj = new Proxy(obj, proxyHandler);
+  wrapper = new Proxy(wrapper, proxyHandler);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -13141,20 +14246,20 @@ const IteratorPrototype = Object.create(utils.IteratorPrototype, {
   }
 });
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'URLSearchParams'.\`);
 };
 
-exports.createDefaultIterator = function createDefaultIterator(target, kind) {
+exports.createDefaultIterator = (target, kind) => {
   const iterator = Object.create(IteratorPrototype);
   Object.defineProperty(iterator, utils.iterInternalSymbol, {
     value: { target, kind, index: 0 },
@@ -13163,7 +14268,7 @@ exports.createDefaultIterator = function createDefaultIterator(target, kind) {
   return iterator;
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -13173,26 +14278,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor URLSearchParams is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
@@ -13549,20 +14673,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"URLSearchParamsCollection\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'URLSearchParamsCollection'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -13574,28 +14698,49 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     );
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj = new Proxy(obj, proxyHandler);
+  wrapper = new Proxy(wrapper, proxyHandler);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -13889,20 +15034,20 @@ const URLSearchParamsCollection = require(\\"./URLSearchParamsCollection.js\\");
 
 const interfaceName = \\"URLSearchParamsCollection2\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'URLSearchParamsCollection2'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -13914,30 +15059,51 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     );
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {
-  URLSearchParamsCollection._internalSetup(obj, globalObject);
-};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {
+  URLSearchParamsCollection._internalSetup(wrapper, globalObject);
+};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj = new Proxy(obj, proxyHandler);
+  wrapper = new Proxy(wrapper, proxyHandler);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -14203,20 +15369,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"UnderscoredProperties\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'UnderscoredProperties'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -14226,26 +15392,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor UnderscoredProperties is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -14376,20 +15561,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Unforgeable\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Unforgeable'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -14399,17 +15584,22 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Unforgeable is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
 };
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
 };
-exports._internalSetup = function _internalSetup(obj, globalObject) {
+
+exports._internalSetup = (wrapper, globalObject) => {
   Object.defineProperties(
-    obj,
+    wrapper,
     Object.getOwnPropertyDescriptors({
       assign(url) {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -14498,7 +15688,7 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
     })
   );
 
-  Object.defineProperties(obj, {
+  Object.defineProperties(wrapper, {
     assign: { configurable: false, writable: false },
     href: { configurable: false },
     toString: { configurable: false, writable: false },
@@ -14506,17 +15696,31 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
     protocol: { configurable: false }
   });
 };
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -14560,20 +15764,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"UnforgeableMap\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'UnforgeableMap'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -14583,17 +15787,22 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor UnforgeableMap is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
 };
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
 };
-exports._internalSetup = function _internalSetup(obj, globalObject) {
+
+exports._internalSetup = (wrapper, globalObject) => {
   Object.defineProperties(
-    obj,
+    wrapper,
     Object.getOwnPropertyDescriptors({
       get a() {
         const esValue = this !== null && this !== undefined ? this : globalObject;
@@ -14607,21 +15816,37 @@ exports._internalSetup = function _internalSetup(obj, globalObject) {
     })
   );
 
-  Object.defineProperties(obj, { a: { configurable: false } });
+  Object.defineProperties(wrapper, { a: { configurable: false } });
 };
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj = new Proxy(obj, proxyHandler);
+  wrapper = new Proxy(wrapper, proxyHandler);
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -14840,20 +16065,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Unscopable\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Unscopable'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -14863,26 +16088,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Unscopable is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -14981,20 +16225,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"Variadic\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'Variadic'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -15004,26 +16248,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor Variadic is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);
@@ -15222,20 +16485,20 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = \\"ZeroArgConstructor\\";
 
-exports.is = function is(obj) {
-  return utils.isObject(obj) && utils.hasOwn(obj, implSymbol) && obj[implSymbol] instanceof Impl.implementation;
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
-exports.isImpl = function isImpl(obj) {
-  return utils.isObject(obj) && obj instanceof Impl.implementation;
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
 };
-exports.convert = function convert(obj, { context = \\"The provided value\\" } = {}) {
-  if (exports.is(obj)) {
-    return utils.implForWrapper(obj);
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
   }
   throw new TypeError(\`\${context} is not of type 'ZeroArgConstructor'.\`);
 };
 
-exports.create = function create(globalObject, constructorArgs, privateData) {
+function makeWrapper(globalObject) {
   if (globalObject[ctorRegistrySymbol] === undefined) {
     throw new Error(\\"Internal error: invalid global object\\");
   }
@@ -15245,26 +16508,45 @@ exports.create = function create(globalObject, constructorArgs, privateData) {
     throw new Error(\\"Internal error: constructor ZeroArgConstructor is not installed on the passed global object\\");
   }
 
-  let obj = Object.create(ctor.prototype);
-  obj = exports.setup(obj, globalObject, constructorArgs, privateData);
-  return obj;
-};
-exports.createImpl = function createImpl(globalObject, constructorArgs, privateData) {
-  const obj = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(obj);
-};
-exports._internalSetup = function _internalSetup(obj, globalObject) {};
-exports.setup = function setup(obj, globalObject, constructorArgs = [], privateData = {}) {
-  privateData.wrapper = obj;
+  return Object.create(ctor.prototype);
+}
 
-  exports._internalSetup(obj, globalObject);
-  Object.defineProperty(obj, implSymbol, {
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
     value: new Impl.implementation(globalObject, constructorArgs, privateData),
     configurable: true
   });
 
-  obj[implSymbol][utils.wrapperSymbol] = obj;
-  return obj;
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  return wrapper[implSymbol];
 };
 
 const exposed = new Set([\\"Window\\"]);


### PR DESCRIPTION
Closes #193.

Since I had to do some refactoring to reduce duplication anyway, this also includes general cleanup to the output, such as replacing `obj` with either `value` or `wrapper`, using arrow functions for our exports, and such.

Ideas welcome on further refactoring to reduce duplication, but I think it's probably easiest to wait until we can stop exporting `setup()`; once that's true things become simpler.

On top of #195.