### PR TITLE
Align with Web IDL extended attribute renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,15 +469,16 @@ webidl2js is implementing an ever-growing subset of the Web IDL specification. S
 - `[Clamp]`
 - `[EnforceRange]`
 - `[Exposed]`
+- `[LegacyLenientThis]`
+- `[LegacyNoInterfaceObject]`
+- `[LegacyNullToEmptyString]`
+- `[LegacyOverrideBuiltins]`
 - `[LegacyUnenumerableNamedProperties]`
+- `[LegacyUnforgeable]`
 - `[LegacyWindowAlias]`
-- `[NoInterfaceObject]`
-- `[OverrideBuiltins]`
 - `[PutForwards]`
 - `[Replaceable]`
 - `[SameObject]` (automatic caching)
-- `[TreatNullAs]`
-- `[Unforgeable]`
 - `[Unscopable]`
 
 Supported Web IDL extensions defined in HTML:
@@ -492,11 +493,11 @@ Notable missing features include:
 - `[AllowShared]`
 - `[Default]` (for `toJSON()` operations)
 - `[Global]`'s various consequences, including the named properties object and `[[SetPrototypeOf]]`
-- `[LenientSetter]`
-- `[LenientThis]`
-- `[NamedConstructor]`
+- `[LegacyFactoryFunction]`
+- `[LegacyLenientSetter]`
+- `[LegacyNamespace]`
+- `[LegacyTreatNonObjectAsNull]`
 - `[SecureContext]`
-- `[TreatNonObjectAsNull]`
 
 ## Nonstandard extended attributes
 

--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -16,7 +16,7 @@ class Attribute {
   generate() {
     const requires = new utils.RequiresMap(this.ctx);
 
-    const configurable = !utils.getExtAttr(this.idl.extAttrs, "Unforgeable");
+    const configurable = !utils.getExtAttr(this.idl.extAttrs, "LegacyUnforgeable");
     const shouldReflect =
       this.idl.extAttrs.some(attr => attr.name.startsWith("Reflect")) && this.ctx.processReflect !== null;
     const sameObject = utils.getExtAttr(this.idl.extAttrs, "SameObject");
@@ -48,7 +48,7 @@ class Attribute {
       setterBody = processedOutput.set;
     }
 
-    if (utils.getExtAttr(this.idl.extAttrs, "LenientThis")) {
+    if (utils.getExtAttr(this.idl.extAttrs, "LegacyLenientThis")) {
       brandCheck = "";
     }
 

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -92,14 +92,14 @@ class Interface {
       this.exposed = new Set();
     }
 
-    if (!exposed && !utils.getExtAttr(this.idl.extAttrs, "NoInterfaceObject")) {
-      throw new Error(`Interface ${this.name} has neither [Exposed] nor [NoInterfaceObject]`);
+    if (!exposed && !utils.getExtAttr(this.idl.extAttrs, "LegacyNoInterfaceObject")) {
+      throw new Error(`Interface ${this.name} has neither [Exposed] nor [LegacyNoInterfaceObject]`);
     }
 
     const legacyWindowAlias = utils.getExtAttr(this.idl.extAttrs, "LegacyWindowAlias");
     if (legacyWindowAlias) {
-      if (utils.getExtAttr(this.idl.extAttrs, "NoInterfaceObject")) {
-        throw new Error(`Interface ${this.name} has [LegacyWindowAlias] and [NoInterfaceObject]`);
+      if (utils.getExtAttr(this.idl.extAttrs, "LegacyNoInterfaceObject")) {
+        throw new Error(`Interface ${this.name} has [LegacyWindowAlias] and [LegacyNoInterfaceObject]`);
       }
 
       if (!this.exposed.has("Window")) {
@@ -555,7 +555,7 @@ class Interface {
     const hasIndexedSetter = this.indexedSetter !== null;
     const hasNamedSetter = this.namedSetter !== null;
     const hasNamedDeleter = this.namedDeleter !== null;
-    const overrideBuiltins = Boolean(utils.getExtAttr(this.idl.extAttrs, "OverrideBuiltins"));
+    const overrideBuiltins = Boolean(utils.getExtAttr(this.idl.extAttrs, "LegacyOverrideBuiltins"));
 
     const supportsPropertyIndex = (O, index, indexedValue) => {
       let unsupportedValue = utils.getExtAttr(this.indexedGetter.extAttrs, "WebIDL2JSValueAsUnsupported");
@@ -994,7 +994,7 @@ class Interface {
       const unforgeable = new Set();
       for (const m of this.allMembers()) {
         if ((m.type === "attribute" || m.type === "operation") && m.special !== "static" &&
-            utils.getExtAttr(m.extAttrs, "Unforgeable")) {
+            utils.getExtAttr(m.extAttrs, "LegacyUnforgeable")) {
           unforgeable.add(m.name);
         }
       }
@@ -1513,7 +1513,7 @@ class Interface {
         globalObject[ctorRegistrySymbol][interfaceName] = ${name};
     `;
 
-    if (!utils.getExtAttr(this.idl.extAttrs, "NoInterfaceObject")) {
+    if (!utils.getExtAttr(this.idl.extAttrs, "LegacyNoInterfaceObject")) {
       this.str += `
         Object.defineProperty(globalObject, interfaceName, {
           configurable: true,

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -19,7 +19,9 @@ class Operation {
     const firstOverloadOnInstance = utils.isOnInstance(this.idls[0], this.interface.idl);
     for (const overload of this.idls.slice(1)) {
       if (utils.isOnInstance(overload, this.interface.idl) !== firstOverloadOnInstance) {
-        throw new Error(`[Unforgeable] is not applied uniformly to operation "${this.name}" on ${this.interface.name}`);
+        throw new Error(
+          `[LegacyUnforgeable] is not applied uniformly to operation "${this.name}" on ${this.interface.name}`
+        );
       }
     }
     return firstOverloadOnInstance;
@@ -101,7 +103,7 @@ class Operation {
     if (this.static) {
       this.interface.addStaticMethod(this.name, argNames, str);
     } else {
-      const forgeable = !utils.getExtAttr(this.idls[0].extAttrs, "Unforgeable");
+      const forgeable = !utils.getExtAttr(this.idls[0].extAttrs, "LegacyUnforgeable");
       this.interface.addMethod(
         onInstance ? "instance" : "prototype",
         this.name,

--- a/lib/types.js
+++ b/lib/types.js
@@ -356,7 +356,7 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
   function generateGeneric(conversionFn) {
     const enforceRange = utils.getExtAttr(extAttrs, "EnforceRange");
     const clamp = utils.getExtAttr(extAttrs, "Clamp");
-    const treatNullAs = utils.getExtAttr(extAttrs, "TreatNullAs");
+    const nullToEmptyString = utils.getExtAttr(extAttrs, "LegacyNullToEmptyString");
 
     let optString = `context: ${errPrefix},`;
     if (clamp) {
@@ -365,7 +365,7 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
     if (enforceRange) {
       optString += "enforceRange: true,";
     }
-    if (treatNullAs && treatNullAs.rhs.value === "EmptyString") {
+    if (nullToEmptyString) {
       optString += "treatNullAsEmptyString: true,";
     }
     if (idlType.array) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,7 +38,8 @@ function hasCEReactions(idl) {
 }
 
 function isOnInstance(memberIDL, interfaceIDL) {
-  return memberIDL.special !== "static" && (getExtAttr(memberIDL.extAttrs, "Unforgeable") || isGlobal(interfaceIDL));
+  return memberIDL.special !== "static" && (getExtAttr(memberIDL.extAttrs, "LegacyUnforgeable") ||
+    isGlobal(interfaceIDL));
 }
 
 function symbolName(symbol) {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -2104,6 +2104,522 @@ const Impl = require(\\"../implementations/HTMLConstructor.js\\");
 "
 `;
 
+exports[`with processors LegacyUnforgeable.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
+
+const interfaceName = \\"LegacyUnforgeable\\";
+
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+};
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
+};
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
+  }
+  throw new TypeError(\`\${context} is not of type 'LegacyUnforgeable'.\`);
+};
+
+function makeWrapper(globalObject) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistrySymbol][\\"LegacyUnforgeable\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor LegacyUnforgeable is not installed on the passed global object\\");
+  }
+
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {
+  Object.defineProperties(
+    wrapper,
+    Object.getOwnPropertyDescriptors({
+      assign(url) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'assign' on 'LegacyUnforgeable': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          curArg = conversions[\\"USVString\\"](curArg, {
+            context: \\"Failed to execute 'assign' on 'LegacyUnforgeable': parameter 1\\"
+          });
+          args.push(curArg);
+        }
+        return esValue[implSymbol].assign(...args);
+      },
+      get href() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return esValue[implSymbol][\\"href\\"];
+      },
+      set href(V) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        V = conversions[\\"USVString\\"](V, {
+          context: \\"Failed to set the 'href' property on 'LegacyUnforgeable': The provided value\\"
+        });
+
+        esValue[implSymbol][\\"href\\"] = V;
+      },
+      toString() {
+        const esValue = this;
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return esValue[implSymbol][\\"href\\"];
+      },
+      get origin() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return esValue[implSymbol][\\"origin\\"];
+      },
+      get protocol() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return esValue[implSymbol][\\"protocol\\"];
+      },
+      set protocol(V) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        V = conversions[\\"USVString\\"](V, {
+          context: \\"Failed to set the 'protocol' property on 'LegacyUnforgeable': The provided value\\"
+        });
+
+        esValue[implSymbol][\\"protocol\\"] = V;
+      }
+    })
+  );
+
+  Object.defineProperties(wrapper, {
+    assign: { configurable: false, writable: false },
+    href: { configurable: false },
+    toString: { configurable: false, writable: false },
+    origin: { configurable: false },
+    protocol: { configurable: false }
+  });
+};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper[implSymbol];
+};
+
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
+    return;
+  }
+  class LegacyUnforgeable {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+  }
+  Object.defineProperties(LegacyUnforgeable.prototype, {
+    [Symbol.toStringTag]: { value: \\"LegacyUnforgeable\\", configurable: true }
+  });
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
+  }
+  globalObject[ctorRegistrySymbol][interfaceName] = LegacyUnforgeable;
+
+  Object.defineProperty(globalObject, interfaceName, {
+    configurable: true,
+    writable: true,
+    value: LegacyUnforgeable
+  });
+};
+
+const Impl = require(\\"../implementations/LegacyUnforgeable.js\\");
+"
+`;
+
+exports[`with processors LegacyUnforgeableMap.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
+
+const interfaceName = \\"LegacyUnforgeableMap\\";
+
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+};
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
+};
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
+  }
+  throw new TypeError(\`\${context} is not of type 'LegacyUnforgeableMap'.\`);
+};
+
+function makeWrapper(globalObject) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistrySymbol][\\"LegacyUnforgeableMap\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor LegacyUnforgeableMap is not installed on the passed global object\\");
+  }
+
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {
+  Object.defineProperties(
+    wrapper,
+    Object.getOwnPropertyDescriptors({
+      get a() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return esValue[implSymbol][\\"a\\"];
+      }
+    })
+  );
+
+  Object.defineProperties(wrapper, { a: { configurable: false } });
+};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper[implSymbol];
+};
+
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
+    return;
+  }
+  class LegacyUnforgeableMap {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+  }
+  Object.defineProperties(LegacyUnforgeableMap.prototype, {
+    [Symbol.toStringTag]: { value: \\"LegacyUnforgeableMap\\", configurable: true }
+  });
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
+  }
+  globalObject[ctorRegistrySymbol][interfaceName] = LegacyUnforgeableMap;
+
+  Object.defineProperty(globalObject, interfaceName, {
+    configurable: true,
+    writable: true,
+    value: LegacyUnforgeableMap
+  });
+};
+
+const proxyHandler = {
+  get(target, P, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.get(target, P, receiver);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc === undefined) {
+      const parent = Object.getPrototypeOf(target);
+      if (parent === null) {
+        return undefined;
+      }
+      return Reflect.get(target, P, receiver);
+    }
+    if (!desc.get && !desc.set) {
+      return desc.value;
+    }
+    const getter = desc.get;
+    if (getter === undefined) {
+      return undefined;
+    }
+    return Reflect.apply(getter, receiver, []);
+  },
+
+  has(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.has(target, P);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc !== undefined) {
+      return true;
+    }
+    const parent = Object.getPrototypeOf(target);
+    if (parent !== null) {
+      return Reflect.has(parent, P);
+    }
+    return false;
+  },
+
+  ownKeys(target) {
+    const keys = new Set();
+
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
+      if (!(key in target)) {
+        keys.add(\`\${key}\`);
+      }
+    }
+
+    for (const key of Reflect.ownKeys(target)) {
+      keys.add(key);
+    }
+    return [...keys];
+  },
+
+  getOwnPropertyDescriptor(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    let ignoreNamedProps = false;
+
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
+
+      return {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value: utils.tryWrapperForImpl(namedValue)
+      };
+    }
+
+    return Reflect.getOwnPropertyDescriptor(target, P);
+  },
+
+  set(target, P, V, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.set(target, P, V, receiver);
+    }
+    if (target === receiver) {
+      if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
+        let namedValue = V;
+
+        namedValue = conversions[\\"DOMString\\"](namedValue, {
+          context: \\"Failed to set the '\\" + P + \\"' property on 'LegacyUnforgeableMap': The provided value\\"
+        });
+
+        const creating = !target[implSymbol][utils.supportsPropertyName](P);
+        if (creating) {
+          target[implSymbol][utils.namedSetNew](P, namedValue);
+        } else {
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
+        }
+
+        return true;
+      }
+    }
+    let ownDesc;
+
+    if (ownDesc === undefined) {
+      ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    if (ownDesc === undefined) {
+      const parent = Reflect.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.set(parent, P, V, receiver);
+      }
+      ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+    }
+    if (!ownDesc.writable) {
+      return false;
+    }
+    if (!utils.isObject(receiver)) {
+      return false;
+    }
+    const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+    let valueDesc;
+    if (existingDesc !== undefined) {
+      if (existingDesc.get || existingDesc.set) {
+        return false;
+      }
+      if (!existingDesc.writable) {
+        return false;
+      }
+      valueDesc = { value: V };
+    } else {
+      valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+    }
+    return Reflect.defineProperty(receiver, P, valueDesc);
+  },
+
+  defineProperty(target, P, desc) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.defineProperty(target, P, desc);
+    }
+    if (![\\"a\\"].includes(P)) {
+      if (!utils.hasOwn(target, P)) {
+        if (desc.get || desc.set) {
+          return false;
+        }
+
+        let namedValue = desc.value;
+
+        namedValue = conversions[\\"DOMString\\"](namedValue, {
+          context: \\"Failed to set the '\\" + P + \\"' property on 'LegacyUnforgeableMap': The provided value\\"
+        });
+
+        const creating = !target[implSymbol][utils.supportsPropertyName](P);
+        if (creating) {
+          target[implSymbol][utils.namedSetNew](P, namedValue);
+        } else {
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
+        }
+
+        return true;
+      }
+    }
+    return Reflect.defineProperty(target, P, desc);
+  },
+
+  deleteProperty(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.deleteProperty(target, P);
+    }
+
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      return false;
+    }
+
+    return Reflect.deleteProperty(target, P);
+  },
+
+  preventExtensions() {
+    return false;
+  }
+};
+
+const Impl = require(\\"../implementations/LegacyUnforgeableMap.js\\");
+"
+`;
+
 exports[`with processors MixedIn.webidl 1`] = `
 "\\"use strict\\";
 
@@ -7329,522 +7845,6 @@ const Impl = require(\\"../implementations/UnderscoredProperties.js\\");
 "
 `;
 
-exports[`with processors Unforgeable.webidl 1`] = `
-"\\"use strict\\";
-
-const conversions = require(\\"webidl-conversions\\");
-const utils = require(\\"./utils.js\\");
-
-const implSymbol = utils.implSymbol;
-const ctorRegistrySymbol = utils.ctorRegistrySymbol;
-
-const interfaceName = \\"Unforgeable\\";
-
-exports.is = value => {
-  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
-};
-exports.isImpl = value => {
-  return utils.isObject(value) && value instanceof Impl.implementation;
-};
-exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
-  if (exports.is(value)) {
-    return utils.implForWrapper(value);
-  }
-  throw new TypeError(\`\${context} is not of type 'Unforgeable'.\`);
-};
-
-function makeWrapper(globalObject) {
-  if (globalObject[ctorRegistrySymbol] === undefined) {
-    throw new Error(\\"Internal error: invalid global object\\");
-  }
-
-  const ctor = globalObject[ctorRegistrySymbol][\\"Unforgeable\\"];
-  if (ctor === undefined) {
-    throw new Error(\\"Internal error: constructor Unforgeable is not installed on the passed global object\\");
-  }
-
-  return Object.create(ctor.prototype);
-}
-
-exports.create = (globalObject, constructorArgs, privateData) => {
-  const wrapper = makeWrapper(globalObject);
-  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
-};
-
-exports.createImpl = (globalObject, constructorArgs, privateData) => {
-  const wrapper = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(wrapper);
-};
-
-exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      assign(url) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'assign' on 'Unforgeable': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'assign' on 'Unforgeable': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return esValue[implSymbol].assign(...args);
-      },
-      get href() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return esValue[implSymbol][\\"href\\"];
-      },
-      set href(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'href' property on 'Unforgeable': The provided value\\"
-        });
-
-        esValue[implSymbol][\\"href\\"] = V;
-      },
-      toString() {
-        const esValue = this;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return esValue[implSymbol][\\"href\\"];
-      },
-      get origin() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return esValue[implSymbol][\\"origin\\"];
-      },
-      get protocol() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return esValue[implSymbol][\\"protocol\\"];
-      },
-      set protocol(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'protocol' property on 'Unforgeable': The provided value\\"
-        });
-
-        esValue[implSymbol][\\"protocol\\"] = V;
-      }
-    })
-  );
-
-  Object.defineProperties(wrapper, {
-    assign: { configurable: false, writable: false },
-    href: { configurable: false },
-    toString: { configurable: false, writable: false },
-    origin: { configurable: false },
-    protocol: { configurable: false }
-  });
-};
-
-exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
-  privateData.wrapper = wrapper;
-
-  exports._internalSetup(wrapper, globalObject);
-  Object.defineProperty(wrapper, implSymbol, {
-    value: new Impl.implementation(globalObject, constructorArgs, privateData),
-    configurable: true
-  });
-
-  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
-  if (Impl.init) {
-    Impl.init(wrapper[implSymbol]);
-  }
-  return wrapper;
-};
-
-exports.new = globalObject => {
-  const wrapper = makeWrapper(globalObject);
-
-  exports._internalSetup(wrapper, globalObject);
-  Object.defineProperty(wrapper, implSymbol, {
-    value: Object.create(Impl.implementation.prototype),
-    configurable: true
-  });
-
-  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
-  if (Impl.init) {
-    Impl.init(wrapper[implSymbol]);
-  }
-  return wrapper[implSymbol];
-};
-
-const exposed = new Set([\\"Window\\"]);
-
-exports.install = (globalObject, globalNames) => {
-  if (!globalNames.some(globalName => exposed.has(globalName))) {
-    return;
-  }
-  class Unforgeable {
-    constructor() {
-      throw new TypeError(\\"Illegal constructor\\");
-    }
-  }
-  Object.defineProperties(Unforgeable.prototype, {
-    [Symbol.toStringTag]: { value: \\"Unforgeable\\", configurable: true }
-  });
-  if (globalObject[ctorRegistrySymbol] === undefined) {
-    globalObject[ctorRegistrySymbol] = Object.create(null);
-  }
-  globalObject[ctorRegistrySymbol][interfaceName] = Unforgeable;
-
-  Object.defineProperty(globalObject, interfaceName, {
-    configurable: true,
-    writable: true,
-    value: Unforgeable
-  });
-};
-
-const Impl = require(\\"../implementations/Unforgeable.js\\");
-"
-`;
-
-exports[`with processors UnforgeableMap.webidl 1`] = `
-"\\"use strict\\";
-
-const conversions = require(\\"webidl-conversions\\");
-const utils = require(\\"./utils.js\\");
-
-const implSymbol = utils.implSymbol;
-const ctorRegistrySymbol = utils.ctorRegistrySymbol;
-
-const interfaceName = \\"UnforgeableMap\\";
-
-exports.is = value => {
-  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
-};
-exports.isImpl = value => {
-  return utils.isObject(value) && value instanceof Impl.implementation;
-};
-exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
-  if (exports.is(value)) {
-    return utils.implForWrapper(value);
-  }
-  throw new TypeError(\`\${context} is not of type 'UnforgeableMap'.\`);
-};
-
-function makeWrapper(globalObject) {
-  if (globalObject[ctorRegistrySymbol] === undefined) {
-    throw new Error(\\"Internal error: invalid global object\\");
-  }
-
-  const ctor = globalObject[ctorRegistrySymbol][\\"UnforgeableMap\\"];
-  if (ctor === undefined) {
-    throw new Error(\\"Internal error: constructor UnforgeableMap is not installed on the passed global object\\");
-  }
-
-  return Object.create(ctor.prototype);
-}
-
-exports.create = (globalObject, constructorArgs, privateData) => {
-  const wrapper = makeWrapper(globalObject);
-  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
-};
-
-exports.createImpl = (globalObject, constructorArgs, privateData) => {
-  const wrapper = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(wrapper);
-};
-
-exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      get a() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return esValue[implSymbol][\\"a\\"];
-      }
-    })
-  );
-
-  Object.defineProperties(wrapper, { a: { configurable: false } });
-};
-
-exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
-  privateData.wrapper = wrapper;
-
-  exports._internalSetup(wrapper, globalObject);
-  Object.defineProperty(wrapper, implSymbol, {
-    value: new Impl.implementation(globalObject, constructorArgs, privateData),
-    configurable: true
-  });
-
-  wrapper = new Proxy(wrapper, proxyHandler);
-
-  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
-  if (Impl.init) {
-    Impl.init(wrapper[implSymbol]);
-  }
-  return wrapper;
-};
-
-exports.new = globalObject => {
-  const wrapper = makeWrapper(globalObject);
-
-  exports._internalSetup(wrapper, globalObject);
-  Object.defineProperty(wrapper, implSymbol, {
-    value: Object.create(Impl.implementation.prototype),
-    configurable: true
-  });
-
-  wrapper = new Proxy(wrapper, proxyHandler);
-
-  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
-  if (Impl.init) {
-    Impl.init(wrapper[implSymbol]);
-  }
-  return wrapper[implSymbol];
-};
-
-const exposed = new Set([\\"Window\\"]);
-
-exports.install = (globalObject, globalNames) => {
-  if (!globalNames.some(globalName => exposed.has(globalName))) {
-    return;
-  }
-  class UnforgeableMap {
-    constructor() {
-      throw new TypeError(\\"Illegal constructor\\");
-    }
-  }
-  Object.defineProperties(UnforgeableMap.prototype, {
-    [Symbol.toStringTag]: { value: \\"UnforgeableMap\\", configurable: true }
-  });
-  if (globalObject[ctorRegistrySymbol] === undefined) {
-    globalObject[ctorRegistrySymbol] = Object.create(null);
-  }
-  globalObject[ctorRegistrySymbol][interfaceName] = UnforgeableMap;
-
-  Object.defineProperty(globalObject, interfaceName, {
-    configurable: true,
-    writable: true,
-    value: UnforgeableMap
-  });
-};
-
-const proxyHandler = {
-  get(target, P, receiver) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.get(target, P, receiver);
-    }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
-      }
-      return Reflect.get(target, P, receiver);
-    }
-    if (!desc.get && !desc.set) {
-      return desc.value;
-    }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
-  },
-
-  has(target, P) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.has(target, P);
-    }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc !== undefined) {
-      return true;
-    }
-    const parent = Object.getPrototypeOf(target);
-    if (parent !== null) {
-      return Reflect.has(parent, P);
-    }
-    return false;
-  },
-
-  ownKeys(target) {
-    const keys = new Set();
-
-    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
-      if (!(key in target)) {
-        keys.add(\`\${key}\`);
-      }
-    }
-
-    for (const key of Reflect.ownKeys(target)) {
-      keys.add(key);
-    }
-    return [...keys];
-  },
-
-  getOwnPropertyDescriptor(target, P) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.getOwnPropertyDescriptor(target, P);
-    }
-    let ignoreNamedProps = false;
-
-    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-      const namedValue = target[implSymbol][utils.namedGet](P);
-
-      return {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value: utils.tryWrapperForImpl(namedValue)
-      };
-    }
-
-    return Reflect.getOwnPropertyDescriptor(target, P);
-  },
-
-  set(target, P, V, receiver) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.set(target, P, V, receiver);
-    }
-    if (target === receiver) {
-      if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
-        let namedValue = V;
-
-        namedValue = conversions[\\"DOMString\\"](namedValue, {
-          context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
-        });
-
-        const creating = !target[implSymbol][utils.supportsPropertyName](P);
-        if (creating) {
-          target[implSymbol][utils.namedSetNew](P, namedValue);
-        } else {
-          target[implSymbol][utils.namedSetExisting](P, namedValue);
-        }
-
-        return true;
-      }
-    }
-    let ownDesc;
-
-    if (ownDesc === undefined) {
-      ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-    }
-    if (ownDesc === undefined) {
-      const parent = Reflect.getPrototypeOf(target);
-      if (parent !== null) {
-        return Reflect.set(parent, P, V, receiver);
-      }
-      ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-    }
-    if (!ownDesc.writable) {
-      return false;
-    }
-    if (!utils.isObject(receiver)) {
-      return false;
-    }
-    const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-    let valueDesc;
-    if (existingDesc !== undefined) {
-      if (existingDesc.get || existingDesc.set) {
-        return false;
-      }
-      if (!existingDesc.writable) {
-        return false;
-      }
-      valueDesc = { value: V };
-    } else {
-      valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-    }
-    return Reflect.defineProperty(receiver, P, valueDesc);
-  },
-
-  defineProperty(target, P, desc) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.defineProperty(target, P, desc);
-    }
-    if (![\\"a\\"].includes(P)) {
-      if (!utils.hasOwn(target, P)) {
-        if (desc.get || desc.set) {
-          return false;
-        }
-
-        let namedValue = desc.value;
-
-        namedValue = conversions[\\"DOMString\\"](namedValue, {
-          context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
-        });
-
-        const creating = !target[implSymbol][utils.supportsPropertyName](P);
-        if (creating) {
-          target[implSymbol][utils.namedSetNew](P, namedValue);
-        } else {
-          target[implSymbol][utils.namedSetExisting](P, namedValue);
-        }
-
-        return true;
-      }
-    }
-    return Reflect.defineProperty(target, P, desc);
-  },
-
-  deleteProperty(target, P) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.deleteProperty(target, P);
-    }
-
-    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
-      return false;
-    }
-
-    return Reflect.deleteProperty(target, P);
-  },
-
-  preventExtensions() {
-    return false;
-  }
-};
-
-const Impl = require(\\"../implementations/UnforgeableMap.js\\");
-"
-`;
-
 exports[`with processors Unscopable.webidl 1`] = `
 "\\"use strict\\";
 
@@ -10457,6 +10457,522 @@ exports.install = (globalObject, globalNames) => {
 };
 
 const Impl = require(\\"../implementations/HTMLConstructor.js\\");
+"
+`;
+
+exports[`without processors LegacyUnforgeable.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
+
+const interfaceName = \\"LegacyUnforgeable\\";
+
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+};
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
+};
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
+  }
+  throw new TypeError(\`\${context} is not of type 'LegacyUnforgeable'.\`);
+};
+
+function makeWrapper(globalObject) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistrySymbol][\\"LegacyUnforgeable\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor LegacyUnforgeable is not installed on the passed global object\\");
+  }
+
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {
+  Object.defineProperties(
+    wrapper,
+    Object.getOwnPropertyDescriptors({
+      assign(url) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'assign' on 'LegacyUnforgeable': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          curArg = conversions[\\"USVString\\"](curArg, {
+            context: \\"Failed to execute 'assign' on 'LegacyUnforgeable': parameter 1\\"
+          });
+          args.push(curArg);
+        }
+        return esValue[implSymbol].assign(...args);
+      },
+      get href() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return esValue[implSymbol][\\"href\\"];
+      },
+      set href(V) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        V = conversions[\\"USVString\\"](V, {
+          context: \\"Failed to set the 'href' property on 'LegacyUnforgeable': The provided value\\"
+        });
+
+        esValue[implSymbol][\\"href\\"] = V;
+      },
+      toString() {
+        const esValue = this;
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return esValue[implSymbol][\\"href\\"];
+      },
+      get origin() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return esValue[implSymbol][\\"origin\\"];
+      },
+      get protocol() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return esValue[implSymbol][\\"protocol\\"];
+      },
+      set protocol(V) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        V = conversions[\\"USVString\\"](V, {
+          context: \\"Failed to set the 'protocol' property on 'LegacyUnforgeable': The provided value\\"
+        });
+
+        esValue[implSymbol][\\"protocol\\"] = V;
+      }
+    })
+  );
+
+  Object.defineProperties(wrapper, {
+    assign: { configurable: false, writable: false },
+    href: { configurable: false },
+    toString: { configurable: false, writable: false },
+    origin: { configurable: false },
+    protocol: { configurable: false }
+  });
+};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper[implSymbol];
+};
+
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
+    return;
+  }
+  class LegacyUnforgeable {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+  }
+  Object.defineProperties(LegacyUnforgeable.prototype, {
+    [Symbol.toStringTag]: { value: \\"LegacyUnforgeable\\", configurable: true }
+  });
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
+  }
+  globalObject[ctorRegistrySymbol][interfaceName] = LegacyUnforgeable;
+
+  Object.defineProperty(globalObject, interfaceName, {
+    configurable: true,
+    writable: true,
+    value: LegacyUnforgeable
+  });
+};
+
+const Impl = require(\\"../implementations/LegacyUnforgeable.js\\");
+"
+`;
+
+exports[`without processors LegacyUnforgeableMap.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
+
+const interfaceName = \\"LegacyUnforgeableMap\\";
+
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+};
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
+};
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
+  }
+  throw new TypeError(\`\${context} is not of type 'LegacyUnforgeableMap'.\`);
+};
+
+function makeWrapper(globalObject) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistrySymbol][\\"LegacyUnforgeableMap\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor LegacyUnforgeableMap is not installed on the passed global object\\");
+  }
+
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {
+  Object.defineProperties(
+    wrapper,
+    Object.getOwnPropertyDescriptors({
+      get a() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"Illegal invocation\\");
+        }
+
+        return esValue[implSymbol][\\"a\\"];
+      }
+    })
+  );
+
+  Object.defineProperties(wrapper, { a: { configurable: false } });
+};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper = new Proxy(wrapper, proxyHandler);
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper[implSymbol];
+};
+
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
+    return;
+  }
+  class LegacyUnforgeableMap {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+  }
+  Object.defineProperties(LegacyUnforgeableMap.prototype, {
+    [Symbol.toStringTag]: { value: \\"LegacyUnforgeableMap\\", configurable: true }
+  });
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
+  }
+  globalObject[ctorRegistrySymbol][interfaceName] = LegacyUnforgeableMap;
+
+  Object.defineProperty(globalObject, interfaceName, {
+    configurable: true,
+    writable: true,
+    value: LegacyUnforgeableMap
+  });
+};
+
+const proxyHandler = {
+  get(target, P, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.get(target, P, receiver);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc === undefined) {
+      const parent = Object.getPrototypeOf(target);
+      if (parent === null) {
+        return undefined;
+      }
+      return Reflect.get(target, P, receiver);
+    }
+    if (!desc.get && !desc.set) {
+      return desc.value;
+    }
+    const getter = desc.get;
+    if (getter === undefined) {
+      return undefined;
+    }
+    return Reflect.apply(getter, receiver, []);
+  },
+
+  has(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.has(target, P);
+    }
+    const desc = this.getOwnPropertyDescriptor(target, P);
+    if (desc !== undefined) {
+      return true;
+    }
+    const parent = Object.getPrototypeOf(target);
+    if (parent !== null) {
+      return Reflect.has(parent, P);
+    }
+    return false;
+  },
+
+  ownKeys(target) {
+    const keys = new Set();
+
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
+      if (!(key in target)) {
+        keys.add(\`\${key}\`);
+      }
+    }
+
+    for (const key of Reflect.ownKeys(target)) {
+      keys.add(key);
+    }
+    return [...keys];
+  },
+
+  getOwnPropertyDescriptor(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    let ignoreNamedProps = false;
+
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
+
+      return {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value: utils.tryWrapperForImpl(namedValue)
+      };
+    }
+
+    return Reflect.getOwnPropertyDescriptor(target, P);
+  },
+
+  set(target, P, V, receiver) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.set(target, P, V, receiver);
+    }
+    if (target === receiver) {
+      if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
+        let namedValue = V;
+
+        namedValue = conversions[\\"DOMString\\"](namedValue, {
+          context: \\"Failed to set the '\\" + P + \\"' property on 'LegacyUnforgeableMap': The provided value\\"
+        });
+
+        const creating = !target[implSymbol][utils.supportsPropertyName](P);
+        if (creating) {
+          target[implSymbol][utils.namedSetNew](P, namedValue);
+        } else {
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
+        }
+
+        return true;
+      }
+    }
+    let ownDesc;
+
+    if (ownDesc === undefined) {
+      ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
+    }
+    if (ownDesc === undefined) {
+      const parent = Reflect.getPrototypeOf(target);
+      if (parent !== null) {
+        return Reflect.set(parent, P, V, receiver);
+      }
+      ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
+    }
+    if (!ownDesc.writable) {
+      return false;
+    }
+    if (!utils.isObject(receiver)) {
+      return false;
+    }
+    const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
+    let valueDesc;
+    if (existingDesc !== undefined) {
+      if (existingDesc.get || existingDesc.set) {
+        return false;
+      }
+      if (!existingDesc.writable) {
+        return false;
+      }
+      valueDesc = { value: V };
+    } else {
+      valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
+    }
+    return Reflect.defineProperty(receiver, P, valueDesc);
+  },
+
+  defineProperty(target, P, desc) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.defineProperty(target, P, desc);
+    }
+    if (![\\"a\\"].includes(P)) {
+      if (!utils.hasOwn(target, P)) {
+        if (desc.get || desc.set) {
+          return false;
+        }
+
+        let namedValue = desc.value;
+
+        namedValue = conversions[\\"DOMString\\"](namedValue, {
+          context: \\"Failed to set the '\\" + P + \\"' property on 'LegacyUnforgeableMap': The provided value\\"
+        });
+
+        const creating = !target[implSymbol][utils.supportsPropertyName](P);
+        if (creating) {
+          target[implSymbol][utils.namedSetNew](P, namedValue);
+        } else {
+          target[implSymbol][utils.namedSetExisting](P, namedValue);
+        }
+
+        return true;
+      }
+    }
+    return Reflect.defineProperty(target, P, desc);
+  },
+
+  deleteProperty(target, P) {
+    if (typeof P === \\"symbol\\") {
+      return Reflect.deleteProperty(target, P);
+    }
+
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      return false;
+    }
+
+    return Reflect.deleteProperty(target, P);
+  },
+
+  preventExtensions() {
+    return false;
+  }
+};
+
+const Impl = require(\\"../implementations/LegacyUnforgeableMap.js\\");
 "
 `;
 
@@ -15667,522 +16183,6 @@ exports.install = (globalObject, globalNames) => {
 };
 
 const Impl = require(\\"../implementations/UnderscoredProperties.js\\");
-"
-`;
-
-exports[`without processors Unforgeable.webidl 1`] = `
-"\\"use strict\\";
-
-const conversions = require(\\"webidl-conversions\\");
-const utils = require(\\"./utils.js\\");
-
-const implSymbol = utils.implSymbol;
-const ctorRegistrySymbol = utils.ctorRegistrySymbol;
-
-const interfaceName = \\"Unforgeable\\";
-
-exports.is = value => {
-  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
-};
-exports.isImpl = value => {
-  return utils.isObject(value) && value instanceof Impl.implementation;
-};
-exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
-  if (exports.is(value)) {
-    return utils.implForWrapper(value);
-  }
-  throw new TypeError(\`\${context} is not of type 'Unforgeable'.\`);
-};
-
-function makeWrapper(globalObject) {
-  if (globalObject[ctorRegistrySymbol] === undefined) {
-    throw new Error(\\"Internal error: invalid global object\\");
-  }
-
-  const ctor = globalObject[ctorRegistrySymbol][\\"Unforgeable\\"];
-  if (ctor === undefined) {
-    throw new Error(\\"Internal error: constructor Unforgeable is not installed on the passed global object\\");
-  }
-
-  return Object.create(ctor.prototype);
-}
-
-exports.create = (globalObject, constructorArgs, privateData) => {
-  const wrapper = makeWrapper(globalObject);
-  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
-};
-
-exports.createImpl = (globalObject, constructorArgs, privateData) => {
-  const wrapper = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(wrapper);
-};
-
-exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      assign(url) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'assign' on 'Unforgeable': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'assign' on 'Unforgeable': parameter 1\\"
-          });
-          args.push(curArg);
-        }
-        return esValue[implSymbol].assign(...args);
-      },
-      get href() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return esValue[implSymbol][\\"href\\"];
-      },
-      set href(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'href' property on 'Unforgeable': The provided value\\"
-        });
-
-        esValue[implSymbol][\\"href\\"] = V;
-      },
-      toString() {
-        const esValue = this;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return esValue[implSymbol][\\"href\\"];
-      },
-      get origin() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return esValue[implSymbol][\\"origin\\"];
-      },
-      get protocol() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return esValue[implSymbol][\\"protocol\\"];
-      },
-      set protocol(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'protocol' property on 'Unforgeable': The provided value\\"
-        });
-
-        esValue[implSymbol][\\"protocol\\"] = V;
-      }
-    })
-  );
-
-  Object.defineProperties(wrapper, {
-    assign: { configurable: false, writable: false },
-    href: { configurable: false },
-    toString: { configurable: false, writable: false },
-    origin: { configurable: false },
-    protocol: { configurable: false }
-  });
-};
-
-exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
-  privateData.wrapper = wrapper;
-
-  exports._internalSetup(wrapper, globalObject);
-  Object.defineProperty(wrapper, implSymbol, {
-    value: new Impl.implementation(globalObject, constructorArgs, privateData),
-    configurable: true
-  });
-
-  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
-  if (Impl.init) {
-    Impl.init(wrapper[implSymbol]);
-  }
-  return wrapper;
-};
-
-exports.new = globalObject => {
-  const wrapper = makeWrapper(globalObject);
-
-  exports._internalSetup(wrapper, globalObject);
-  Object.defineProperty(wrapper, implSymbol, {
-    value: Object.create(Impl.implementation.prototype),
-    configurable: true
-  });
-
-  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
-  if (Impl.init) {
-    Impl.init(wrapper[implSymbol]);
-  }
-  return wrapper[implSymbol];
-};
-
-const exposed = new Set([\\"Window\\"]);
-
-exports.install = (globalObject, globalNames) => {
-  if (!globalNames.some(globalName => exposed.has(globalName))) {
-    return;
-  }
-  class Unforgeable {
-    constructor() {
-      throw new TypeError(\\"Illegal constructor\\");
-    }
-  }
-  Object.defineProperties(Unforgeable.prototype, {
-    [Symbol.toStringTag]: { value: \\"Unforgeable\\", configurable: true }
-  });
-  if (globalObject[ctorRegistrySymbol] === undefined) {
-    globalObject[ctorRegistrySymbol] = Object.create(null);
-  }
-  globalObject[ctorRegistrySymbol][interfaceName] = Unforgeable;
-
-  Object.defineProperty(globalObject, interfaceName, {
-    configurable: true,
-    writable: true,
-    value: Unforgeable
-  });
-};
-
-const Impl = require(\\"../implementations/Unforgeable.js\\");
-"
-`;
-
-exports[`without processors UnforgeableMap.webidl 1`] = `
-"\\"use strict\\";
-
-const conversions = require(\\"webidl-conversions\\");
-const utils = require(\\"./utils.js\\");
-
-const implSymbol = utils.implSymbol;
-const ctorRegistrySymbol = utils.ctorRegistrySymbol;
-
-const interfaceName = \\"UnforgeableMap\\";
-
-exports.is = value => {
-  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
-};
-exports.isImpl = value => {
-  return utils.isObject(value) && value instanceof Impl.implementation;
-};
-exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
-  if (exports.is(value)) {
-    return utils.implForWrapper(value);
-  }
-  throw new TypeError(\`\${context} is not of type 'UnforgeableMap'.\`);
-};
-
-function makeWrapper(globalObject) {
-  if (globalObject[ctorRegistrySymbol] === undefined) {
-    throw new Error(\\"Internal error: invalid global object\\");
-  }
-
-  const ctor = globalObject[ctorRegistrySymbol][\\"UnforgeableMap\\"];
-  if (ctor === undefined) {
-    throw new Error(\\"Internal error: constructor UnforgeableMap is not installed on the passed global object\\");
-  }
-
-  return Object.create(ctor.prototype);
-}
-
-exports.create = (globalObject, constructorArgs, privateData) => {
-  const wrapper = makeWrapper(globalObject);
-  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
-};
-
-exports.createImpl = (globalObject, constructorArgs, privateData) => {
-  const wrapper = exports.create(globalObject, constructorArgs, privateData);
-  return utils.implForWrapper(wrapper);
-};
-
-exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      get a() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"Illegal invocation\\");
-        }
-
-        return esValue[implSymbol][\\"a\\"];
-      }
-    })
-  );
-
-  Object.defineProperties(wrapper, { a: { configurable: false } });
-};
-
-exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
-  privateData.wrapper = wrapper;
-
-  exports._internalSetup(wrapper, globalObject);
-  Object.defineProperty(wrapper, implSymbol, {
-    value: new Impl.implementation(globalObject, constructorArgs, privateData),
-    configurable: true
-  });
-
-  wrapper = new Proxy(wrapper, proxyHandler);
-
-  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
-  if (Impl.init) {
-    Impl.init(wrapper[implSymbol]);
-  }
-  return wrapper;
-};
-
-exports.new = globalObject => {
-  const wrapper = makeWrapper(globalObject);
-
-  exports._internalSetup(wrapper, globalObject);
-  Object.defineProperty(wrapper, implSymbol, {
-    value: Object.create(Impl.implementation.prototype),
-    configurable: true
-  });
-
-  wrapper = new Proxy(wrapper, proxyHandler);
-
-  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
-  if (Impl.init) {
-    Impl.init(wrapper[implSymbol]);
-  }
-  return wrapper[implSymbol];
-};
-
-const exposed = new Set([\\"Window\\"]);
-
-exports.install = (globalObject, globalNames) => {
-  if (!globalNames.some(globalName => exposed.has(globalName))) {
-    return;
-  }
-  class UnforgeableMap {
-    constructor() {
-      throw new TypeError(\\"Illegal constructor\\");
-    }
-  }
-  Object.defineProperties(UnforgeableMap.prototype, {
-    [Symbol.toStringTag]: { value: \\"UnforgeableMap\\", configurable: true }
-  });
-  if (globalObject[ctorRegistrySymbol] === undefined) {
-    globalObject[ctorRegistrySymbol] = Object.create(null);
-  }
-  globalObject[ctorRegistrySymbol][interfaceName] = UnforgeableMap;
-
-  Object.defineProperty(globalObject, interfaceName, {
-    configurable: true,
-    writable: true,
-    value: UnforgeableMap
-  });
-};
-
-const proxyHandler = {
-  get(target, P, receiver) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.get(target, P, receiver);
-    }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
-      }
-      return Reflect.get(target, P, receiver);
-    }
-    if (!desc.get && !desc.set) {
-      return desc.value;
-    }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
-  },
-
-  has(target, P) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.has(target, P);
-    }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc !== undefined) {
-      return true;
-    }
-    const parent = Object.getPrototypeOf(target);
-    if (parent !== null) {
-      return Reflect.has(parent, P);
-    }
-    return false;
-  },
-
-  ownKeys(target) {
-    const keys = new Set();
-
-    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
-      if (!(key in target)) {
-        keys.add(\`\${key}\`);
-      }
-    }
-
-    for (const key of Reflect.ownKeys(target)) {
-      keys.add(key);
-    }
-    return [...keys];
-  },
-
-  getOwnPropertyDescriptor(target, P) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.getOwnPropertyDescriptor(target, P);
-    }
-    let ignoreNamedProps = false;
-
-    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
-      const namedValue = target[implSymbol][utils.namedGet](P);
-
-      return {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value: utils.tryWrapperForImpl(namedValue)
-      };
-    }
-
-    return Reflect.getOwnPropertyDescriptor(target, P);
-  },
-
-  set(target, P, V, receiver) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.set(target, P, V, receiver);
-    }
-    if (target === receiver) {
-      if (typeof P === \\"string\\" && !utils.isArrayIndexPropName(P)) {
-        let namedValue = V;
-
-        namedValue = conversions[\\"DOMString\\"](namedValue, {
-          context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
-        });
-
-        const creating = !target[implSymbol][utils.supportsPropertyName](P);
-        if (creating) {
-          target[implSymbol][utils.namedSetNew](P, namedValue);
-        } else {
-          target[implSymbol][utils.namedSetExisting](P, namedValue);
-        }
-
-        return true;
-      }
-    }
-    let ownDesc;
-
-    if (ownDesc === undefined) {
-      ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
-    }
-    if (ownDesc === undefined) {
-      const parent = Reflect.getPrototypeOf(target);
-      if (parent !== null) {
-        return Reflect.set(parent, P, V, receiver);
-      }
-      ownDesc = { writable: true, enumerable: true, configurable: true, value: undefined };
-    }
-    if (!ownDesc.writable) {
-      return false;
-    }
-    if (!utils.isObject(receiver)) {
-      return false;
-    }
-    const existingDesc = Reflect.getOwnPropertyDescriptor(receiver, P);
-    let valueDesc;
-    if (existingDesc !== undefined) {
-      if (existingDesc.get || existingDesc.set) {
-        return false;
-      }
-      if (!existingDesc.writable) {
-        return false;
-      }
-      valueDesc = { value: V };
-    } else {
-      valueDesc = { writable: true, enumerable: true, configurable: true, value: V };
-    }
-    return Reflect.defineProperty(receiver, P, valueDesc);
-  },
-
-  defineProperty(target, P, desc) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.defineProperty(target, P, desc);
-    }
-    if (![\\"a\\"].includes(P)) {
-      if (!utils.hasOwn(target, P)) {
-        if (desc.get || desc.set) {
-          return false;
-        }
-
-        let namedValue = desc.value;
-
-        namedValue = conversions[\\"DOMString\\"](namedValue, {
-          context: \\"Failed to set the '\\" + P + \\"' property on 'UnforgeableMap': The provided value\\"
-        });
-
-        const creating = !target[implSymbol][utils.supportsPropertyName](P);
-        if (creating) {
-          target[implSymbol][utils.namedSetNew](P, namedValue);
-        } else {
-          target[implSymbol][utils.namedSetExisting](P, namedValue);
-        }
-
-        return true;
-      }
-    }
-    return Reflect.defineProperty(target, P, desc);
-  },
-
-  deleteProperty(target, P) {
-    if (typeof P === \\"symbol\\") {
-      return Reflect.deleteProperty(target, P);
-    }
-
-    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
-      return false;
-    }
-
-    return Reflect.deleteProperty(target, P);
-  },
-
-  preventExtensions() {
-    return false;
-  }
-};
-
-const Impl = require(\\"../implementations/UnforgeableMap.js\\");
 "
 `;
 

--- a/test/cases/DOMImplementation.webidl
+++ b/test/cases/DOMImplementation.webidl
@@ -1,7 +1,7 @@
 [Exposed=Window]
 interface DOMImplementation {
   [NewObject] DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
-  [NewObject] XMLDocument createDocument(DOMString? namespace, [TreatNullAs=EmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
+  [NewObject] XMLDocument createDocument(DOMString? namespace, [LegacyNullToEmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
   [NewObject] Document createHTMLDocument(optional DOMString title);
 
   boolean hasFeature(); // useless; always returns true

--- a/test/cases/Global.webidl
+++ b/test/cases/Global.webidl
@@ -1,9 +1,9 @@
 [Global=Global,Exposed=Global]
 interface Global {
   void op();
-  [Unforgeable] void unforgeableOp();
+  [LegacyUnforgeable] void unforgeableOp();
   attribute DOMString attr;
-  [Unforgeable] attribute DOMString unforgeableAttr;
+  [LegacyUnforgeable] attribute DOMString unforgeableAttr;
 
   getter DOMString (unsigned long index);
   attribute unsigned long length;

--- a/test/cases/LegacyUnforgeable.webidl
+++ b/test/cases/LegacyUnforgeable.webidl
@@ -1,5 +1,5 @@
 [Exposed=Window]
-interface Unforgeable {
+interface LegacyUnforgeable {
   [LegacyUnforgeable] stringifier attribute USVString href;
   [LegacyUnforgeable] readonly attribute USVString origin;
   [LegacyUnforgeable] attribute USVString protocol;

--- a/test/cases/LegacyUnforgeableMap.webidl
+++ b/test/cases/LegacyUnforgeableMap.webidl
@@ -1,5 +1,5 @@
 [Exposed=Window]
-interface UnforgeableMap {
+interface LegacyUnforgeableMap {
   [LegacyUnforgeable] readonly attribute DOMString a;
   getter DOMString (DOMString x);
   setter DOMString (DOMString x, DOMString y);

--- a/test/cases/Unforgeable.webidl
+++ b/test/cases/Unforgeable.webidl
@@ -1,7 +1,7 @@
 [Exposed=Window]
 interface Unforgeable {
-  [Unforgeable] stringifier attribute USVString href;
-  [Unforgeable] readonly attribute USVString origin;
-  [Unforgeable] attribute USVString protocol;
-  [Unforgeable] void assign(USVString url);
+  [LegacyUnforgeable] stringifier attribute USVString href;
+  [LegacyUnforgeable] readonly attribute USVString origin;
+  [LegacyUnforgeable] attribute USVString protocol;
+  [LegacyUnforgeable] void assign(USVString url);
 };

--- a/test/cases/UnforgeableMap.webidl
+++ b/test/cases/UnforgeableMap.webidl
@@ -1,6 +1,6 @@
 [Exposed=Window]
 interface UnforgeableMap {
-  [Unforgeable] readonly attribute DOMString a;
+  [LegacyUnforgeable] readonly attribute DOMString a;
   getter DOMString (DOMString x);
   setter DOMString (DOMString x, DOMString y);
 };


### PR DESCRIPTION
I added a second commit for the renaming, so that you can see that the first commit does not effect the snapshot output at all.

Interestingly, we seem to support [LegacyLenientThis] and [LegacyOverrideBuiltins] with no tests.

This conflicts with #203; I will take care of the conflicts when merging, if both get approved.