### PR TITLE
Use `[[Unforgeables]]` object for unforgeable properties

### DIFF
--- a/lib/constructs/attribute.js
+++ b/lib/constructs/attribute.js
@@ -13,15 +13,25 @@ class Attribute {
     this.static = idl.special === "static";
   }
 
+  getWhence() {
+    const { idl } = this;
+    const isOnInstance = utils.isOnInstance(idl, this.interface.idl);
+
+    if (utils.getExtAttr(idl.extAttrs, "LegacyUnforgeable")) {
+      return "unforgeables";
+    }
+
+    return isOnInstance ? "instance" : "prototype";
+  }
+
   generate() {
     const requires = new utils.RequiresMap(this.ctx);
 
-    const configurable = !utils.getExtAttr(this.idl.extAttrs, "LegacyUnforgeable");
+    const whence = this.getWhence();
+    const configurable = whence !== "unforgeables";
     const shouldReflect =
       this.idl.extAttrs.some(attr => attr.name.startsWith("Reflect")) && this.ctx.processReflect !== null;
     const sameObject = utils.getExtAttr(this.idl.extAttrs, "SameObject");
-
-    const onInstance = utils.isOnInstance(this.idl, this.interface.idl);
 
     const async = this.idl.idlType.generic === "Promise";
     const promiseHandlingBefore = async ? `try {` : ``;
@@ -40,7 +50,7 @@ class Attribute {
 
     const addMethod = this.static ?
       this.interface.addStaticMethod.bind(this.interface) :
-      this.interface.addMethod.bind(this.interface, onInstance ? "instance" : "prototype");
+      this.interface.addMethod.bind(this.interface, whence);
 
     if (this.static) {
       brandCheck = "";

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -57,6 +57,7 @@ class Interface {
 
     this.iterable = null;
     this._analyzed = false;
+    this._needsUnforgeablesObject = false;
 
     this._outputMethods = new Map();
     this._outputStaticMethods = new Map();
@@ -109,14 +110,14 @@ class Interface {
     }
   }
 
-  // whence is either "instance" or "prototype"
+  // whence is either "instance", "prototype" or "unforgeables"
   // type is either "regular", "get", or "set"
   addMethod(whence, propName, args, body, type = "regular", {
     configurable = true,
     enumerable = typeof propName === "string",
     writable = type === "regular" ? true : undefined
   } = {}) {
-    if (whence !== "instance" && whence !== "prototype") {
+    if (whence !== "instance" && whence !== "prototype" && whence !== "unforgeables") {
       throw new Error(`Internal error: Invalid whence ${whence}`);
     }
     if (type !== "regular") {
@@ -139,6 +140,10 @@ class Interface {
 
     const descriptor = { configurable, enumerable, writable };
     this._outputMethods.set(propName, { whence, type, args, body, descriptor });
+
+    if (whence === "unforgeables" && !this.isGlobal) {
+      this._needsUnforgeablesObject = true;
+    }
   }
 
   // type is either "regular", "get", or "set"
@@ -1205,6 +1210,8 @@ class Interface {
   }
 
   generateIface() {
+    const { _needsUnforgeablesObject } = this;
+
     this.str += `
       function makeWrapper(globalObject, newTarget) {
         let proto;
@@ -1252,13 +1259,29 @@ class Interface {
         const wrapper = exports.create(globalObject, constructorArgs, privateData);
         return utils.implForWrapper(wrapper);
       };
+    `;
 
+    if (_needsUnforgeablesObject) {
+      this.generateUnforgeablesObject();
+    }
+
+    this.str += `
       exports._internalSetup = (wrapper, globalObject) => {
     `;
 
     if (this.idl.inheritance) {
       this.str += `
         ${this.idl.inheritance}._internalSetup(wrapper, globalObject);
+      `;
+    }
+
+    if (_needsUnforgeablesObject) {
+      this.str += `
+        const unforgeables = getUnforgeables(globalObject);
+        for (const key of Reflect.ownKeys(unforgeables)) {
+          const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
+          Object.defineProperty(wrapper, key, descriptor);
+        }
       `;
     }
 
@@ -1496,6 +1519,7 @@ class Interface {
   }
 
   generateOnInstance() {
+    const { isGlobal } = this;
     const methods = [];
     const props = new Map();
 
@@ -1506,7 +1530,7 @@ class Interface {
     }
 
     for (const [name, { whence, type, args, body, descriptor }] of this._outputMethods) {
-      if (whence !== "instance") {
+      if (whence !== "instance" && (whence !== "unforgeables" || !isGlobal)) {
         continue;
       }
 
@@ -1564,8 +1588,77 @@ class Interface {
     }
   }
 
+  generateUnforgeablesObject() {
+    const methods = [];
+    const props = new Map();
+
+    function addOne(name, args, body) {
+      methods.push(`
+        ${name}(${utils.formatArgs(args)}) {${body}}
+      `);
+    }
+
+    for (const [name, { whence, type, args, body, descriptor }] of this._outputMethods) {
+      if (whence !== "unforgeables") {
+        continue;
+      }
+
+      const propName = utils.stringifyPropertyKey(name);
+      if (type === "regular") {
+        addOne(propName, args, body);
+      } else {
+        if (body[0] !== undefined) {
+          addOne(`get ${propName}`, [], body[0]);
+        }
+        if (body[1] !== undefined) {
+          addOne(`set ${propName}`, args, body[1]);
+        }
+      }
+
+      const descriptorModifier = utils.getPropertyDescriptorModifier(defaultObjectLiteralDescriptor, descriptor, type);
+      if (descriptorModifier === undefined) {
+        continue;
+      }
+      props.set(utils.stringifyPropertyKey(name), descriptorModifier);
+    }
+
+    this.str += `
+      function getUnforgeables(globalObject) {
+        let unforgeables = unforgeablesMap.get(globalObject);
+        if (unforgeables === undefined) {
+          unforgeables = Object.create(
+            null,
+    `;
+
+    if (methods.length > 0) {
+      this.str += `Object.getOwnPropertyDescriptors({ ${methods.join(", ")} }),`;
+    }
+
+    this.str += ");";
+
+    if (props.size > 0) {
+      const propStrs = [...props].map(([name, body]) => `${name}: ${body}`);
+      this.str += `
+          Object.defineProperties(unforgeables, {
+            ${propStrs.join(", ")}
+          });`;
+    }
+
+    this.str += `
+          unforgeablesMap.set(globalObject, unforgeables);
+        }
+        return unforgeables;
+      }
+    `;
+  }
+
   generateInstall() {
     const { idl, name } = this;
+
+    if (this._needsUnforgeablesObject) {
+      this.str += `
+        const unforgeablesMap = new WeakMap();`;
+    }
 
     this.str += `
       const exposed = new Set(${JSON.stringify([...this.exposed])});
@@ -1640,6 +1733,7 @@ class Interface {
     this.generateExport();
     this.generateIface();
     this.generateInstall();
+
     if (this.isLegacyPlatformObj) {
       this.generateLegacyProxyHandler();
     }

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -1277,11 +1277,7 @@ class Interface {
 
     if (_needsUnforgeablesObject) {
       this.str += `
-        const unforgeables = getUnforgeables(globalObject);
-        for (const key of Reflect.ownKeys(unforgeables)) {
-          const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
-          Object.defineProperty(wrapper, key, descriptor);
-        }
+        utils.define(wrapper, getUnforgeables(globalObject));
       `;
     }
 
@@ -1572,10 +1568,9 @@ class Interface {
     const propStrs = [...props].map(([name, body]) => `${name}: ${body}`);
     if (methods.length > 0) {
       this.str += `
-        Object.defineProperties(
-          wrapper,
-          Object.getOwnPropertyDescriptors({ ${methods.join(", ")} })
-        );
+        utils.define(wrapper, {
+          ${methods.join(", ")}
+        });
       `;
     }
     if (propStrs.length > 0) {
@@ -1626,15 +1621,12 @@ class Interface {
       function getUnforgeables(globalObject) {
         let unforgeables = unforgeablesMap.get(globalObject);
         if (unforgeables === undefined) {
-          unforgeables = Object.create(
-            null,
+          unforgeables = Object.create(null);
     `;
 
     if (methods.length > 0) {
-      this.str += `Object.getOwnPropertyDescriptors({ ${methods.join(", ")} }),`;
+      this.str += `utils.define(unforgeables, { ${methods.join(", ")} });`;
     }
-
-    this.str += ");";
 
     if (props.size > 0) {
       const propStrs = [...props].map(([name, body]) => `${name}: ${body}`);

--- a/lib/constructs/operation.js
+++ b/lib/constructs/operation.js
@@ -15,16 +15,24 @@ class Operation {
     this.static = idl.special === "static";
   }
 
-  isOnInstance() {
-    const firstOverloadOnInstance = utils.isOnInstance(this.idls[0], this.interface.idl);
-    for (const overload of this.idls.slice(1)) {
-      if (utils.isOnInstance(overload, this.interface.idl) !== firstOverloadOnInstance) {
+  getWhence() {
+    const { idls } = this;
+    const firstOverloadOnInstance = utils.isOnInstance(idls[0], this.interface.idl);
+    const hasLegacyUnforgeable = Boolean(utils.getExtAttr(idls[0].extAttrs, "LegacyUnforgeable"));
+
+    for (let i = 1; i < idls.length; i++) {
+      if (Boolean(utils.getExtAttr(idls[i].extAttrs, "LegacyUnforgeable")) !== hasLegacyUnforgeable) {
         throw new Error(
           `[LegacyUnforgeable] is not applied uniformly to operation "${this.name}" on ${this.interface.name}`
         );
       }
     }
-    return firstOverloadOnInstance;
+
+    if (hasLegacyUnforgeable) {
+      return "unforgeables";
+    }
+
+    return firstOverloadOnInstance ? "instance" : "prototype";
   }
 
   isAsync() {
@@ -86,7 +94,7 @@ class Operation {
       throw new Error(`Internal error: this operation does not have a name (in interface ${this.interface.name})`);
     }
 
-    const onInstance = this.isOnInstance();
+    const whence = this.getWhence();
     const async = this.isAsync();
     const promiseHandlingBefore = async ? `try {` : ``;
     const promiseHandlingAfter = async ? `} catch (e) { return Promise.reject(e); }` : ``;
@@ -159,9 +167,9 @@ class Operation {
     if (this.static) {
       this.interface.addStaticMethod(this.name, argNames, str);
     } else {
-      const forgeable = !utils.getExtAttr(this.idls[0].extAttrs, "LegacyUnforgeable");
+      const forgeable = whence !== "unforgeables";
       this.interface.addMethod(
-        onInstance ? "instance" : "prototype",
+        whence,
         this.name,
         argNames,
         str,

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -7,6 +7,17 @@ function isObject(value) {
 
 const hasOwn = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
 
+// Like `Object.assign`, but using `[[GetOwnProperty]]` and `[[DefineOwnProperty]]`
+// instead of `[[Get]]` and `[[Set]]` and only allowing objects
+function define(target, source) {
+  for (const key of Reflect.ownKeys(source)) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(source, key);
+    if (descriptor && !Reflect.defineProperty(target, key, descriptor)) {
+      throw new TypeError(`Cannot redefine property: ${String(key)}`);
+    }
+  }
+}
+
 const wrapperSymbol = Symbol("wrapper");
 const implSymbol = Symbol("impl");
 const sameObjectCaches = Symbol("SameObject caches");
@@ -131,6 +142,7 @@ const asyncIteratorEOI = Symbol("async iterator end of iteration");
 module.exports = exports = {
   isObject,
   hasOwn,
+  define,
   wrapperSymbol,
   implSymbol,
   getSameObject,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,8 +39,7 @@ function hasCEReactions(idl) {
 }
 
 function isOnInstance(memberIDL, interfaceIDL) {
-  return memberIDL.special !== "static" && (getExtAttr(memberIDL.extAttrs, "LegacyUnforgeable") ||
-    isGlobal(interfaceIDL));
+  return memberIDL.special !== "static" && isGlobal(interfaceIDL);
 }
 
 function symbolName(symbol) {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -3818,104 +3818,120 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
   return utils.implForWrapper(wrapper);
 };
 
-exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      assign(url) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'assign' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
+function getUnforgeables(globalObject) {
+  let unforgeables = unforgeablesMap.get(globalObject);
+  if (unforgeables === undefined) {
+    unforgeables = Object.create(
+      null,
+      Object.getOwnPropertyDescriptors({
+        assign(url) {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'assign' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+          }
 
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'assign' on 'LegacyUnforgeable': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'assign' on 'LegacyUnforgeable': parameter 1\\"
+          if (arguments.length < 1) {
+            throw new TypeError(
+              \\"Failed to execute 'assign' on 'LegacyUnforgeable': 1 argument required, but only \\" +
+                arguments.length +
+                \\" present.\\"
+            );
+          }
+          const args = [];
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"USVString\\"](curArg, {
+              context: \\"Failed to execute 'assign' on 'LegacyUnforgeable': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+          return esValue[implSymbol].assign(...args);
+        },
+        get href() {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'get href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+          }
+
+          return esValue[implSymbol][\\"href\\"];
+        },
+        set href(V) {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'set href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+          }
+
+          V = conversions[\\"USVString\\"](V, {
+            context: \\"Failed to set the 'href' property on 'LegacyUnforgeable': The provided value\\"
           });
-          args.push(curArg);
+
+          esValue[implSymbol][\\"href\\"] = V;
+        },
+        toString() {
+          const esValue = this;
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'toString' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+          }
+
+          return esValue[implSymbol][\\"href\\"];
+        },
+        get origin() {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'get origin' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+          }
+
+          return esValue[implSymbol][\\"origin\\"];
+        },
+        get protocol() {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(
+              \\"'get protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\"
+            );
+          }
+
+          return esValue[implSymbol][\\"protocol\\"];
+        },
+        set protocol(V) {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(
+              \\"'set protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\"
+            );
+          }
+
+          V = conversions[\\"USVString\\"](V, {
+            context: \\"Failed to set the 'protocol' property on 'LegacyUnforgeable': The provided value\\"
+          });
+
+          esValue[implSymbol][\\"protocol\\"] = V;
         }
-        return esValue[implSymbol].assign(...args);
-      },
-      get href() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      })
+    );
+    Object.defineProperties(unforgeables, {
+      assign: { configurable: false, writable: false },
+      href: { configurable: false },
+      toString: { configurable: false, writable: false },
+      origin: { configurable: false },
+      protocol: { configurable: false }
+    });
+    unforgeablesMap.set(globalObject, unforgeables);
+  }
+  return unforgeables;
+}
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        return esValue[implSymbol][\\"href\\"];
-      },
-      set href(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'set href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'href' property on 'LegacyUnforgeable': The provided value\\"
-        });
-
-        esValue[implSymbol][\\"href\\"] = V;
-      },
-      toString() {
-        const esValue = this;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'toString' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        return esValue[implSymbol][\\"href\\"];
-      },
-      get origin() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get origin' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        return esValue[implSymbol][\\"origin\\"];
-      },
-      get protocol() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        return esValue[implSymbol][\\"protocol\\"];
-      },
-      set protocol(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'set protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'protocol' property on 'LegacyUnforgeable': The provided value\\"
-        });
-
-        esValue[implSymbol][\\"protocol\\"] = V;
-      }
-    })
-  );
-
-  Object.defineProperties(wrapper, {
-    assign: { configurable: false, writable: false },
-    href: { configurable: false },
-    toString: { configurable: false, writable: false },
-    origin: { configurable: false },
-    protocol: { configurable: false }
-  });
+exports._internalSetup = (wrapper, globalObject) => {
+  const unforgeables = getUnforgeables(globalObject);
+  for (const key of Reflect.ownKeys(unforgeables)) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
+    Object.defineProperty(wrapper, key, descriptor);
+  }
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -3950,6 +3966,7 @@ exports.new = (globalObject, newTarget) => {
   return wrapper[implSymbol];
 };
 
+const unforgeablesMap = new WeakMap();
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
@@ -4026,23 +4043,37 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
   return utils.implForWrapper(wrapper);
 };
 
-exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      get a() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+function getUnforgeables(globalObject) {
+  let unforgeables = unforgeablesMap.get(globalObject);
+  if (unforgeables === undefined) {
+    unforgeables = Object.create(
+      null,
+      Object.getOwnPropertyDescriptors({
+        get a() {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get a' called on an object that is not a valid instance of LegacyUnforgeableMap.\\");
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'get a' called on an object that is not a valid instance of LegacyUnforgeableMap.\\");
+          }
+
+          return esValue[implSymbol][\\"a\\"];
         }
+      })
+    );
+    Object.defineProperties(unforgeables, {
+      a: { configurable: false }
+    });
+    unforgeablesMap.set(globalObject, unforgeables);
+  }
+  return unforgeables;
+}
 
-        return esValue[implSymbol][\\"a\\"];
-      }
-    })
-  );
-
-  Object.defineProperties(wrapper, { a: { configurable: false } });
+exports._internalSetup = (wrapper, globalObject) => {
+  const unforgeables = getUnforgeables(globalObject);
+  for (const key of Reflect.ownKeys(unforgeables)) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
+    Object.defineProperty(wrapper, key, descriptor);
+  }
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -4081,6 +4112,7 @@ exports.new = (globalObject, newTarget) => {
   return wrapper[implSymbol];
 };
 
+const unforgeablesMap = new WeakMap();
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
@@ -5019,46 +5051,58 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
   return utils.implForWrapper(wrapper);
 };
 
+function getUnforgeables(globalObject) {
+  let unforgeables = unforgeablesMap.get(globalObject);
+  if (unforgeables === undefined) {
+    unforgeables = Object.create(
+      null,
+      Object.getOwnPropertyDescriptors({
+        unforgeablePromiseOperation() {
+          try {
+            const esValue = this !== null && this !== undefined ? this : globalObject;
+            if (!exports.is(esValue)) {
+              throw new TypeError(
+                \\"'unforgeablePromiseOperation' called on an object that is not a valid instance of PromiseTypes.\\"
+              );
+            }
+
+            return utils.tryWrapperForImpl(esValue[implSymbol].unforgeablePromiseOperation());
+          } catch (e) {
+            return Promise.reject(e);
+          }
+        },
+        get unforgeablePromiseAttribute() {
+          try {
+            const esValue = this !== null && this !== undefined ? this : globalObject;
+
+            if (!exports.is(esValue)) {
+              throw new TypeError(
+                \\"'get unforgeablePromiseAttribute' called on an object that is not a valid instance of PromiseTypes.\\"
+              );
+            }
+
+            return utils.tryWrapperForImpl(esValue[implSymbol][\\"unforgeablePromiseAttribute\\"]);
+          } catch (e) {
+            return Promise.reject(e);
+          }
+        }
+      })
+    );
+    Object.defineProperties(unforgeables, {
+      unforgeablePromiseOperation: { configurable: false, writable: false },
+      unforgeablePromiseAttribute: { configurable: false }
+    });
+    unforgeablesMap.set(globalObject, unforgeables);
+  }
+  return unforgeables;
+}
+
 exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      unforgeablePromiseOperation() {
-        try {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-          if (!exports.is(esValue)) {
-            throw new TypeError(
-              \\"'unforgeablePromiseOperation' called on an object that is not a valid instance of PromiseTypes.\\"
-            );
-          }
-
-          return utils.tryWrapperForImpl(esValue[implSymbol].unforgeablePromiseOperation());
-        } catch (e) {
-          return Promise.reject(e);
-        }
-      },
-      get unforgeablePromiseAttribute() {
-        try {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(
-              \\"'get unforgeablePromiseAttribute' called on an object that is not a valid instance of PromiseTypes.\\"
-            );
-          }
-
-          return utils.tryWrapperForImpl(esValue[implSymbol][\\"unforgeablePromiseAttribute\\"]);
-        } catch (e) {
-          return Promise.reject(e);
-        }
-      }
-    })
-  );
-
-  Object.defineProperties(wrapper, {
-    unforgeablePromiseOperation: { configurable: false, writable: false },
-    unforgeablePromiseAttribute: { configurable: false }
-  });
+  const unforgeables = getUnforgeables(globalObject);
+  for (const key of Reflect.ownKeys(unforgeables)) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
+    Object.defineProperty(wrapper, key, descriptor);
+  }
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -5093,6 +5137,7 @@ exports.new = (globalObject, newTarget) => {
   return wrapper[implSymbol];
 };
 
+const unforgeablesMap = new WeakMap();
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
@@ -14049,104 +14094,120 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
   return utils.implForWrapper(wrapper);
 };
 
-exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      assign(url) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'assign' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
+function getUnforgeables(globalObject) {
+  let unforgeables = unforgeablesMap.get(globalObject);
+  if (unforgeables === undefined) {
+    unforgeables = Object.create(
+      null,
+      Object.getOwnPropertyDescriptors({
+        assign(url) {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'assign' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+          }
 
-        if (arguments.length < 1) {
-          throw new TypeError(
-            \\"Failed to execute 'assign' on 'LegacyUnforgeable': 1 argument required, but only \\" +
-              arguments.length +
-              \\" present.\\"
-          );
-        }
-        const args = [];
-        {
-          let curArg = arguments[0];
-          curArg = conversions[\\"USVString\\"](curArg, {
-            context: \\"Failed to execute 'assign' on 'LegacyUnforgeable': parameter 1\\"
+          if (arguments.length < 1) {
+            throw new TypeError(
+              \\"Failed to execute 'assign' on 'LegacyUnforgeable': 1 argument required, but only \\" +
+                arguments.length +
+                \\" present.\\"
+            );
+          }
+          const args = [];
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"USVString\\"](curArg, {
+              context: \\"Failed to execute 'assign' on 'LegacyUnforgeable': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+          return esValue[implSymbol].assign(...args);
+        },
+        get href() {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'get href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+          }
+
+          return esValue[implSymbol][\\"href\\"];
+        },
+        set href(V) {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'set href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+          }
+
+          V = conversions[\\"USVString\\"](V, {
+            context: \\"Failed to set the 'href' property on 'LegacyUnforgeable': The provided value\\"
           });
-          args.push(curArg);
+
+          esValue[implSymbol][\\"href\\"] = V;
+        },
+        toString() {
+          const esValue = this;
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'toString' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+          }
+
+          return esValue[implSymbol][\\"href\\"];
+        },
+        get origin() {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'get origin' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+          }
+
+          return esValue[implSymbol][\\"origin\\"];
+        },
+        get protocol() {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(
+              \\"'get protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\"
+            );
+          }
+
+          return esValue[implSymbol][\\"protocol\\"];
+        },
+        set protocol(V) {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(
+              \\"'set protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\"
+            );
+          }
+
+          V = conversions[\\"USVString\\"](V, {
+            context: \\"Failed to set the 'protocol' property on 'LegacyUnforgeable': The provided value\\"
+          });
+
+          esValue[implSymbol][\\"protocol\\"] = V;
         }
-        return esValue[implSymbol].assign(...args);
-      },
-      get href() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      })
+    );
+    Object.defineProperties(unforgeables, {
+      assign: { configurable: false, writable: false },
+      href: { configurable: false },
+      toString: { configurable: false, writable: false },
+      origin: { configurable: false },
+      protocol: { configurable: false }
+    });
+    unforgeablesMap.set(globalObject, unforgeables);
+  }
+  return unforgeables;
+}
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        return esValue[implSymbol][\\"href\\"];
-      },
-      set href(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'set href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'href' property on 'LegacyUnforgeable': The provided value\\"
-        });
-
-        esValue[implSymbol][\\"href\\"] = V;
-      },
-      toString() {
-        const esValue = this;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'toString' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        return esValue[implSymbol][\\"href\\"];
-      },
-      get origin() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get origin' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        return esValue[implSymbol][\\"origin\\"];
-      },
-      get protocol() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        return esValue[implSymbol][\\"protocol\\"];
-      },
-      set protocol(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'set protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-        }
-
-        V = conversions[\\"USVString\\"](V, {
-          context: \\"Failed to set the 'protocol' property on 'LegacyUnforgeable': The provided value\\"
-        });
-
-        esValue[implSymbol][\\"protocol\\"] = V;
-      }
-    })
-  );
-
-  Object.defineProperties(wrapper, {
-    assign: { configurable: false, writable: false },
-    href: { configurable: false },
-    toString: { configurable: false, writable: false },
-    origin: { configurable: false },
-    protocol: { configurable: false }
-  });
+exports._internalSetup = (wrapper, globalObject) => {
+  const unforgeables = getUnforgeables(globalObject);
+  for (const key of Reflect.ownKeys(unforgeables)) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
+    Object.defineProperty(wrapper, key, descriptor);
+  }
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -14181,6 +14242,7 @@ exports.new = (globalObject, newTarget) => {
   return wrapper[implSymbol];
 };
 
+const unforgeablesMap = new WeakMap();
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
@@ -14257,23 +14319,37 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
   return utils.implForWrapper(wrapper);
 };
 
-exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      get a() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+function getUnforgeables(globalObject) {
+  let unforgeables = unforgeablesMap.get(globalObject);
+  if (unforgeables === undefined) {
+    unforgeables = Object.create(
+      null,
+      Object.getOwnPropertyDescriptors({
+        get a() {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get a' called on an object that is not a valid instance of LegacyUnforgeableMap.\\");
+          if (!exports.is(esValue)) {
+            throw new TypeError(\\"'get a' called on an object that is not a valid instance of LegacyUnforgeableMap.\\");
+          }
+
+          return esValue[implSymbol][\\"a\\"];
         }
+      })
+    );
+    Object.defineProperties(unforgeables, {
+      a: { configurable: false }
+    });
+    unforgeablesMap.set(globalObject, unforgeables);
+  }
+  return unforgeables;
+}
 
-        return esValue[implSymbol][\\"a\\"];
-      }
-    })
-  );
-
-  Object.defineProperties(wrapper, { a: { configurable: false } });
+exports._internalSetup = (wrapper, globalObject) => {
+  const unforgeables = getUnforgeables(globalObject);
+  for (const key of Reflect.ownKeys(unforgeables)) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
+    Object.defineProperty(wrapper, key, descriptor);
+  }
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -14312,6 +14388,7 @@ exports.new = (globalObject, newTarget) => {
   return wrapper[implSymbol];
 };
 
+const unforgeablesMap = new WeakMap();
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {
@@ -15250,46 +15327,58 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
   return utils.implForWrapper(wrapper);
 };
 
+function getUnforgeables(globalObject) {
+  let unforgeables = unforgeablesMap.get(globalObject);
+  if (unforgeables === undefined) {
+    unforgeables = Object.create(
+      null,
+      Object.getOwnPropertyDescriptors({
+        unforgeablePromiseOperation() {
+          try {
+            const esValue = this !== null && this !== undefined ? this : globalObject;
+            if (!exports.is(esValue)) {
+              throw new TypeError(
+                \\"'unforgeablePromiseOperation' called on an object that is not a valid instance of PromiseTypes.\\"
+              );
+            }
+
+            return utils.tryWrapperForImpl(esValue[implSymbol].unforgeablePromiseOperation());
+          } catch (e) {
+            return Promise.reject(e);
+          }
+        },
+        get unforgeablePromiseAttribute() {
+          try {
+            const esValue = this !== null && this !== undefined ? this : globalObject;
+
+            if (!exports.is(esValue)) {
+              throw new TypeError(
+                \\"'get unforgeablePromiseAttribute' called on an object that is not a valid instance of PromiseTypes.\\"
+              );
+            }
+
+            return utils.tryWrapperForImpl(esValue[implSymbol][\\"unforgeablePromiseAttribute\\"]);
+          } catch (e) {
+            return Promise.reject(e);
+          }
+        }
+      })
+    );
+    Object.defineProperties(unforgeables, {
+      unforgeablePromiseOperation: { configurable: false, writable: false },
+      unforgeablePromiseAttribute: { configurable: false }
+    });
+    unforgeablesMap.set(globalObject, unforgeables);
+  }
+  return unforgeables;
+}
+
 exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      unforgeablePromiseOperation() {
-        try {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-          if (!exports.is(esValue)) {
-            throw new TypeError(
-              \\"'unforgeablePromiseOperation' called on an object that is not a valid instance of PromiseTypes.\\"
-            );
-          }
-
-          return utils.tryWrapperForImpl(esValue[implSymbol].unforgeablePromiseOperation());
-        } catch (e) {
-          return Promise.reject(e);
-        }
-      },
-      get unforgeablePromiseAttribute() {
-        try {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(
-              \\"'get unforgeablePromiseAttribute' called on an object that is not a valid instance of PromiseTypes.\\"
-            );
-          }
-
-          return utils.tryWrapperForImpl(esValue[implSymbol][\\"unforgeablePromiseAttribute\\"]);
-        } catch (e) {
-          return Promise.reject(e);
-        }
-      }
-    })
-  );
-
-  Object.defineProperties(wrapper, {
-    unforgeablePromiseOperation: { configurable: false, writable: false },
-    unforgeablePromiseAttribute: { configurable: false }
-  });
+  const unforgeables = getUnforgeables(globalObject);
+  for (const key of Reflect.ownKeys(unforgeables)) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
+    Object.defineProperty(wrapper, key, descriptor);
+  }
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -15324,6 +15413,7 @@ exports.new = (globalObject, newTarget) => {
   return wrapper[implSymbol];
 };
 
+const unforgeablesMap = new WeakMap();
 const exposed = new Set([\\"Window\\"]);
 
 exports.install = (globalObject, globalNames) => {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -3136,98 +3136,93 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
 };
 
 exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      op() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'op' called on an object that is not a valid instance of Global.\\");
-        }
+  utils.define(wrapper, {
+    op() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'op' called on an object that is not a valid instance of Global.\\");
+      }
 
-        return esValue[implSymbol].op();
-      },
-      unforgeableOp() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'unforgeableOp' called on an object that is not a valid instance of Global.\\");
-        }
+      return esValue[implSymbol].op();
+    },
+    unforgeableOp() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'unforgeableOp' called on an object that is not a valid instance of Global.\\");
+      }
 
-        return esValue[implSymbol].unforgeableOp();
-      },
-      get attr() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      return esValue[implSymbol].unforgeableOp();
+    },
+    get attr() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get attr' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'get attr' called on an object that is not a valid instance of Global.\\");
+      }
 
-        return esValue[implSymbol][\\"attr\\"];
-      },
-      set attr(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      return esValue[implSymbol][\\"attr\\"];
+    },
+    set attr(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'set attr' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'set attr' called on an object that is not a valid instance of Global.\\");
+      }
 
-        V = conversions[\\"DOMString\\"](V, {
-          context: \\"Failed to set the 'attr' property on 'Global': The provided value\\"
-        });
+      V = conversions[\\"DOMString\\"](V, { context: \\"Failed to set the 'attr' property on 'Global': The provided value\\" });
 
-        esValue[implSymbol][\\"attr\\"] = V;
-      },
-      get unforgeableAttr() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      esValue[implSymbol][\\"attr\\"] = V;
+    },
+    get unforgeableAttr() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get unforgeableAttr' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'get unforgeableAttr' called on an object that is not a valid instance of Global.\\");
+      }
 
-        return esValue[implSymbol][\\"unforgeableAttr\\"];
-      },
-      set unforgeableAttr(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      return esValue[implSymbol][\\"unforgeableAttr\\"];
+    },
+    set unforgeableAttr(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'set unforgeableAttr' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'set unforgeableAttr' called on an object that is not a valid instance of Global.\\");
+      }
 
-        V = conversions[\\"DOMString\\"](V, {
-          context: \\"Failed to set the 'unforgeableAttr' property on 'Global': The provided value\\"
-        });
+      V = conversions[\\"DOMString\\"](V, {
+        context: \\"Failed to set the 'unforgeableAttr' property on 'Global': The provided value\\"
+      });
 
-        esValue[implSymbol][\\"unforgeableAttr\\"] = V;
-      },
-      get length() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      esValue[implSymbol][\\"unforgeableAttr\\"] = V;
+    },
+    get length() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get length' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'get length' called on an object that is not a valid instance of Global.\\");
+      }
 
-        return esValue[implSymbol][\\"length\\"];
-      },
-      set length(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      return esValue[implSymbol][\\"length\\"];
+    },
+    set length(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'set length' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'set length' called on an object that is not a valid instance of Global.\\");
+      }
 
-        V = conversions[\\"unsigned long\\"](V, {
-          context: \\"Failed to set the 'length' property on 'Global': The provided value\\"
-        });
+      V = conversions[\\"unsigned long\\"](V, {
+        context: \\"Failed to set the 'length' property on 'Global': The provided value\\"
+      });
 
-        esValue[implSymbol][\\"length\\"] = V;
-      },
-      [Symbol.iterator]: ctorRegistry[\\"%Array%\\"].prototype[Symbol.iterator],
-      keys: ctorRegistry[\\"%Array%\\"].prototype.keys,
-      values: ctorRegistry[\\"%Array%\\"].prototype.values,
-      entries: ctorRegistry[\\"%Array%\\"].prototype.entries,
-      forEach: ctorRegistry[\\"%Array%\\"].prototype.forEach
-    })
-  );
+      esValue[implSymbol][\\"length\\"] = V;
+    },
+    [Symbol.iterator]: ctorRegistry[\\"%Array%\\"].prototype[Symbol.iterator],
+    keys: ctorRegistry[\\"%Array%\\"].prototype.keys,
+    values: ctorRegistry[\\"%Array%\\"].prototype.values,
+    entries: ctorRegistry[\\"%Array%\\"].prototype.entries,
+    forEach: ctorRegistry[\\"%Array%\\"].prototype.forEach
+  });
 
   Object.defineProperties(wrapper, {
     unforgeableOp: { configurable: false, writable: false },
@@ -3821,99 +3816,93 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
 function getUnforgeables(globalObject) {
   let unforgeables = unforgeablesMap.get(globalObject);
   if (unforgeables === undefined) {
-    unforgeables = Object.create(
-      null,
-      Object.getOwnPropertyDescriptors({
-        assign(url) {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'assign' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-          }
-
-          if (arguments.length < 1) {
-            throw new TypeError(
-              \\"Failed to execute 'assign' on 'LegacyUnforgeable': 1 argument required, but only \\" +
-                arguments.length +
-                \\" present.\\"
-            );
-          }
-          const args = [];
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"USVString\\"](curArg, {
-              context: \\"Failed to execute 'assign' on 'LegacyUnforgeable': parameter 1\\"
-            });
-            args.push(curArg);
-          }
-          return esValue[implSymbol].assign(...args);
-        },
-        get href() {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'get href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-          }
-
-          return esValue[implSymbol][\\"href\\"];
-        },
-        set href(V) {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'set href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-          }
-
-          V = conversions[\\"USVString\\"](V, {
-            context: \\"Failed to set the 'href' property on 'LegacyUnforgeable': The provided value\\"
-          });
-
-          esValue[implSymbol][\\"href\\"] = V;
-        },
-        toString() {
-          const esValue = this;
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'toString' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-          }
-
-          return esValue[implSymbol][\\"href\\"];
-        },
-        get origin() {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'get origin' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-          }
-
-          return esValue[implSymbol][\\"origin\\"];
-        },
-        get protocol() {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(
-              \\"'get protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\"
-            );
-          }
-
-          return esValue[implSymbol][\\"protocol\\"];
-        },
-        set protocol(V) {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(
-              \\"'set protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\"
-            );
-          }
-
-          V = conversions[\\"USVString\\"](V, {
-            context: \\"Failed to set the 'protocol' property on 'LegacyUnforgeable': The provided value\\"
-          });
-
-          esValue[implSymbol][\\"protocol\\"] = V;
+    unforgeables = Object.create(null);
+    utils.define(unforgeables, {
+      assign(url) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'assign' called on an object that is not a valid instance of LegacyUnforgeable.\\");
         }
-      })
-    );
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'assign' on 'LegacyUnforgeable': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          curArg = conversions[\\"USVString\\"](curArg, {
+            context: \\"Failed to execute 'assign' on 'LegacyUnforgeable': parameter 1\\"
+          });
+          args.push(curArg);
+        }
+        return esValue[implSymbol].assign(...args);
+      },
+      get href() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'get href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        return esValue[implSymbol][\\"href\\"];
+      },
+      set href(V) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'set href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        V = conversions[\\"USVString\\"](V, {
+          context: \\"Failed to set the 'href' property on 'LegacyUnforgeable': The provided value\\"
+        });
+
+        esValue[implSymbol][\\"href\\"] = V;
+      },
+      toString() {
+        const esValue = this;
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'toString' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        return esValue[implSymbol][\\"href\\"];
+      },
+      get origin() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'get origin' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        return esValue[implSymbol][\\"origin\\"];
+      },
+      get protocol() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'get protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        return esValue[implSymbol][\\"protocol\\"];
+      },
+      set protocol(V) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'set protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        V = conversions[\\"USVString\\"](V, {
+          context: \\"Failed to set the 'protocol' property on 'LegacyUnforgeable': The provided value\\"
+        });
+
+        esValue[implSymbol][\\"protocol\\"] = V;
+      }
+    });
     Object.defineProperties(unforgeables, {
       assign: { configurable: false, writable: false },
       href: { configurable: false },
@@ -3927,11 +3916,7 @@ function getUnforgeables(globalObject) {
 }
 
 exports._internalSetup = (wrapper, globalObject) => {
-  const unforgeables = getUnforgeables(globalObject);
-  for (const key of Reflect.ownKeys(unforgeables)) {
-    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
-    Object.defineProperty(wrapper, key, descriptor);
-  }
+  utils.define(wrapper, getUnforgeables(globalObject));
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -4046,20 +4031,18 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
 function getUnforgeables(globalObject) {
   let unforgeables = unforgeablesMap.get(globalObject);
   if (unforgeables === undefined) {
-    unforgeables = Object.create(
-      null,
-      Object.getOwnPropertyDescriptors({
-        get a() {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
+    unforgeables = Object.create(null);
+    utils.define(unforgeables, {
+      get a() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
 
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'get a' called on an object that is not a valid instance of LegacyUnforgeableMap.\\");
-          }
-
-          return esValue[implSymbol][\\"a\\"];
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'get a' called on an object that is not a valid instance of LegacyUnforgeableMap.\\");
         }
-      })
-    );
+
+        return esValue[implSymbol][\\"a\\"];
+      }
+    });
     Object.defineProperties(unforgeables, {
       a: { configurable: false }
     });
@@ -4069,11 +4052,7 @@ function getUnforgeables(globalObject) {
 }
 
 exports._internalSetup = (wrapper, globalObject) => {
-  const unforgeables = getUnforgeables(globalObject);
-  for (const key of Reflect.ownKeys(unforgeables)) {
-    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
-    Object.defineProperty(wrapper, key, descriptor);
-  }
+  utils.define(wrapper, getUnforgeables(globalObject));
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -5054,40 +5033,38 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
 function getUnforgeables(globalObject) {
   let unforgeables = unforgeablesMap.get(globalObject);
   if (unforgeables === undefined) {
-    unforgeables = Object.create(
-      null,
-      Object.getOwnPropertyDescriptors({
-        unforgeablePromiseOperation() {
-          try {
-            const esValue = this !== null && this !== undefined ? this : globalObject;
-            if (!exports.is(esValue)) {
-              throw new TypeError(
-                \\"'unforgeablePromiseOperation' called on an object that is not a valid instance of PromiseTypes.\\"
-              );
-            }
-
-            return utils.tryWrapperForImpl(esValue[implSymbol].unforgeablePromiseOperation());
-          } catch (e) {
-            return Promise.reject(e);
+    unforgeables = Object.create(null);
+    utils.define(unforgeables, {
+      unforgeablePromiseOperation() {
+        try {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+          if (!exports.is(esValue)) {
+            throw new TypeError(
+              \\"'unforgeablePromiseOperation' called on an object that is not a valid instance of PromiseTypes.\\"
+            );
           }
-        },
-        get unforgeablePromiseAttribute() {
-          try {
-            const esValue = this !== null && this !== undefined ? this : globalObject;
 
-            if (!exports.is(esValue)) {
-              throw new TypeError(
-                \\"'get unforgeablePromiseAttribute' called on an object that is not a valid instance of PromiseTypes.\\"
-              );
-            }
-
-            return utils.tryWrapperForImpl(esValue[implSymbol][\\"unforgeablePromiseAttribute\\"]);
-          } catch (e) {
-            return Promise.reject(e);
-          }
+          return utils.tryWrapperForImpl(esValue[implSymbol].unforgeablePromiseOperation());
+        } catch (e) {
+          return Promise.reject(e);
         }
-      })
-    );
+      },
+      get unforgeablePromiseAttribute() {
+        try {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(
+              \\"'get unforgeablePromiseAttribute' called on an object that is not a valid instance of PromiseTypes.\\"
+            );
+          }
+
+          return utils.tryWrapperForImpl(esValue[implSymbol][\\"unforgeablePromiseAttribute\\"]);
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      }
+    });
     Object.defineProperties(unforgeables, {
       unforgeablePromiseOperation: { configurable: false, writable: false },
       unforgeablePromiseAttribute: { configurable: false }
@@ -5098,11 +5075,7 @@ function getUnforgeables(globalObject) {
 }
 
 exports._internalSetup = (wrapper, globalObject) => {
-  const unforgeables = getUnforgeables(globalObject);
-  for (const key of Reflect.ownKeys(unforgeables)) {
-    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
-    Object.defineProperty(wrapper, key, descriptor);
-  }
+  utils.define(wrapper, getUnforgeables(globalObject));
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -13413,98 +13386,93 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
 };
 
 exports._internalSetup = (wrapper, globalObject) => {
-  Object.defineProperties(
-    wrapper,
-    Object.getOwnPropertyDescriptors({
-      op() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'op' called on an object that is not a valid instance of Global.\\");
-        }
+  utils.define(wrapper, {
+    op() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'op' called on an object that is not a valid instance of Global.\\");
+      }
 
-        return esValue[implSymbol].op();
-      },
-      unforgeableOp() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'unforgeableOp' called on an object that is not a valid instance of Global.\\");
-        }
+      return esValue[implSymbol].op();
+    },
+    unforgeableOp() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'unforgeableOp' called on an object that is not a valid instance of Global.\\");
+      }
 
-        return esValue[implSymbol].unforgeableOp();
-      },
-      get attr() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      return esValue[implSymbol].unforgeableOp();
+    },
+    get attr() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get attr' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'get attr' called on an object that is not a valid instance of Global.\\");
+      }
 
-        return esValue[implSymbol][\\"attr\\"];
-      },
-      set attr(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      return esValue[implSymbol][\\"attr\\"];
+    },
+    set attr(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'set attr' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'set attr' called on an object that is not a valid instance of Global.\\");
+      }
 
-        V = conversions[\\"DOMString\\"](V, {
-          context: \\"Failed to set the 'attr' property on 'Global': The provided value\\"
-        });
+      V = conversions[\\"DOMString\\"](V, { context: \\"Failed to set the 'attr' property on 'Global': The provided value\\" });
 
-        esValue[implSymbol][\\"attr\\"] = V;
-      },
-      get unforgeableAttr() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      esValue[implSymbol][\\"attr\\"] = V;
+    },
+    get unforgeableAttr() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get unforgeableAttr' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'get unforgeableAttr' called on an object that is not a valid instance of Global.\\");
+      }
 
-        return esValue[implSymbol][\\"unforgeableAttr\\"];
-      },
-      set unforgeableAttr(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      return esValue[implSymbol][\\"unforgeableAttr\\"];
+    },
+    set unforgeableAttr(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'set unforgeableAttr' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'set unforgeableAttr' called on an object that is not a valid instance of Global.\\");
+      }
 
-        V = conversions[\\"DOMString\\"](V, {
-          context: \\"Failed to set the 'unforgeableAttr' property on 'Global': The provided value\\"
-        });
+      V = conversions[\\"DOMString\\"](V, {
+        context: \\"Failed to set the 'unforgeableAttr' property on 'Global': The provided value\\"
+      });
 
-        esValue[implSymbol][\\"unforgeableAttr\\"] = V;
-      },
-      get length() {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      esValue[implSymbol][\\"unforgeableAttr\\"] = V;
+    },
+    get length() {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'get length' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'get length' called on an object that is not a valid instance of Global.\\");
+      }
 
-        return esValue[implSymbol][\\"length\\"];
-      },
-      set length(V) {
-        const esValue = this !== null && this !== undefined ? this : globalObject;
+      return esValue[implSymbol][\\"length\\"];
+    },
+    set length(V) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
 
-        if (!exports.is(esValue)) {
-          throw new TypeError(\\"'set length' called on an object that is not a valid instance of Global.\\");
-        }
+      if (!exports.is(esValue)) {
+        throw new TypeError(\\"'set length' called on an object that is not a valid instance of Global.\\");
+      }
 
-        V = conversions[\\"unsigned long\\"](V, {
-          context: \\"Failed to set the 'length' property on 'Global': The provided value\\"
-        });
+      V = conversions[\\"unsigned long\\"](V, {
+        context: \\"Failed to set the 'length' property on 'Global': The provided value\\"
+      });
 
-        esValue[implSymbol][\\"length\\"] = V;
-      },
-      [Symbol.iterator]: ctorRegistry[\\"%Array%\\"].prototype[Symbol.iterator],
-      keys: ctorRegistry[\\"%Array%\\"].prototype.keys,
-      values: ctorRegistry[\\"%Array%\\"].prototype.values,
-      entries: ctorRegistry[\\"%Array%\\"].prototype.entries,
-      forEach: ctorRegistry[\\"%Array%\\"].prototype.forEach
-    })
-  );
+      esValue[implSymbol][\\"length\\"] = V;
+    },
+    [Symbol.iterator]: ctorRegistry[\\"%Array%\\"].prototype[Symbol.iterator],
+    keys: ctorRegistry[\\"%Array%\\"].prototype.keys,
+    values: ctorRegistry[\\"%Array%\\"].prototype.values,
+    entries: ctorRegistry[\\"%Array%\\"].prototype.entries,
+    forEach: ctorRegistry[\\"%Array%\\"].prototype.forEach
+  });
 
   Object.defineProperties(wrapper, {
     unforgeableOp: { configurable: false, writable: false },
@@ -14097,99 +14065,93 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
 function getUnforgeables(globalObject) {
   let unforgeables = unforgeablesMap.get(globalObject);
   if (unforgeables === undefined) {
-    unforgeables = Object.create(
-      null,
-      Object.getOwnPropertyDescriptors({
-        assign(url) {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'assign' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-          }
-
-          if (arguments.length < 1) {
-            throw new TypeError(
-              \\"Failed to execute 'assign' on 'LegacyUnforgeable': 1 argument required, but only \\" +
-                arguments.length +
-                \\" present.\\"
-            );
-          }
-          const args = [];
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"USVString\\"](curArg, {
-              context: \\"Failed to execute 'assign' on 'LegacyUnforgeable': parameter 1\\"
-            });
-            args.push(curArg);
-          }
-          return esValue[implSymbol].assign(...args);
-        },
-        get href() {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'get href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-          }
-
-          return esValue[implSymbol][\\"href\\"];
-        },
-        set href(V) {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'set href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-          }
-
-          V = conversions[\\"USVString\\"](V, {
-            context: \\"Failed to set the 'href' property on 'LegacyUnforgeable': The provided value\\"
-          });
-
-          esValue[implSymbol][\\"href\\"] = V;
-        },
-        toString() {
-          const esValue = this;
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'toString' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-          }
-
-          return esValue[implSymbol][\\"href\\"];
-        },
-        get origin() {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'get origin' called on an object that is not a valid instance of LegacyUnforgeable.\\");
-          }
-
-          return esValue[implSymbol][\\"origin\\"];
-        },
-        get protocol() {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(
-              \\"'get protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\"
-            );
-          }
-
-          return esValue[implSymbol][\\"protocol\\"];
-        },
-        set protocol(V) {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
-
-          if (!exports.is(esValue)) {
-            throw new TypeError(
-              \\"'set protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\"
-            );
-          }
-
-          V = conversions[\\"USVString\\"](V, {
-            context: \\"Failed to set the 'protocol' property on 'LegacyUnforgeable': The provided value\\"
-          });
-
-          esValue[implSymbol][\\"protocol\\"] = V;
+    unforgeables = Object.create(null);
+    utils.define(unforgeables, {
+      assign(url) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'assign' called on an object that is not a valid instance of LegacyUnforgeable.\\");
         }
-      })
-    );
+
+        if (arguments.length < 1) {
+          throw new TypeError(
+            \\"Failed to execute 'assign' on 'LegacyUnforgeable': 1 argument required, but only \\" +
+              arguments.length +
+              \\" present.\\"
+          );
+        }
+        const args = [];
+        {
+          let curArg = arguments[0];
+          curArg = conversions[\\"USVString\\"](curArg, {
+            context: \\"Failed to execute 'assign' on 'LegacyUnforgeable': parameter 1\\"
+          });
+          args.push(curArg);
+        }
+        return esValue[implSymbol].assign(...args);
+      },
+      get href() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'get href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        return esValue[implSymbol][\\"href\\"];
+      },
+      set href(V) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'set href' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        V = conversions[\\"USVString\\"](V, {
+          context: \\"Failed to set the 'href' property on 'LegacyUnforgeable': The provided value\\"
+        });
+
+        esValue[implSymbol][\\"href\\"] = V;
+      },
+      toString() {
+        const esValue = this;
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'toString' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        return esValue[implSymbol][\\"href\\"];
+      },
+      get origin() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'get origin' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        return esValue[implSymbol][\\"origin\\"];
+      },
+      get protocol() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'get protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        return esValue[implSymbol][\\"protocol\\"];
+      },
+      set protocol(V) {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
+
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'set protocol' called on an object that is not a valid instance of LegacyUnforgeable.\\");
+        }
+
+        V = conversions[\\"USVString\\"](V, {
+          context: \\"Failed to set the 'protocol' property on 'LegacyUnforgeable': The provided value\\"
+        });
+
+        esValue[implSymbol][\\"protocol\\"] = V;
+      }
+    });
     Object.defineProperties(unforgeables, {
       assign: { configurable: false, writable: false },
       href: { configurable: false },
@@ -14203,11 +14165,7 @@ function getUnforgeables(globalObject) {
 }
 
 exports._internalSetup = (wrapper, globalObject) => {
-  const unforgeables = getUnforgeables(globalObject);
-  for (const key of Reflect.ownKeys(unforgeables)) {
-    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
-    Object.defineProperty(wrapper, key, descriptor);
-  }
+  utils.define(wrapper, getUnforgeables(globalObject));
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -14322,20 +14280,18 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
 function getUnforgeables(globalObject) {
   let unforgeables = unforgeablesMap.get(globalObject);
   if (unforgeables === undefined) {
-    unforgeables = Object.create(
-      null,
-      Object.getOwnPropertyDescriptors({
-        get a() {
-          const esValue = this !== null && this !== undefined ? this : globalObject;
+    unforgeables = Object.create(null);
+    utils.define(unforgeables, {
+      get a() {
+        const esValue = this !== null && this !== undefined ? this : globalObject;
 
-          if (!exports.is(esValue)) {
-            throw new TypeError(\\"'get a' called on an object that is not a valid instance of LegacyUnforgeableMap.\\");
-          }
-
-          return esValue[implSymbol][\\"a\\"];
+        if (!exports.is(esValue)) {
+          throw new TypeError(\\"'get a' called on an object that is not a valid instance of LegacyUnforgeableMap.\\");
         }
-      })
-    );
+
+        return esValue[implSymbol][\\"a\\"];
+      }
+    });
     Object.defineProperties(unforgeables, {
       a: { configurable: false }
     });
@@ -14345,11 +14301,7 @@ function getUnforgeables(globalObject) {
 }
 
 exports._internalSetup = (wrapper, globalObject) => {
-  const unforgeables = getUnforgeables(globalObject);
-  for (const key of Reflect.ownKeys(unforgeables)) {
-    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
-    Object.defineProperty(wrapper, key, descriptor);
-  }
+  utils.define(wrapper, getUnforgeables(globalObject));
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
@@ -15330,40 +15282,38 @@ exports.createImpl = (globalObject, constructorArgs, privateData) => {
 function getUnforgeables(globalObject) {
   let unforgeables = unforgeablesMap.get(globalObject);
   if (unforgeables === undefined) {
-    unforgeables = Object.create(
-      null,
-      Object.getOwnPropertyDescriptors({
-        unforgeablePromiseOperation() {
-          try {
-            const esValue = this !== null && this !== undefined ? this : globalObject;
-            if (!exports.is(esValue)) {
-              throw new TypeError(
-                \\"'unforgeablePromiseOperation' called on an object that is not a valid instance of PromiseTypes.\\"
-              );
-            }
-
-            return utils.tryWrapperForImpl(esValue[implSymbol].unforgeablePromiseOperation());
-          } catch (e) {
-            return Promise.reject(e);
+    unforgeables = Object.create(null);
+    utils.define(unforgeables, {
+      unforgeablePromiseOperation() {
+        try {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+          if (!exports.is(esValue)) {
+            throw new TypeError(
+              \\"'unforgeablePromiseOperation' called on an object that is not a valid instance of PromiseTypes.\\"
+            );
           }
-        },
-        get unforgeablePromiseAttribute() {
-          try {
-            const esValue = this !== null && this !== undefined ? this : globalObject;
 
-            if (!exports.is(esValue)) {
-              throw new TypeError(
-                \\"'get unforgeablePromiseAttribute' called on an object that is not a valid instance of PromiseTypes.\\"
-              );
-            }
-
-            return utils.tryWrapperForImpl(esValue[implSymbol][\\"unforgeablePromiseAttribute\\"]);
-          } catch (e) {
-            return Promise.reject(e);
-          }
+          return utils.tryWrapperForImpl(esValue[implSymbol].unforgeablePromiseOperation());
+        } catch (e) {
+          return Promise.reject(e);
         }
-      })
-    );
+      },
+      get unforgeablePromiseAttribute() {
+        try {
+          const esValue = this !== null && this !== undefined ? this : globalObject;
+
+          if (!exports.is(esValue)) {
+            throw new TypeError(
+              \\"'get unforgeablePromiseAttribute' called on an object that is not a valid instance of PromiseTypes.\\"
+            );
+          }
+
+          return utils.tryWrapperForImpl(esValue[implSymbol][\\"unforgeablePromiseAttribute\\"]);
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      }
+    });
     Object.defineProperties(unforgeables, {
       unforgeablePromiseOperation: { configurable: false, writable: false },
       unforgeablePromiseAttribute: { configurable: false }
@@ -15374,11 +15324,7 @@ function getUnforgeables(globalObject) {
 }
 
 exports._internalSetup = (wrapper, globalObject) => {
-  const unforgeables = getUnforgeables(globalObject);
-  for (const key of Reflect.ownKeys(unforgeables)) {
-    const descriptor = Reflect.getOwnPropertyDescriptor(unforgeables, key);
-    Object.defineProperty(wrapper, key, descriptor);
-  }
+  utils.define(wrapper, getUnforgeables(globalObject));
 };
 
 exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {


### PR DESCRIPTION
This makes it so that:
```js
console.assert(new Event("foo").__lookupGetter__("isTrusted") === new Event("bar").__lookupGetter__("isTrusted"));
```

Which passes in browsers.

## See also:
<dl>
<dt><a href="https://heycam.github.io/webidl/#create-an-interface-object">create an interface object</a></dt>
<dd>

> 5. Let <var>unforgeables</var> be [!] [OrdinaryObjectCreate]\(<b>null</b>\).
> 6. [Define the unforgeable regular operations] of <var>I</var> on <var>unforgeables</var>, given <var>realm</var>.
> 7. [Define the unforgeable regular attributes] of <var>I</var> on <var>unforgeables</var>, given <var>realm</var>.
> 8. Set <var>F</var>.[[Unforgeables]] to <var>unforgeables</var>.
</dd>
<dt><a href="https://heycam.github.io/webidl/#internally-create-a-new-object-implementing-the-interface">internally create a new object implementing the interface</a></dt>
<dd>

> 9. [For every] [interface] <var>ancestor interface</var> in <var>interfaces</var>:<ol type="1"><li>Let <var>unforgeables</var> be the value of the [[Unforgeables]] slot of the [interface object] of <var>ancestor interface</var> in <var>realm</var>.</li><li>Let <var>keys</var> be [!] <var>unforgeables</var>.[[OwnPropertyKeys]]\(\).</li><li>[For each] element <var>key</var> of <var>keys</var>:<ol type="1"><li>Let <var>descriptor</var> be [!] <var>unforgeables</var>.[[GetOwnProperty]]\(<var>key</var>\).</li><li>Perform [!] [DefinePropertyOrThrow]\(<var>instance</var>, <var>key</var>, <var>descriptor</var>\).</li></ol></li></ol>
</dd>
</dl>

[!]: https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands
[OrdinaryObjectCreate]: https://tc39.github.io/ecma262/#sec-ordinaryobjectcreate
[Define the unforgeable regular operations]: https://heycam.github.io/webidl/#define-the-unforgeable-regular-operations
[Define the unforgeable regular attributes]: https://heycam.github.io/webidl/#define-the-unforgeable-regular-attributes
[For every]: https://infra.spec.whatwg.org/#list-iterate
[interface]: https://heycam.github.io/webidl/#dfn-interface
[interface object]: https://heycam.github.io/webidl/#dfn-interface-object
[For each]: https://infra.spec.whatwg.org/#list
[DefinePropertyOrThrow]: https://tc39.github.io/ecma262/#sec-definepropertyorthrow

---

<details>
<summary><strong>JSDOM benchmark results</strong></summary>
<p></p>

| benchmark                                                                                    | `master`                                                                                        | `fix/ext-attr/legacy-unforgeable/use-unforgeables-object`
| ---------                                                                                    | --------                                                                                        | ---------------------------------------------------------
| dom/compare-document-position/compare&nbsp;ancestor                                          | jsdom  ×&nbsp;31,680&nbsp;ops/sec ±3.33%&nbsp;(8&nbsp;runs&nbsp;sampled)                        | jsdom  ×&nbsp;31,039&nbsp;ops/sec ±4.80%&nbsp;(9&nbsp;runs&nbsp;sampled)
| dom/compare-document-position/compare&nbsp;descendant                                        | jsdom  ×&nbsp;33,229&nbsp;ops/sec ±4.04%&nbsp;(10&nbsp;runs&nbsp;sampled)                       | jsdom  ×&nbsp;31,615&nbsp;ops/sec ±5.98%&nbsp;(10&nbsp;runs&nbsp;sampled)
| dom/compare-document-position/compare&nbsp;siblings                                          | jsdom  ×&nbsp;1,092,845&nbsp;ops/sec ±1.22%&nbsp;(11&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,043,994&nbsp;ops/sec ±1.51%&nbsp;(12&nbsp;runs&nbsp;sampled)
| dom/construction/createComment                                                               | jsdom  ×&nbsp;1,301,196&nbsp;ops/sec ±1.76%&nbsp;(94&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,445,954&nbsp;ops/sec ±1.76%&nbsp;(92&nbsp;runs&nbsp;sampled)
| dom/construction/createDocumentFragment                                                      | jsdom  ×&nbsp;1,178,947&nbsp;ops/sec ±0.53%&nbsp;(96&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,320,875&nbsp;ops/sec ±0.84%&nbsp;(93&nbsp;runs&nbsp;sampled)
| dom/construction/createElement                                                               | jsdom  ×&nbsp;283,346&nbsp;ops/sec ±0.21%&nbsp;(95&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;283,587&nbsp;ops/sec ±0.67%&nbsp;(94&nbsp;runs&nbsp;sampled)
| dom/construction/createEvent                                                                 | jsdom  ×&nbsp;206,199&nbsp;ops/sec ±1.61%&nbsp;(93&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;381,336&nbsp;ops/sec ±0.76%&nbsp;(93&nbsp;runs&nbsp;sampled)
| dom/construction/createNodeIterator                                                          | jsdom  ×&nbsp;1,326,075&nbsp;ops/sec ±0.61%&nbsp;(94&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,478,440&nbsp;ops/sec ±0.79%&nbsp;(95&nbsp;runs&nbsp;sampled)
| dom/construction/createProcessingInstruction                                                 | jsdom  ×&nbsp;664,399&nbsp;ops/sec ±0.70%&nbsp;(94&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;658,141&nbsp;ops/sec ±2.20%&nbsp;(90&nbsp;runs&nbsp;sampled)
| dom/construction/createTextNode                                                              | jsdom  ×&nbsp;1,042,538&nbsp;ops/sec ±0.68%&nbsp;(92&nbsp;runs&nbsp;sampled)                    | jsdom  ×&nbsp;1,180,503&nbsp;ops/sec ±1.91%&nbsp;(90&nbsp;runs&nbsp;sampled)
| dom/inner-html/tables                                                                        | jsdom  ×&nbsp;0.31&nbsp;ops/sec ±3.76%&nbsp;(5&nbsp;runs&nbsp;sampled)                          | jsdom  ×&nbsp;0.30&nbsp;ops/sec ±2.46%&nbsp;(5&nbsp;runs&nbsp;sampled)
| dom/named-properties/setAttribute(): Remove&nbsp;a&nbsp;named&nbsp;property from&nbsp;window | jsdom  ×&nbsp;2,465&nbsp;ops/sec ±0.52%&nbsp;(58&nbsp;runs&nbsp;sampled)                        | jsdom  ×&nbsp;2,283&nbsp;ops/sec ±1.15%&nbsp;(55&nbsp;runs&nbsp;sampled)
| dom/tree-modification/appendChild: many&nbsp;parents                                         | jsdom  ×&nbsp;26.99&nbsp;ops/sec ±1.15%&nbsp;(47&nbsp;runs&nbsp;sampled)                        | jsdom  ×&nbsp;25.85&nbsp;ops/sec ±0.56%&nbsp;(45&nbsp;runs&nbsp;sampled)
| dom/tree-modification/appendChild: many&nbsp;siblings                                        | jsdom  ×&nbsp;246,844&nbsp;ops/sec ±9.27%&nbsp;(18&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;242,924&nbsp;ops/sec ±8.88%&nbsp;(19&nbsp;runs&nbsp;sampled)
| dom/tree-modification/appendChild: no&nbsp;siblings                                          | jsdom  ×&nbsp;227,547&nbsp;ops/sec ±4.73%&nbsp;(28&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;217,066&nbsp;ops/sec ±7.04%&nbsp;(29&nbsp;runs&nbsp;sampled)
| dom/tree-modification/insertBefore: many&nbsp;siblings                                       | jsdom  ×&nbsp;213,163&nbsp;ops/sec ±11.42%&nbsp;(18&nbsp;runs&nbsp;sampled)                     | jsdom  ×&nbsp;213,551&nbsp;ops/sec ±8.32%&nbsp;(18&nbsp;runs&nbsp;sampled)
| dom/tree-modification/removeChild: many&nbsp;parents                                         | jsdom  ×&nbsp;122&nbsp;ops/sec ±1.00%&nbsp;(63&nbsp;runs&nbsp;sampled)                          | jsdom  ×&nbsp;117&nbsp;ops/sec ±1.01%&nbsp;(60&nbsp;runs&nbsp;sampled)
| dom/tree-modification/removeChild: many&nbsp;siblings                                        | jsdom  ×&nbsp;152,153&nbsp;ops/sec ±6.38%&nbsp;(40&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;157,846&nbsp;ops/sec ±6.10%&nbsp;(38&nbsp;runs&nbsp;sampled)
| dom/tree-modification/removeChild: no&nbsp;siblings                                          | jsdom  ×&nbsp;141,264&nbsp;ops/sec ±8.47%&nbsp;(32&nbsp;runs&nbsp;sampled)                      | jsdom  ×&nbsp;148,015&nbsp;ops/sec ±7.62%&nbsp;(28&nbsp;runs&nbsp;sampled)
| html/parsing/text                                                                            | jsdom  ×&nbsp;15.77&nbsp;ops/sec ±1.75%&nbsp;(43&nbsp;runs&nbsp;sampled)                        | jsdom  ×&nbsp;15.93&nbsp;ops/sec ±1.53%&nbsp;(44&nbsp;runs&nbsp;sampled)
| jsdom/api/new&nbsp;JSDOM() defaults                                                          | &lt;Test&nbsp;#&#x2060;10&gt; ×&nbsp;290&nbsp;ops/sec ±2.77%&nbsp;(78&nbsp;runs&nbsp;sampled)   | &lt;Test&nbsp;#&#x2060;10&gt; ×&nbsp;291&nbsp;ops/sec ±2.89%&nbsp;(80&nbsp;runs&nbsp;sampled)
| jsdom/api/new&nbsp;JSDOM() with&nbsp;many&nbsp;elements                                      | &lt;Test&nbsp;#&#x2060;11&gt; ×&nbsp;29.79&nbsp;ops/sec ±4.19%&nbsp;(54&nbsp;runs&nbsp;sampled) | &lt;Test&nbsp;#&#x2060;11&gt; ×&nbsp;29.39&nbsp;ops/sec ±5.70%&nbsp;(54&nbsp;runs&nbsp;sampled)
</details>