### PR TITLE
Implement [LegacyLenientSetter] and fix [LegacyLenientThis]

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ webidl2js is implementing an ever-growing subset of the Web IDL specification. S
 - `[EnforceRange]`
 - `[Exposed]`
 - `[LegacyLenientThis]`
+- `[LegacyLenientSetter]`
 - `[LegacyNoInterfaceObject]`
 - `[LegacyNullToEmptyString]`
 - `[LegacyOverrideBuiltins]`
@@ -494,7 +495,6 @@ Notable missing features include:
 - `[Default]` (for `toJSON()` operations)
 - `[Global]`'s various consequences, including the named properties object and `[[SetPrototypeOf]]`
 - `[LegacyFactoryFunction]`
-- `[LegacyLenientSetter]`
 - `[LegacyNamespace]`
 - `[LegacyTreatNonObjectAsNull]`
 - `[SecureContext]`

--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -48,8 +48,16 @@ class Attribute {
       setterBody = processedOutput.set;
     }
 
-    if (utils.getExtAttr(this.idl.extAttrs, "LegacyLenientThis")) {
-      brandCheck = "";
+    const replaceable = utils.getExtAttr(this.idl.extAttrs, "Replaceable");
+    const legacyLenientSetter = utils.getExtAttr(this.idl.extAttrs, "LegacyLenientSetter");
+    const legacyLenientThis = utils.getExtAttr(this.idl.extAttrs, "LegacyLenientThis");
+
+    if (legacyLenientThis) {
+      brandCheck = `
+        if (!exports.is(esValue)) {
+          return;
+        }
+      `;
     }
 
     if (sameObject) {
@@ -94,23 +102,47 @@ class Attribute {
         ${idlConversion}
         ${setterBody}
       `, "set", { configurable });
-    } else if (utils.getExtAttr(this.idl.extAttrs, "PutForwards")) {
-      addMethod(this.idl.name, ["V"], `
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-        ${brandCheck}
-        this.${this.idl.name}.${utils.getExtAttr(this.idl.extAttrs, "PutForwards").rhs.value} = V;
-      `, "set", { configurable });
-    } else if (utils.getExtAttr(this.idl.extAttrs, "Replaceable")) {
-      addMethod(this.idl.name, ["V"], `
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-        ${brandCheck}
-        Object.defineProperty(esValue, "${this.idl.name}", {
-          configurable: true,
-          enumerable: true,
-          value: V,
-          writable: true
-        });
-      `, "set", { configurable });
+    } else {
+      const putForwards = utils.getExtAttr(this.idl.extAttrs, "PutForwards");
+
+      setterBody = "";
+      if (replaceable) {
+        if (legacyLenientThis) {
+          brandCheck = "";
+        }
+
+        setterBody = `
+          Object.defineProperty(esValue, "${this.idl.name}", {
+            configurable: true,
+            enumerable: true,
+            value: V,
+            writable: true
+          });
+        `;
+      } else if (putForwards) {
+        setterBody = `
+          const Q = esValue["${this.idl.name}"];
+          if (!utils.isObject(Q)) {
+            throw new TypeError("Property '${this.idl.name}' is not an object");
+          }
+        `;
+
+        // WebIDL calls the `Set` abstract operation with a `Throw` value of `false`:
+        setterBody += `Reflect.set(Q, "${putForwards.rhs.value}", V);`;
+      }
+
+      if (setterBody) {
+        addMethod(this.idl.name, ["V"], `
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+          ${brandCheck}
+          ${setterBody}
+        `, "set", { configurable });
+      } else if (legacyLenientSetter) {
+        addMethod(this.idl.name, ["V"], legacyLenientThis ? "" : `
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+          ${brandCheck}
+        `, "set", { configurable });
+      }
     }
 
     if (!this.static && this.idl.special === "stringifier") {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -2104,6 +2104,207 @@ const Impl = require(\\"../implementations/HTMLConstructor.js\\");
 "
 `;
 
+exports[`with processors LegacyLenientAttributes.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
+
+const interfaceName = \\"LegacyLenientAttributes\\";
+
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+};
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
+};
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
+  }
+  throw new TypeError(\`\${context} is not of type 'LegacyLenientAttributes'.\`);
+};
+
+function makeWrapper(globalObject) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistrySymbol][\\"LegacyLenientAttributes\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor LegacyLenientAttributes is not installed on the passed global object\\");
+  }
+
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper[implSymbol];
+};
+
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
+    return;
+  }
+  class LegacyLenientAttributes {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    get lenientSetter() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return esValue[implSymbol][\\"lenientSetter\\"];
+    }
+
+    set lenientSetter(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+    }
+
+    get lenientThisSetter() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        return;
+      }
+
+      return esValue[implSymbol][\\"lenientThisSetter\\"];
+    }
+
+    set lenientThisSetter(V) {}
+
+    get lenientThis() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        return;
+      }
+
+      return esValue[implSymbol][\\"lenientThis\\"];
+    }
+
+    set lenientThis(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        return;
+      }
+
+      V = conversions[\\"DOMString\\"](V, {
+        context: \\"Failed to set the 'lenientThis' property on 'LegacyLenientAttributes': The provided value\\"
+      });
+
+      esValue[implSymbol][\\"lenientThis\\"] = V;
+    }
+
+    get readonlyLenientThis() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        return;
+      }
+
+      return esValue[implSymbol][\\"readonlyLenientThis\\"];
+    }
+
+    get replaceableLenientThis() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        return;
+      }
+
+      return esValue[implSymbol][\\"replaceableLenientThis\\"];
+    }
+
+    set replaceableLenientThis(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      Object.defineProperty(esValue, \\"replaceableLenientThis\\", {
+        configurable: true,
+        enumerable: true,
+        value: V,
+        writable: true
+      });
+    }
+  }
+  Object.defineProperties(LegacyLenientAttributes.prototype, {
+    lenientSetter: { enumerable: true },
+    lenientThisSetter: { enumerable: true },
+    lenientThis: { enumerable: true },
+    readonlyLenientThis: { enumerable: true },
+    replaceableLenientThis: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"LegacyLenientAttributes\\", configurable: true }
+  });
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
+  }
+  globalObject[ctorRegistrySymbol][interfaceName] = LegacyLenientAttributes;
+
+  Object.defineProperty(globalObject, interfaceName, {
+    configurable: true,
+    writable: true,
+    value: LegacyLenientAttributes
+  });
+};
+
+const Impl = require(\\"../implementations/LegacyLenientAttributes.js\\");
+"
+`;
+
 exports[`with processors LegacyUnforgeable.webidl 1`] = `
 "\\"use strict\\";
 
@@ -3774,6 +3975,143 @@ exports.install = (globalObject, globalNames) => {
 };
 
 const Impl = require(\\"../implementations/Reflect.js\\");
+"
+`;
+
+exports[`with processors Replaceable.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
+
+const interfaceName = \\"Replaceable\\";
+
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+};
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
+};
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
+  }
+  throw new TypeError(\`\${context} is not of type 'Replaceable'.\`);
+};
+
+function makeWrapper(globalObject) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistrySymbol][\\"Replaceable\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Replaceable is not installed on the passed global object\\");
+  }
+
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper[implSymbol];
+};
+
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
+    return;
+  }
+  class Replaceable {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    get replaceable() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return esValue[implSymbol][\\"replaceable\\"];
+    }
+
+    set replaceable(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      Object.defineProperty(esValue, \\"replaceable\\", {
+        configurable: true,
+        enumerable: true,
+        value: V,
+        writable: true
+      });
+    }
+  }
+  Object.defineProperties(Replaceable.prototype, {
+    replaceable: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"Replaceable\\", configurable: true }
+  });
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
+  }
+  globalObject[ctorRegistrySymbol][interfaceName] = Replaceable;
+
+  Object.defineProperty(globalObject, interfaceName, {
+    configurable: true,
+    writable: true,
+    value: Replaceable
+  });
+};
+
+const Impl = require(\\"../implementations/Replaceable.js\\");
 "
 `;
 
@@ -10460,6 +10798,207 @@ const Impl = require(\\"../implementations/HTMLConstructor.js\\");
 "
 `;
 
+exports[`without processors LegacyLenientAttributes.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
+
+const interfaceName = \\"LegacyLenientAttributes\\";
+
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+};
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
+};
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
+  }
+  throw new TypeError(\`\${context} is not of type 'LegacyLenientAttributes'.\`);
+};
+
+function makeWrapper(globalObject) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistrySymbol][\\"LegacyLenientAttributes\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor LegacyLenientAttributes is not installed on the passed global object\\");
+  }
+
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper[implSymbol];
+};
+
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
+    return;
+  }
+  class LegacyLenientAttributes {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    get lenientSetter() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return esValue[implSymbol][\\"lenientSetter\\"];
+    }
+
+    set lenientSetter(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+    }
+
+    get lenientThisSetter() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        return;
+      }
+
+      return esValue[implSymbol][\\"lenientThisSetter\\"];
+    }
+
+    set lenientThisSetter(V) {}
+
+    get lenientThis() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        return;
+      }
+
+      return esValue[implSymbol][\\"lenientThis\\"];
+    }
+
+    set lenientThis(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        return;
+      }
+
+      V = conversions[\\"DOMString\\"](V, {
+        context: \\"Failed to set the 'lenientThis' property on 'LegacyLenientAttributes': The provided value\\"
+      });
+
+      esValue[implSymbol][\\"lenientThis\\"] = V;
+    }
+
+    get readonlyLenientThis() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        return;
+      }
+
+      return esValue[implSymbol][\\"readonlyLenientThis\\"];
+    }
+
+    get replaceableLenientThis() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        return;
+      }
+
+      return esValue[implSymbol][\\"replaceableLenientThis\\"];
+    }
+
+    set replaceableLenientThis(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      Object.defineProperty(esValue, \\"replaceableLenientThis\\", {
+        configurable: true,
+        enumerable: true,
+        value: V,
+        writable: true
+      });
+    }
+  }
+  Object.defineProperties(LegacyLenientAttributes.prototype, {
+    lenientSetter: { enumerable: true },
+    lenientThisSetter: { enumerable: true },
+    lenientThis: { enumerable: true },
+    readonlyLenientThis: { enumerable: true },
+    replaceableLenientThis: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"LegacyLenientAttributes\\", configurable: true }
+  });
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
+  }
+  globalObject[ctorRegistrySymbol][interfaceName] = LegacyLenientAttributes;
+
+  Object.defineProperty(globalObject, interfaceName, {
+    configurable: true,
+    writable: true,
+    value: LegacyLenientAttributes
+  });
+};
+
+const Impl = require(\\"../implementations/LegacyLenientAttributes.js\\");
+"
+`;
+
 exports[`without processors LegacyUnforgeable.webidl 1`] = `
 "\\"use strict\\";
 
@@ -12115,6 +12654,143 @@ exports.install = (globalObject, globalNames) => {
 };
 
 const Impl = require(\\"../implementations/Reflect.js\\");
+"
+`;
+
+exports[`without processors Replaceable.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
+
+const interfaceName = \\"Replaceable\\";
+
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+};
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
+};
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
+  }
+  throw new TypeError(\`\${context} is not of type 'Replaceable'.\`);
+};
+
+function makeWrapper(globalObject) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistrySymbol][\\"Replaceable\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor Replaceable is not installed on the passed global object\\");
+  }
+
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper[implSymbol];
+};
+
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
+    return;
+  }
+  class Replaceable {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    get replaceable() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      return esValue[implSymbol][\\"replaceable\\"];
+    }
+
+    set replaceable(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"Illegal invocation\\");
+      }
+
+      Object.defineProperty(esValue, \\"replaceable\\", {
+        configurable: true,
+        enumerable: true,
+        value: V,
+        writable: true
+      });
+    }
+  }
+  Object.defineProperties(Replaceable.prototype, {
+    replaceable: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"Replaceable\\", configurable: true }
+  });
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
+  }
+  globalObject[ctorRegistrySymbol][interfaceName] = Replaceable;
+
+  Object.defineProperty(globalObject, interfaceName, {
+    configurable: true,
+    writable: true,
+    value: Replaceable
+  });
+};
+
+const Impl = require(\\"../implementations/Replaceable.js\\");
 "
 `;
 

--- a/test/cases/LegacyLenientAttributes.webidl
+++ b/test/cases/LegacyLenientAttributes.webidl
@@ -1,0 +1,9 @@
+[Exposed=Window]
+interface LegacyLenientAttributes {
+  [LegacyLenientSetter] readonly attribute DOMString lenientSetter;
+  [LegacyLenientSetter, LegacyLenientThis] readonly attribute DOMString lenientThisSetter;
+
+  [LegacyLenientThis] attribute DOMString lenientThis;
+  [LegacyLenientThis] readonly attribute DOMString readonlyLenientThis;
+  [LegacyLenientThis, Replaceable] readonly attribute DOMString replaceableLenientThis;
+};

--- a/test/cases/Replaceable.webidl
+++ b/test/cases/Replaceable.webidl
@@ -1,0 +1,4 @@
+[Exposed=Window]
+interface Replaceable {
+  [Replaceable] readonly attribute DOMString replaceable;
+};


### PR DESCRIPTION
For [LegacyLenientThis], this fixes an issue where it would still try to get the impl value, even when the thisArg did not pass the is() check, resulting in a TypeError.

This also adds test coverage for [LegacyLenientThis] and [Replaceable], as part of #207.

---

This was originally #209 but that PR was sent from an organization and thus not acceptable for this project.