### PR TITLE
Fix treatment of non-strings as enumerations

### DIFF
--- a/lib/constructs/dictionary.js
+++ b/lib/constructs/dictionary.js
@@ -33,7 +33,7 @@ class Dictionary {
       const typeConversion = field.idlType;
       const argAttrs = field.extAttrs;
       const conv = Types.generateTypeConversion(
-        this.ctx, "value", typeConversion, argAttrs, this.name, `context + " has member ${field.name} that"`);
+        this.ctx, "value", typeConversion, argAttrs, this.name, `context + " has member '${field.name}' that"`);
       this.requires.merge(conv.requires);
 
       str += `

--- a/lib/constructs/enumeration.js
+++ b/lib/constructs/enumeration.js
@@ -20,8 +20,8 @@ class Enumeration {
 
       exports.convert = function convert(value, { context = "The provided value" } = {}) {
         const string = \`\${value}\`;
-        if (!enumerationValues.has(value)) {
-          throw new TypeError(\`\${context} '\${value}' is not a valid enumeration value for ${this.name}\`);
+        if (!enumerationValues.has(string)) {
+          throw new TypeError(\`\${context} '\${string}' is not a valid enumeration value for ${this.name}\`);
         }
         return string;
       };

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1197,7 +1197,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"boolWithDefault\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = conversions[\\"boolean\\"](value, { context: context + \\" has member boolWithDefault that\\" });
+      value = conversions[\\"boolean\\"](value, { context: context + \\" has member 'boolWithDefault' that\\" });
 
       ret[key] = value;
     } else {
@@ -1209,7 +1209,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"requiredInterface\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = URL.convert(value, { context: context + \\" has member requiredInterface that\\" });
+      value = URL.convert(value, { context: context + \\" has member 'requiredInterface' that\\" });
 
       ret[key] = value;
     } else {
@@ -1222,12 +1222,12 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
       if (!utils.isObject(value)) {
-        throw new TypeError(context + \\" has member seq that\\" + \\" is not an iterable object.\\");
+        throw new TypeError(context + \\" has member 'seq' that\\" + \\" is not an iterable object.\\");
       } else {
         const V = [];
         const tmp = value;
         for (let nextItem of tmp) {
-          nextItem = URLSearchParams.convert(nextItem, { context: context + \\" has member seq that\\" + \\"'s element\\" });
+          nextItem = URLSearchParams.convert(nextItem, { context: context + \\" has member 'seq' that\\" + \\"'s element\\" });
 
           V.push(nextItem);
         }
@@ -1242,7 +1242,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"vanillaString\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = conversions[\\"DOMString\\"](value, { context: context + \\" has member vanillaString that\\" });
+      value = conversions[\\"DOMString\\"](value, { context: context + \\" has member 'vanillaString' that\\" });
 
       ret[key] = value;
     }
@@ -3325,8 +3325,8 @@ exports.enumerationValues = enumerationValues;
 
 exports.convert = function convert(value, { context = \\"The provided value\\" } = {}) {
   const string = \`\${value}\`;
-  if (!enumerationValues.has(value)) {
-    throw new TypeError(\`\${context} '\${value}' is not a valid enumeration value for RequestDestination\`);
+  if (!enumerationValues.has(string)) {
+    throw new TypeError(\`\${context} '\${string}' is not a valid enumeration value for RequestDestination\`);
   }
   return string;
 };
@@ -9479,7 +9479,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"boolWithDefault\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = conversions[\\"boolean\\"](value, { context: context + \\" has member boolWithDefault that\\" });
+      value = conversions[\\"boolean\\"](value, { context: context + \\" has member 'boolWithDefault' that\\" });
 
       ret[key] = value;
     } else {
@@ -9491,7 +9491,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"requiredInterface\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = URL.convert(value, { context: context + \\" has member requiredInterface that\\" });
+      value = URL.convert(value, { context: context + \\" has member 'requiredInterface' that\\" });
 
       ret[key] = value;
     } else {
@@ -9504,12 +9504,12 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
       if (!utils.isObject(value)) {
-        throw new TypeError(context + \\" has member seq that\\" + \\" is not an iterable object.\\");
+        throw new TypeError(context + \\" has member 'seq' that\\" + \\" is not an iterable object.\\");
       } else {
         const V = [];
         const tmp = value;
         for (let nextItem of tmp) {
-          nextItem = URLSearchParams.convert(nextItem, { context: context + \\" has member seq that\\" + \\"'s element\\" });
+          nextItem = URLSearchParams.convert(nextItem, { context: context + \\" has member 'seq' that\\" + \\"'s element\\" });
 
           V.push(nextItem);
         }
@@ -9524,7 +9524,7 @@ exports._convertInherit = (obj, ret, { context = \\"The provided value\\" } = {}
     const key = \\"vanillaString\\";
     let value = obj === undefined || obj === null ? undefined : obj[key];
     if (value !== undefined) {
-      value = conversions[\\"DOMString\\"](value, { context: context + \\" has member vanillaString that\\" });
+      value = conversions[\\"DOMString\\"](value, { context: context + \\" has member 'vanillaString' that\\" });
 
       ret[key] = value;
     }
@@ -11591,8 +11591,8 @@ exports.enumerationValues = enumerationValues;
 
 exports.convert = function convert(value, { context = \\"The provided value\\" } = {}) {
   const string = \`\${value}\`;
-  if (!enumerationValues.has(value)) {
-    throw new TypeError(\`\${context} '\${value}' is not a valid enumeration value for RequestDestination\`);
+  if (!enumerationValues.has(string)) {
+    throw new TypeError(\`\${context} '\${string}' is not a valid enumeration value for RequestDestination\`);
   }
   return string;
 };


### PR DESCRIPTION
Previously, we were comparing the original value with the set of possible enumeration values. This means values like { toString() { "valid-value" } } would not be allowed. Instead, we should check the post-string-conversion value.

Also changes the error messages generated in cases like these, from

> The provided value has member type that 'bytes' is not a valid enumeration value for ReadableStreamType

to

> The provided value has member 'type' that 'bytes' is not a valid enumeration value for ReadableStreamType

which is slightly better, although still not grammatical.