### PR TITLE
Tweak test cases for dictionary defaults

### DIFF
--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -18,7 +18,8 @@ function generateVarConversion(ctx, overload, i, parent, errPrefix, targetIdx = 
                                 overload.operation.arguments[i].default.type === "dictionary";
   if (isDefaultedDictionary && !ctx.dictionaries.has(idlType.idlType)) {
     throw new Error(
-      `The dictionary ${idlType.idlType} was referenced in an argument list, but doesn't exist`);
+      `The parameter ${overload.operation.arguments[i].name} was defaulted to {}, but no dictionary named ` +
+      `${idlType.idlType} exists`);
   }
   const optional = overload.optionalityList[i] === "optional" && !isDefaultedDictionary;
   let str = `{ let curArg = arguments[${targetIdx}];`;

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -14,7 +14,13 @@ function generateVarConversion(ctx, overload, i, parent, errPrefix, targetIdx = 
   const requires = new utils.RequiresMap(ctx);
   const idlType = overload.typeList[i];
   // Always (try to) force-convert dictionaries
-  const optional = overload.optionalityList[i] === "optional" && !ctx.dictionaries.has(idlType.idlType);
+  const isDefaultedDictionary = overload.operation.arguments[i].default &&
+                                overload.operation.arguments[i].default.type === "dictionary";
+  if (isDefaultedDictionary && !ctx.dictionaries.has(idlType.idlType)) {
+    throw new Error(
+      `The dictionary ${idlType.idlType} was referenced in an argument list, but doesn't exist`);
+  }
+  const optional = overload.optionalityList[i] === "optional" && !isDefaultedDictionary;
   let str = `{ let curArg = arguments[${targetIdx}];`;
   if (optional) {
     str += `

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1181,6 +1181,7 @@ exports[`with processors DOMRect.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
+const Dictionary = require(\\"./Dictionary.js\\");
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -1412,9 +1413,7 @@ exports.install = (globalObject, globalNames) => {
       const args = [];
       {
         let curArg = arguments[0];
-        if (curArg !== undefined) {
-          curArg = utils.tryImplForWrapper(curArg);
-        }
+        curArg = Dictionary.convert(curArg, { context: \\"Failed to execute 'fromRect' on 'DOMRect': parameter 1\\" });
         args.push(curArg);
       }
       return utils.tryWrapperForImpl(Impl.implementation.fromRect(globalObject, ...args));
@@ -10243,6 +10242,7 @@ exports[`without processors DOMRect.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
+const Dictionary = require(\\"./Dictionary.js\\");
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -10474,9 +10474,7 @@ exports.install = (globalObject, globalNames) => {
       const args = [];
       {
         let curArg = arguments[0];
-        if (curArg !== undefined) {
-          curArg = utils.tryImplForWrapper(curArg);
-        }
+        curArg = Dictionary.convert(curArg, { context: \\"Failed to execute 'fromRect' on 'DOMRect': parameter 1\\" });
         args.push(curArg);
       }
       return utils.tryWrapperForImpl(Impl.implementation.fromRect(globalObject, ...args));

--- a/test/cases/DOMRect.webidl
+++ b/test/cases/DOMRect.webidl
@@ -7,7 +7,7 @@ interface DOMRect /* : DOMRectReadOnly */ {
   constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
           optional unrestricted double width = 0, optional unrestricted double height = 0);
 
-  [NewObject, WebIDL2JSCallWithGlobal] static DOMRect fromRect(optional DOMRectInit other);
+  [NewObject, WebIDL2JSCallWithGlobal] static DOMRect fromRect(optional Dictionary other = {});
 
   attribute unrestricted double x;
   attribute unrestricted double y;

--- a/test/cases/DictionaryConvert.webidl
+++ b/test/cases/DictionaryConvert.webidl
@@ -1,5 +1,5 @@
 [Exposed=Window]
 interface DictionaryConvert {
   // Test force-conversion of dictionary types.
-  DOMString op(optional DOMString arg1, optional Dictionary arg2);
+  DOMString op(optional DOMString arg1, optional Dictionary arg2 = {});
 };


### PR DESCRIPTION
In Web IDL these days, optional dictionary arguments must have a trailing "= {}". This adds those to the test .webidl files. Doing so uncovered an issue where DOMRectInit was referenced in the test files, but did not exist, so we add code to throw in this case, and correct the test file.