### PR TITLE
Use `member.parent.name` instead of `member.definingInterface`

### DIFF
--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -35,10 +35,6 @@ class Interface {
     this.idl = idl;
     this.name = idl.name;
 
-    for (const member of this.idl.members) {
-      member.definingInterface = this.name;
-    }
-
     this.str = null;
     this.opts = opts;
     this.requires = new utils.RequiresMap(ctx);
@@ -204,8 +200,8 @@ class Interface {
       if (member.type === "operation") {
         if (member.special === "getter") {
           let msg = `Invalid getter ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
-          if (member.definingInterface !== this.name) {
-            msg += ` (defined in ${member.definingInterface})`;
+          if (member.parent.name !== this.name) {
+            msg += ` (defined in ${member.parent.name})`;
           }
           msg += ": ";
           if (member.arguments.length !== 1) {
@@ -227,8 +223,8 @@ class Interface {
         }
         if (member.special === "setter") {
           let msg = `Invalid setter ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
-          if (member.definingInterface !== this.name) {
-            msg += ` (defined in ${member.definingInterface})`;
+          if (member.parent.name !== this.name) {
+            msg += ` (defined in ${member.parent.name})`;
           }
           msg += ": ";
 
@@ -257,8 +253,8 @@ class Interface {
         }
         if (member.special === "deleter") {
           let msg = `Invalid deleter ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
-          if (member.definingInterface !== this.name) {
-            msg += ` (defined in ${member.definingInterface})`;
+          if (member.parent.name !== this.name) {
+            msg += ` (defined in ${member.parent.name})`;
           }
           msg += ": ";
 
@@ -321,8 +317,8 @@ class Interface {
 
       if (member.special === "stringifier") {
         let msg = `Invalid stringifier ${member.name ? `"${member.name}" ` : ""}on interface ${this.name}`;
-        if (member.definingInterface !== this.name) {
-          msg += ` (defined in ${member.definingInterface})`;
+        if (member.parent.name !== this.name) {
+          msg += ` (defined in ${member.parent.name})`;
         }
         msg += ": ";
         if (member.type === "operation") {
@@ -362,7 +358,7 @@ class Interface {
     for (const member of this.inheritedMembers()) {
       if (this.iterable && member.type === "iterable") {
         throw new Error(`Iterable interface ${this.name} inherits from another iterable interface ` +
-                        `${member.definingInterface}`);
+                        `${member.parent.name}`);
       }
 
       handleSpecialOperations(member);
@@ -388,8 +384,8 @@ class Interface {
     for (const member of this.allMembers()) {
       if (forbiddenMembers.has(member.name)) {
         let msg = `${member.name} is forbidden in interface ${this.name}`;
-        if (member.definingInterface !== this.name) {
-          msg += ` (defined in ${member.definingInterface})`;
+        if (member.parent.name !== this.name) {
+          msg += ` (defined in ${member.parent.name})`;
         }
         throw new Error(msg);
       }


### PR DESCRIPTION
The `parent` property was added to the AST in [**WebIDL2** v2.10.0](https://github.com/w3c/webidl2.js/blob/gh-pages/CHANGELOG.md#v23100-2019-10-14) in <https://github.com/w3c/webidl2.js/pull/425>.