### PR TITLE
Implement [WebIDL2JSCallWithGlobal] for static operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ A couple of non-standard extended attributes are baked in to webidl2js:
 
 ### `[WebIDL2JSCallWithGlobal]`
 
-The `[WebIDL2JSCallWithGlobal]` extended attribute is used on IDL members to pass the  `globalObject` as the first parameter to static operations.
+When the `[WebIDL2JSCallWithGlobal]` extended attribute is specified on static IDL operations, the generated interface code passes the [current global object](https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object) as the first parameter to the implementation code. All other parameters follow `globalObject` and are unchanged. This could be used to implement factory functions that create objects in the current realm.
 
 ### `[WebIDL2JSValueAsUnsupported=value]`
 

--- a/README.md
+++ b/README.md
@@ -501,7 +501,11 @@ Notable missing features include:
 
 ## Nonstandard extended attributes
 
-One non-standard extended attribute is baked in to webidl2js:
+A couple of non-standard extended attributes are baked in to webidl2js:
+
+### `[WebIDL2JSCallWithGlobal]`
+
+The `[WebIDL2JSCallWithGlobal]` extended attribute is used on IDL members to pass the  `globalObject` as the first parameter to static operations.
 
 ### `[WebIDL2JSValueAsUnsupported=value]`
 

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -8,17 +8,12 @@ const Operation = require("./operation");
 const Types = require("../types");
 const Overloads = require("../overloads");
 const Parameters = require("../parameters");
-const keywords = require("../keywords");
 
 function isNamed(idl) {
   return idl.arguments[0].idlType.idlType === "DOMString";
 }
 function isIndexed(idl) {
   return idl.arguments[0].idlType.idlType === "unsigned long";
-}
-
-function formatArgs(args) {
-  return args.map(name => name + (keywords.has(name) ? "_" : "")).join(", ");
 }
 
 const defaultObjectLiteralDescriptor = {
@@ -1249,7 +1244,7 @@ class Interface {
 
       body = `
         ${conversions.body}
-        return exports.setup(${formatArgs(setupArgs)});
+        return exports.setup(${utils.formatArgs(setupArgs)});
       `;
     } else {
       body = `
@@ -1319,7 +1314,7 @@ class Interface {
   generateOffInstanceMethods() {
     const addOne = (name, args, body) => {
       this.str += `
-        ${name}(${formatArgs(args)}) {${body}}
+        ${name}(${utils.formatArgs(args)}) {${body}}
       `;
     };
 
@@ -1415,7 +1410,7 @@ class Interface {
 
     function addOne(name, args, body) {
       methods.push(`
-        ${name}(${formatArgs(args)}) {${body}}
+        ${name}(${utils.formatArgs(args)}) {${body}}
       `);
     }
 

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -43,6 +43,30 @@ class Operation {
     return firstAsync;
   }
 
+  getCallWithGlobal() {
+    const { idls } = this;
+    /** @type {import("webidl2").ExtendedAttribute} */
+    const firstCallWith = utils.getExtAttr(idls[0].extAttrs, "WebIDL2JSCallWithGlobal");
+    const hasCallWith = Boolean(firstCallWith);
+
+    if (hasCallWith && !this.static) {
+      throw new Error(
+        `[WebIDL2JSCallWithGlobal] is only valid for static operations: "${this.name}" on ${this.interface.name}`
+      );
+    }
+
+    for (let i = 1; i < idls.length; i++) {
+      const currentCallWith = utils.getExtAttr(idls[i].extAttrs, "WebIDL2JSCallWithGlobal");
+      if (hasCallWith !== Boolean(currentCallWith)) {
+        throw new Error(
+          `[WebIDL2JSCallWithGlobal] is not applied uniformly to operation "${this.name}" on ${this.interface.name}`
+        );
+      }
+    }
+
+    return firstCallWith;
+  }
+
   fixUpArgsExtAttrs() {
     for (const idl of this.idls) {
       for (const arg of idl.arguments) {
@@ -69,6 +93,7 @@ class Operation {
     const async = this.isAsync();
     const promiseHandlingBefore = async ? `try {` : ``;
     const promiseHandlingAfter = async ? `} catch (e) { return Promise.reject(e); }` : ``;
+    const callWithGlobal = this.getCallWithGlobal();
 
     const type = this.static ? "static operation" : "regular operation";
     const overloads = Overloads.getEffectiveOverloads(type, this.name, 0, this.interface);
@@ -97,18 +122,26 @@ class Operation {
 
     const parameterConversions = Parameters.generateOverloadConversions(
       this.ctx, type, this.name, this.interface, `Failed to execute '${this.name}' on '${this.interface.name}': `);
-    const argsSpread = parameterConversions.hasArgs ? "...args" : "";
+    const args = [];
     requires.merge(parameterConversions.requires);
     str += parameterConversions.body;
+
+    if (callWithGlobal) {
+      args.push("globalObject");
+    }
+
+    if (parameterConversions.hasArgs) {
+      args.push("...args");
+    }
 
     let invocation;
     if (overloads.every(overload => conversions[overload.operation.idlType.idlType])) {
       invocation = `
-        return ${callOn}.${implFunc}(${argsSpread});
+        return ${callOn}.${implFunc}(${utils.formatArgs(args)});
       `;
     } else {
       invocation = `
-        return utils.tryWrapperForImpl(${callOn}.${implFunc}(${argsSpread}));
+        return utils.tryWrapperForImpl(${callOn}.${implFunc}(${utils.formatArgs(args)}));
       `;
     }
 

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -43,28 +43,25 @@ class Operation {
     return firstAsync;
   }
 
-  getCallWithGlobal() {
+  hasCallWithGlobal() {
     const { idls } = this;
-    /** @type {import("webidl2").ExtendedAttribute} */
-    const firstCallWith = utils.getExtAttr(idls[0].extAttrs, "WebIDL2JSCallWithGlobal");
-    const hasCallWith = Boolean(firstCallWith);
+    const hasCallWithGlobal = Boolean(utils.getExtAttr(idls[0].extAttrs, "WebIDL2JSCallWithGlobal"));
 
-    if (hasCallWith && !this.static) {
+    if (hasCallWithGlobal && !this.static) {
       throw new Error(
         `[WebIDL2JSCallWithGlobal] is only valid for static operations: "${this.name}" on ${this.interface.name}`
       );
     }
 
     for (let i = 1; i < idls.length; i++) {
-      const currentCallWith = utils.getExtAttr(idls[i].extAttrs, "WebIDL2JSCallWithGlobal");
-      if (hasCallWith !== Boolean(currentCallWith)) {
+      if (hasCallWithGlobal !== Boolean(utils.getExtAttr(idls[i].extAttrs, "WebIDL2JSCallWithGlobal"))) {
         throw new Error(
           `[WebIDL2JSCallWithGlobal] is not applied uniformly to operation "${this.name}" on ${this.interface.name}`
         );
       }
     }
 
-    return firstCallWith;
+    return hasCallWithGlobal;
   }
 
   fixUpArgsExtAttrs() {
@@ -93,7 +90,7 @@ class Operation {
     const async = this.isAsync();
     const promiseHandlingBefore = async ? `try {` : ``;
     const promiseHandlingAfter = async ? `} catch (e) { return Promise.reject(e); }` : ``;
-    const callWithGlobal = this.getCallWithGlobal();
+    const hasCallWithGlobal = this.hasCallWithGlobal();
 
     const type = this.static ? "static operation" : "regular operation";
     const overloads = Overloads.getEffectiveOverloads(type, this.name, 0, this.interface);
@@ -126,7 +123,7 @@ class Operation {
     requires.merge(parameterConversions.requires);
     str += parameterConversions.body;
 
-    if (callWithGlobal) {
+    if (hasCallWithGlobal) {
       args.push("globalObject");
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 "use strict";
 const { extname } = require("path");
+const keywords = require("./keywords.js");
 
 function getDefault(dflt) {
   switch (dflt.type) {
@@ -95,6 +96,13 @@ const defaultDefinePropertyDescriptor = {
   writable: false
 };
 
+function formatArgs(args) {
+  return args
+    .filter(name => name !== null && name !== undefined && name !== "")
+    .map(name => name + (keywords.has(name) ? "_" : ""))
+    .join(", ");
+}
+
 function toKey(type, func = "") {
   return String(func + type).replace(/[./-]+/g, " ").trim().replace(/ /g, "_");
 }
@@ -168,5 +176,6 @@ module.exports = {
   stringifyPropertyName,
   getPropertyDescriptorModifier,
   defaultDefinePropertyDescriptor,
+  formatArgs,
   RequiresMap
 };

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1211,7 +1211,7 @@ exports.install = (globalObject, globalNames) => {
         }
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(Impl.implementation.fromRect(...args));
+      return utils.tryWrapperForImpl(Impl.implementation.fromRect(globalObject, ...args));
     }
   }
   Object.defineProperties(DOMRect.prototype, {
@@ -10028,7 +10028,7 @@ exports.install = (globalObject, globalNames) => {
         }
         args.push(curArg);
       }
-      return utils.tryWrapperForImpl(Impl.implementation.fromRect(...args));
+      return utils.tryWrapperForImpl(Impl.implementation.fromRect(globalObject, ...args));
     }
   }
   Object.defineProperties(DOMRect.prototype, {

--- a/test/cases/DOMRect.webidl
+++ b/test/cases/DOMRect.webidl
@@ -7,7 +7,7 @@ interface DOMRect /* : DOMRectReadOnly */ {
   constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
           optional unrestricted double width = 0, optional unrestricted double height = 0);
 
-  [NewObject] static DOMRect fromRect(optional DOMRectInit other);
+  [NewObject, WebIDL2JSCallWithGlobal] static DOMRect fromRect(optional DOMRectInit other);
 
   attribute unrestricted double x;
   attribute unrestricted double y;


### PR DESCRIPTION
This is necessary to be able to implement `DOMRect.fromRect(…)` in **JSDOM**.

---

Fixes <https://github.com/jsdom/webidl2js/issues/186>

review?(@domenic, @TimothyGu)