### PR TITLE
Fix ECMAScript to IDL `Promise` type conversion

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -328,19 +328,39 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
   }
 
   function generatePromise() {
-    str += `${name} = new Promise(resolve => resolve(${name}))`;
+    str += `${name} = new Promise(resolve => resolve(${name}));`;
 
     if (idlType.idlType[0].idlType !== "void") {
-      const conv = generateTypeConversion(ctx, "value", idlType.idlType[0], [], parentName,
+      const convOnFulfilled = generateTypeConversion(ctx, "value", idlType.idlType[0], [], parentName,
         `${errPrefix} + " promise value"`);
-      requires.merge(conv.requires);
-      str += `.then(value => {
-        ${conv.body.trim()}
-        return value;
-      })`;
-    }
+      requires.merge(convOnFulfilled.requires);
 
-    str += ";\n";
+      const convOnRejected = generateTypeConversion(ctx, "reason", { idlType: "any" }, [], parentName,
+        `${errPrefix} + " promise value"`);
+      requires.merge(convOnRejected.requires);
+
+      str += `
+        Object.assign(${name}, {
+          then(onFulfilled, onRejected) {
+            return Promise.prototype.then.call(
+              this,
+              value => {
+                ${convOnFulfilled.body.trim()}
+                if (typeof onFulfilled === "function") {
+                  return onFulfilled(value);
+                }
+              },
+              reason => {
+                ${convOnRejected.body.trim()}
+                if (typeof onRejected === "function") {
+                  return onRejected(reason);
+                }
+              }
+            );
+          }
+        });
+      `;
+    }
   }
 
   function generateFrozenArray() {

--- a/lib/types.js
+++ b/lib/types.js
@@ -328,39 +328,49 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
   }
 
   function generatePromise() {
-    str += `${name} = new Promise(resolve => resolve(${name}));`;
+    str += `
+      ${name} = new Promise(resolve => resolve(${name}));
+      Object.assign(${name}, {
+        then(onFulfilled, onRejected) {
+          return Promise.prototype.then.call(
+            this,`;
 
-    if (idlType.idlType[0].idlType !== "void") {
+    if (idlType.idlType[0].idlType === "void") {
+      str += `
+            () => {
+              if (typeof onFulfilled === "function") {
+                return onFulfilled();
+              }
+            },`;
+    } else {
       const convOnFulfilled = generateTypeConversion(ctx, "value", idlType.idlType[0], [], parentName,
         `${errPrefix} + " promise value"`);
       requires.merge(convOnFulfilled.requires);
 
-      const convOnRejected = generateTypeConversion(ctx, "reason", { idlType: "any" }, [], parentName,
-        `${errPrefix} + " promise value"`);
-      requires.merge(convOnRejected.requires);
-
       str += `
-        Object.assign(${name}, {
-          then(onFulfilled, onRejected) {
-            return Promise.prototype.then.call(
-              this,
-              value => {
-                ${convOnFulfilled.body.trim()}
-                if (typeof onFulfilled === "function") {
-                  return onFulfilled(value);
-                }
-              },
-              reason => {
-                ${convOnRejected.body.trim()}
-                if (typeof onRejected === "function") {
-                  return onRejected(reason);
-                }
+            value => {
+              ${convOnFulfilled.body.trim()}
+              if (typeof onFulfilled === "function") {
+                return onFulfilled(value);
               }
-            );
-          }
-        });
-      `;
+            },`;
     }
+
+    const convOnRejected = generateTypeConversion(ctx, "reason", { idlType: "any" }, [], parentName,
+      `${errPrefix} + " promise value"`);
+    requires.merge(convOnRejected.requires);
+
+    str += `
+            reason => {
+              ${convOnRejected.body.trim()}
+              if (typeof onRejected === "function") {
+                return onRejected(reason);
+              }
+            }
+          );
+        }
+      });
+    `;
   }
 
   function generateFrozenArray() {

--- a/lib/types.js
+++ b/lib/types.js
@@ -328,24 +328,19 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
   }
 
   function generatePromise() {
-    let handler;
-    if (idlType.idlType[0].idlType === "void") {
-      // Do nothing.
-      handler = "";
-    } else {
+    str += `${name} = new Promise(resolve => resolve(${name}))`;
+
+    if (idlType.idlType[0].idlType !== "void") {
       const conv = generateTypeConversion(ctx, "value", idlType.idlType[0], [], parentName,
         `${errPrefix} + " promise value"`);
       requires.merge(conv.requires);
-      handler = `
-        ${conv.body}
+      str += `.then(value => {
+        ${conv.body.trim()}
         return value;
-      `;
+      })`;
     }
-    str += `
-      ${name} = Promise.resolve(${name}).then(value => {
-        ${handler}
-      }, reason => reason);
-    `;
+
+    str += ";\n";
   }
 
   function generateFrozenArray() {

--- a/lib/types.js
+++ b/lib/types.js
@@ -328,49 +328,7 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
   }
 
   function generatePromise() {
-    str += `
-      ${name} = new Promise(resolve => resolve(${name}));
-      Object.assign(${name}, {
-        then(onFulfilled, onRejected) {
-          return Promise.prototype.then.call(
-            this,`;
-
-    if (idlType.idlType[0].idlType === "void") {
-      str += `
-            () => {
-              if (typeof onFulfilled === "function") {
-                return onFulfilled();
-              }
-            },`;
-    } else {
-      const convOnFulfilled = generateTypeConversion(ctx, "value", idlType.idlType[0], [], parentName,
-        `${errPrefix} + " promise value"`);
-      requires.merge(convOnFulfilled.requires);
-
-      str += `
-            value => {
-              ${convOnFulfilled.body.trim()}
-              if (typeof onFulfilled === "function") {
-                return onFulfilled(value);
-              }
-            },`;
-    }
-
-    const convOnRejected = generateTypeConversion(ctx, "reason", { idlType: "any" }, [], parentName,
-      `${errPrefix} + " promise value"`);
-    requires.merge(convOnRejected.requires);
-
-    str += `
-            reason => {
-              ${convOnRejected.body.trim()}
-              if (typeof onRejected === "function") {
-                return onRejected(reason);
-              }
-            }
-          );
-        }
-      });
-    `;
+    str += `${name} = new Promise(resolve => resolve(${name}));`;
   }
 
   function generateFrozenArray() {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -3708,6 +3708,26 @@ exports.install = (globalObject, globalNames) => {
       {
         let curArg = arguments[0];
         curArg = new Promise(resolve => resolve(curArg));
+        Object.assign(curArg, {
+          then(onFulfilled, onRejected) {
+            return Promise.prototype.then.call(
+              this,
+              () => {
+                if (typeof onFulfilled === \\"function\\") {
+                  return onFulfilled();
+                }
+              },
+              reason => {
+                reason = conversions[\\"any\\"](reason, {
+                  context: \\"Failed to execute 'voidPromiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
+                });
+                if (typeof onRejected === \\"function\\") {
+                  return onRejected(reason);
+                }
+              }
+            );
+          }
+        });
         args.push(curArg);
       }
       return esValue[implSymbol].voidPromiseConsumer(...args);
@@ -12547,6 +12567,26 @@ exports.install = (globalObject, globalNames) => {
       {
         let curArg = arguments[0];
         curArg = new Promise(resolve => resolve(curArg));
+        Object.assign(curArg, {
+          then(onFulfilled, onRejected) {
+            return Promise.prototype.then.call(
+              this,
+              () => {
+                if (typeof onFulfilled === \\"function\\") {
+                  return onFulfilled();
+                }
+              },
+              reason => {
+                reason = conversions[\\"any\\"](reason, {
+                  context: \\"Failed to execute 'voidPromiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
+                });
+                if (typeof onRejected === \\"function\\") {
+                  return onRejected(reason);
+                }
+              }
+            );
+          }
+        });
         args.push(curArg);
       }
       return esValue[implSymbol].voidPromiseConsumer(...args);

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -27,14 +27,10 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
 
       let callResult = Reflect.apply(X, thisArg, []);
 
-      callResult = Promise.resolve(callResult).then(
-        value => {
-          value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
-
-          return value;
-        },
-        reason => reason
-      );
+      callResult = new Promise(resolve => resolve(callResult)).then(value => {
+        value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
+        return value;
+      });
 
       return callResult;
     } catch (err) {
@@ -3695,10 +3691,7 @@ exports.install = (globalObject, globalNames) => {
       const args = [];
       {
         let curArg = arguments[0];
-        curArg = Promise.resolve(curArg).then(
-          value => {},
-          reason => reason
-        );
+        curArg = new Promise(resolve => resolve(curArg));
         args.push(curArg);
       }
       return esValue[implSymbol].voidPromiseConsumer(...args);
@@ -3720,16 +3713,12 @@ exports.install = (globalObject, globalNames) => {
       const args = [];
       {
         let curArg = arguments[0];
-        curArg = Promise.resolve(curArg).then(
-          value => {
-            value = conversions[\\"double\\"](value, {
-              context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-            });
-
-            return value;
-          },
-          reason => reason
-        );
+        curArg = new Promise(resolve => resolve(curArg)).then(value => {
+          value = conversions[\\"double\\"](value, {
+            context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
+          });
+          return value;
+        });
         args.push(curArg);
       }
       return esValue[implSymbol].promiseConsumer(...args);
@@ -8885,14 +8874,10 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
 
       let callResult = Reflect.apply(X, thisArg, []);
 
-      callResult = Promise.resolve(callResult).then(
-        value => {
-          value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
-
-          return value;
-        },
-        reason => reason
-      );
+      callResult = new Promise(resolve => resolve(callResult)).then(value => {
+        value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
+        return value;
+      });
 
       return callResult;
     } catch (err) {
@@ -12511,10 +12496,7 @@ exports.install = (globalObject, globalNames) => {
       const args = [];
       {
         let curArg = arguments[0];
-        curArg = Promise.resolve(curArg).then(
-          value => {},
-          reason => reason
-        );
+        curArg = new Promise(resolve => resolve(curArg));
         args.push(curArg);
       }
       return esValue[implSymbol].voidPromiseConsumer(...args);
@@ -12536,16 +12518,12 @@ exports.install = (globalObject, globalNames) => {
       const args = [];
       {
         let curArg = arguments[0];
-        curArg = Promise.resolve(curArg).then(
-          value => {
-            value = conversions[\\"double\\"](value, {
-              context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-            });
-
-            return value;
-          },
-          reason => reason
-        );
+        curArg = new Promise(resolve => resolve(curArg)).then(value => {
+          value = conversions[\\"double\\"](value, {
+            context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
+          });
+          return value;
+        });
         args.push(curArg);
       }
       return esValue[implSymbol].promiseConsumer(...args);

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -28,26 +28,6 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
       let callResult = Reflect.apply(X, thisArg, []);
 
       callResult = new Promise(resolve => resolve(callResult));
-      Object.assign(callResult, {
-        then(onFulfilled, onRejected) {
-          return Promise.prototype.then.call(
-            this,
-            value => {
-              value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
-              if (typeof onFulfilled === \\"function\\") {
-                return onFulfilled(value);
-              }
-            },
-            reason => {
-              reason = conversions[\\"any\\"](reason, { context: context + \\" promise value\\" });
-              if (typeof onRejected === \\"function\\") {
-                return onRejected(reason);
-              }
-            }
-          );
-        }
-      });
-
       return callResult;
     } catch (err) {
       return Promise.reject(err);
@@ -3708,26 +3688,6 @@ exports.install = (globalObject, globalNames) => {
       {
         let curArg = arguments[0];
         curArg = new Promise(resolve => resolve(curArg));
-        Object.assign(curArg, {
-          then(onFulfilled, onRejected) {
-            return Promise.prototype.then.call(
-              this,
-              () => {
-                if (typeof onFulfilled === \\"function\\") {
-                  return onFulfilled();
-                }
-              },
-              reason => {
-                reason = conversions[\\"any\\"](reason, {
-                  context: \\"Failed to execute 'voidPromiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-                });
-                if (typeof onRejected === \\"function\\") {
-                  return onRejected(reason);
-                }
-              }
-            );
-          }
-        });
         args.push(curArg);
       }
       return esValue[implSymbol].voidPromiseConsumer(...args);
@@ -3750,29 +3710,6 @@ exports.install = (globalObject, globalNames) => {
       {
         let curArg = arguments[0];
         curArg = new Promise(resolve => resolve(curArg));
-        Object.assign(curArg, {
-          then(onFulfilled, onRejected) {
-            return Promise.prototype.then.call(
-              this,
-              value => {
-                value = conversions[\\"double\\"](value, {
-                  context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-                });
-                if (typeof onFulfilled === \\"function\\") {
-                  return onFulfilled(value);
-                }
-              },
-              reason => {
-                reason = conversions[\\"any\\"](reason, {
-                  context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-                });
-                if (typeof onRejected === \\"function\\") {
-                  return onRejected(reason);
-                }
-              }
-            );
-          }
-        });
         args.push(curArg);
       }
       return esValue[implSymbol].promiseConsumer(...args);
@@ -8929,26 +8866,6 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
       let callResult = Reflect.apply(X, thisArg, []);
 
       callResult = new Promise(resolve => resolve(callResult));
-      Object.assign(callResult, {
-        then(onFulfilled, onRejected) {
-          return Promise.prototype.then.call(
-            this,
-            value => {
-              value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
-              if (typeof onFulfilled === \\"function\\") {
-                return onFulfilled(value);
-              }
-            },
-            reason => {
-              reason = conversions[\\"any\\"](reason, { context: context + \\" promise value\\" });
-              if (typeof onRejected === \\"function\\") {
-                return onRejected(reason);
-              }
-            }
-          );
-        }
-      });
-
       return callResult;
     } catch (err) {
       return Promise.reject(err);
@@ -12567,26 +12484,6 @@ exports.install = (globalObject, globalNames) => {
       {
         let curArg = arguments[0];
         curArg = new Promise(resolve => resolve(curArg));
-        Object.assign(curArg, {
-          then(onFulfilled, onRejected) {
-            return Promise.prototype.then.call(
-              this,
-              () => {
-                if (typeof onFulfilled === \\"function\\") {
-                  return onFulfilled();
-                }
-              },
-              reason => {
-                reason = conversions[\\"any\\"](reason, {
-                  context: \\"Failed to execute 'voidPromiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-                });
-                if (typeof onRejected === \\"function\\") {
-                  return onRejected(reason);
-                }
-              }
-            );
-          }
-        });
         args.push(curArg);
       }
       return esValue[implSymbol].voidPromiseConsumer(...args);
@@ -12609,29 +12506,6 @@ exports.install = (globalObject, globalNames) => {
       {
         let curArg = arguments[0];
         curArg = new Promise(resolve => resolve(curArg));
-        Object.assign(curArg, {
-          then(onFulfilled, onRejected) {
-            return Promise.prototype.then.call(
-              this,
-              value => {
-                value = conversions[\\"double\\"](value, {
-                  context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-                });
-                if (typeof onFulfilled === \\"function\\") {
-                  return onFulfilled(value);
-                }
-              },
-              reason => {
-                reason = conversions[\\"any\\"](reason, {
-                  context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-                });
-                if (typeof onRejected === \\"function\\") {
-                  return onRejected(reason);
-                }
-              }
-            );
-          }
-        });
         args.push(curArg);
       }
       return esValue[implSymbol].promiseConsumer(...args);

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -27,9 +27,25 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
 
       let callResult = Reflect.apply(X, thisArg, []);
 
-      callResult = new Promise(resolve => resolve(callResult)).then(value => {
-        value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
-        return value;
+      callResult = new Promise(resolve => resolve(callResult));
+      Object.assign(callResult, {
+        then(onFulfilled, onRejected) {
+          return Promise.prototype.then.call(
+            this,
+            value => {
+              value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
+              if (typeof onFulfilled === \\"function\\") {
+                return onFulfilled(value);
+              }
+            },
+            reason => {
+              reason = conversions[\\"any\\"](reason, { context: context + \\" promise value\\" });
+              if (typeof onRejected === \\"function\\") {
+                return onRejected(reason);
+              }
+            }
+          );
+        }
       });
 
       return callResult;
@@ -3713,11 +3729,29 @@ exports.install = (globalObject, globalNames) => {
       const args = [];
       {
         let curArg = arguments[0];
-        curArg = new Promise(resolve => resolve(curArg)).then(value => {
-          value = conversions[\\"double\\"](value, {
-            context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-          });
-          return value;
+        curArg = new Promise(resolve => resolve(curArg));
+        Object.assign(curArg, {
+          then(onFulfilled, onRejected) {
+            return Promise.prototype.then.call(
+              this,
+              value => {
+                value = conversions[\\"double\\"](value, {
+                  context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
+                });
+                if (typeof onFulfilled === \\"function\\") {
+                  return onFulfilled(value);
+                }
+              },
+              reason => {
+                reason = conversions[\\"any\\"](reason, {
+                  context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
+                });
+                if (typeof onRejected === \\"function\\") {
+                  return onRejected(reason);
+                }
+              }
+            );
+          }
         });
         args.push(curArg);
       }
@@ -8874,9 +8908,25 @@ exports.convert = function convert(value, { context = \\"The provided value\\" }
 
       let callResult = Reflect.apply(X, thisArg, []);
 
-      callResult = new Promise(resolve => resolve(callResult)).then(value => {
-        value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
-        return value;
+      callResult = new Promise(resolve => resolve(callResult));
+      Object.assign(callResult, {
+        then(onFulfilled, onRejected) {
+          return Promise.prototype.then.call(
+            this,
+            value => {
+              value = conversions[\\"any\\"](value, { context: context + \\" promise value\\" });
+              if (typeof onFulfilled === \\"function\\") {
+                return onFulfilled(value);
+              }
+            },
+            reason => {
+              reason = conversions[\\"any\\"](reason, { context: context + \\" promise value\\" });
+              if (typeof onRejected === \\"function\\") {
+                return onRejected(reason);
+              }
+            }
+          );
+        }
       });
 
       return callResult;
@@ -12518,11 +12568,29 @@ exports.install = (globalObject, globalNames) => {
       const args = [];
       {
         let curArg = arguments[0];
-        curArg = new Promise(resolve => resolve(curArg)).then(value => {
-          value = conversions[\\"double\\"](value, {
-            context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
-          });
-          return value;
+        curArg = new Promise(resolve => resolve(curArg));
+        Object.assign(curArg, {
+          then(onFulfilled, onRejected) {
+            return Promise.prototype.then.call(
+              this,
+              value => {
+                value = conversions[\\"double\\"](value, {
+                  context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
+                });
+                if (typeof onFulfilled === \\"function\\") {
+                  return onFulfilled(value);
+                }
+              },
+              reason => {
+                reason = conversions[\\"any\\"](reason, {
+                  context: \\"Failed to execute 'promiseConsumer' on 'PromiseTypes': parameter 1\\" + \\" promise value\\"
+                });
+                if (typeof onRejected === \\"function\\") {
+                  return onRejected(reason);
+                }
+              }
+            );
+          }
         });
         args.push(curArg);
       }


### PR DESCRIPTION
Most notably, this fixes the bug where rejected promises were being converted into resolved promises and that `Promise.resolve(x)` returns `x` when `x` is a `Promise` object from the same realm as the `Promise.resolve` function, whereas **WebIDL** requires the conversion to always return a new `Promise` object.

---

Note that there still is a small timing difference for non‑`void` promises due to the fact that the IDL conversion and promise reaction are being performed in separate `then` callbacks, whereas `WebIDL` runs them in the same `then` callback. (See the [“to **react** to a <code>Promise&lt;<var>T</var>&gt;</code>”](https://heycam.github.io/webidl/#dfn-perform-steps-once-promise-is-settled) algorithm)

Fixing this minor timing discrepancy would require the type conversion to be performed manually in implementation classes or overriding the `then` method of the converted `Promise` instance.

---

**P.S.:** If you still want `then` to be called with two arguments, then the correct callback is:
```js
reason => {
	throw reason;
}
```

Which is the default behaviour when `null` or `undefined` is passed.