### PR TITLE
fix: setting of enumerated attribute case-sensitive

### DIFF
--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -94,7 +94,7 @@ class Attribute {
         requires.addRelative(this.idl.idlType.idlType);
         idlConversion = `
           V = \`\${V}\`;
-          if (!${this.idl.idlType.idlType}.enumerationValues.has(V)) {
+          if (${this.idl.idlType.idlType}.enumerationValues.find(ev => ev.toLowerCase() === V.toLowerCase()) === undefined) {
             return;
           }
         `;

--- a/lib/constructs/enumeration.js
+++ b/lib/constructs/enumeration.js
@@ -15,12 +15,12 @@ class Enumeration {
     }
 
     this.str += `
-      const enumerationValues = new Set(${JSON.stringify([...values])});
+      const enumerationValues = ${JSON.stringify([...values])};
       exports.enumerationValues = enumerationValues;
 
       exports.convert = function convert(value, { context = "The provided value" } = {}) {
         const string = \`\${value}\`;
-        if (!enumerationValues.has(string)) {
+        if (enumerationValues.find(ev => ev.toLowerCase() === string.toLowerCase()) === undefined) {
           throw new TypeError(\`\${context} '\${string}' is not a valid enumeration value for ${this.name}\`);
         }
         return string;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1591,7 +1591,7 @@ exports.install = (globalObject, globalNames) => {
       }
 
       V = \`\${V}\`;
-      if (!RequestDestination.enumerationValues.has(V)) {
+      if (RequestDestination.enumerationValues.find(ev => ev.toLowerCase() === V.toLowerCase()) === undefined) {
         return;
       }
 
@@ -4248,7 +4248,7 @@ const Impl = require(\\"../implementations/Replaceable.js\\");
 exports[`with processors RequestDestination.webidl 1`] = `
 "\\"use strict\\";
 
-const enumerationValues = new Set([
+const enumerationValues = [
   \\"\\",
   \\"audio\\",
   \\"document\\",
@@ -4265,12 +4265,12 @@ const enumerationValues = new Set([
   \\"video\\",
   \\"worker\\",
   \\"xslt\\"
-]);
+];
 exports.enumerationValues = enumerationValues;
 
 exports.convert = function convert(value, { context = \\"The provided value\\" } = {}) {
   const string = \`\${value}\`;
-  if (!enumerationValues.has(string)) {
+  if (enumerationValues.find(ev => ev.toLowerCase() === string.toLowerCase()) === undefined) {
     throw new TypeError(\`\${context} '\${string}' is not a valid enumeration value for RequestDestination\`);
   }
   return string;
@@ -10408,7 +10408,7 @@ exports.install = (globalObject, globalNames) => {
       }
 
       V = \`\${V}\`;
-      if (!RequestDestination.enumerationValues.has(V)) {
+      if (RequestDestination.enumerationValues.find(ev => ev.toLowerCase() === V.toLowerCase()) === undefined) {
         return;
       }
 
@@ -13049,7 +13049,7 @@ const Impl = require(\\"../implementations/Replaceable.js\\");
 exports[`without processors RequestDestination.webidl 1`] = `
 "\\"use strict\\";
 
-const enumerationValues = new Set([
+const enumerationValues = [
   \\"\\",
   \\"audio\\",
   \\"document\\",
@@ -13066,12 +13066,12 @@ const enumerationValues = new Set([
   \\"video\\",
   \\"worker\\",
   \\"xslt\\"
-]);
+];
 exports.enumerationValues = enumerationValues;
 
 exports.convert = function convert(value, { context = \\"The provided value\\" } = {}) {
   const string = \`\${value}\`;
-  if (!enumerationValues.has(string)) {
+  if (enumerationValues.find(ev => ev.toLowerCase() === string.toLowerCase()) === undefined) {
     throw new TypeError(\`\${context} '\${string}' is not a valid enumeration value for RequestDestination\`);
   }
   return string;


### PR DESCRIPTION
[keywords-and-enumerated-attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#keywords-and-enumerated-attributes)

> If an enumerated attribute is specified, the attribute's value must be an ASCII case-insensitive match for one of the given keywords that are not said to be non-conforming, with no leading or trailing whitespace.
