### PR TITLE
Make [Exposed] and install()'s globalNames argument required

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,6 @@ This method creates a brand new wrapper constructor and prototype and attach it 
 
 The second argument `globalNames` is an array containing the [global names](https://heycam.github.io/webidl/#dfn-global-name) of the interface that `globalObject` implements. This is used for the purposes of deciding which interfaces are [exposed](https://heycam.github.io/webidl/#dfn-exposed). For example, this array should be `["Window"]` for a [`Window`](https://html.spec.whatwg.org/multipage/window-object.html#window) global object. But for a [`DedicatedWorkerGlobalScope`](https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope) global object, this array should be `["Worker", "DedicatedWorker"]`. Note that we do not yet implement [`[SecureContext]`](https://heycam.github.io/webidl/#SecureContext), so the "exposed" check is not fully implemented.
 
-Temporarily, until the next major release, `globalNames` defaults to `["Window"]`.
-
 #### `create(globalObject, constructorArgs, privateData)`
 
 Creates a new instance of the wrapper class and corresponding implementation class, passing in the `globalObject`, the `constructorArgs` array and `privateData` object to the implementation class constructor. Then returns the wrapper class.
@@ -310,7 +308,7 @@ If any part of the conversion fails, _context_ can be used to describe the provi
 
 If this callback interface has constants, then this method creates a brand new legacy callback interface object and attaches it to the passed `globalObject`. Otherwise, this method is a no-op.
 
-The second argument `globalNames` is the same as for [the `install()` export for interfaces](#installglobalobject-globalnames). (However, it does not have a default.)
+The second argument `globalNames` is the same as for [the `install()` export for interfaces](#installglobalobject-globalnames).
 
 ### For dictionaries
 
@@ -470,7 +468,7 @@ webidl2js is implementing an ever-growing subset of the Web IDL specification. S
 - Variadic arguments
 - `[Clamp]`
 - `[EnforceRange]`
-- `[Exposed]` (temporarily defaulting to `[Exposed=Window]`)
+- `[Exposed]`
 - `[LegacyUnenumerableNamedProperties]`
 - `[LegacyWindowAlias]`
 - `[NoInterfaceObject]`

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -92,13 +92,8 @@ class Interface {
       this.exposed = new Set();
     }
 
-    // TODO: put back in next major version.
-    // if (!exposed && !utils.getExtAttr(this.idl.extAttrs, "NoInterfaceObject")) {
-    //   throw new Error(`Interface ${this.name} has neither [Exposed] nor [NoInterfaceObject]`);
-    // }
-    // For now:
-    if (!exposed) {
-      this.exposed = new Set(["Window"]);
+    if (!exposed && !utils.getExtAttr(this.idl.extAttrs, "NoInterfaceObject")) {
+      throw new Error(`Interface ${this.name} has neither [Exposed] nor [NoInterfaceObject]`);
     }
 
     const legacyWindowAlias = utils.getExtAttr(this.idl.extAttrs, "LegacyWindowAlias");
@@ -1489,7 +1484,7 @@ class Interface {
     this.str += `
       const exposed = new Set(${JSON.stringify([...this.exposed])});
 
-      exports.install = (globalObject, globalNames = ["Window"]) => {
+      exports.install = (globalObject, globalNames) => {
         if (!globalNames.some(globalName => exposed.has(globalName))) {
           return;
         }

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -135,7 +135,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -423,7 +423,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -784,7 +784,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -1013,7 +1013,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -1369,7 +1369,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -1505,7 +1505,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -1703,7 +1703,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\", \\"Worker\\", \\"AudioWorklet\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -1949,7 +1949,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Global\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -2076,7 +2076,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -2187,7 +2187,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -2453,7 +2453,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -2874,7 +2874,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -3044,7 +3044,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -3378,7 +3378,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -3694,7 +3694,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -3859,7 +3859,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -4246,7 +4246,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -4380,7 +4380,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -4503,7 +4503,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -4634,7 +4634,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -4757,7 +4757,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -5299,7 +5299,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -5724,7 +5724,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -6082,7 +6082,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -6512,7 +6512,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -6881,7 +6881,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -7214,7 +7214,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -7510,7 +7510,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -7642,7 +7642,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -7928,7 +7928,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -8094,7 +8094,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -8360,7 +8360,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -8523,7 +8523,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -8810,7 +8810,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -9141,7 +9141,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -9370,7 +9370,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -9726,7 +9726,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -9862,7 +9862,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -10060,7 +10060,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\", \\"Worker\\", \\"AudioWorklet\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -10306,7 +10306,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Global\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -10432,7 +10432,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -10543,7 +10543,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -10809,7 +10809,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -11230,7 +11230,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -11399,7 +11399,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -11719,7 +11719,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -12035,7 +12035,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -12200,7 +12200,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -12587,7 +12587,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -12721,7 +12721,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -12844,7 +12844,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -12975,7 +12975,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -13098,7 +13098,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -13640,7 +13640,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -14065,7 +14065,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -14423,7 +14423,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\", \\"Worker\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -14853,7 +14853,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -15222,7 +15222,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -15555,7 +15555,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -15851,7 +15851,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -15983,7 +15983,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -16269,7 +16269,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -16435,7 +16435,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }
@@ -16701,7 +16701,7 @@ exports.new = globalObject => {
 
 const exposed = new Set([\\"Window\\"]);
 
-exports.install = (globalObject, globalNames = [\\"Window\\"]) => {
+exports.install = (globalObject, globalNames) => {
   if (!globalNames.some(globalName => exposed.has(globalName))) {
     return;
   }

--- a/test/cases/CEReactions.webidl
+++ b/test/cases/CEReactions.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface CEReactions {
     [CEReactions] attribute DOMString attr;
     [CEReactions] void method();

--- a/test/cases/HTMLConstructor.webidl
+++ b/test/cases/HTMLConstructor.webidl
@@ -1,2 +1,3 @@
-[HTMLConstructor]
+[Exposed=Window,
+ HTMLConstructor]
 interface HTMLConstructor {};


### PR DESCRIPTION
This is essentially a revert of f717fd45cbfc9fe05d3b03b430daf83504583a37, suitable for incorporation into the next major version.

@ExE-Boss your review on this one would be appreciated.

Also, if anyone has anything else backward-compat breaking we should bundle into v16 let me know.