### PR TITLE
Avoid useless `if`‑`else` check during fallback type conversion

### DIFF
--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -273,32 +273,41 @@ module.exports.generateOverloadConversions = function (ctx, typeOfOp, name, pare
         }
 
         const booleans = S.filter(o => isOrIncludes(ctx, o.typeList[d], t => t.idlType === "boolean"));
-        if (booleans.length) {
-          possibilities.push(`
-            if (typeof curArg === "boolean") {
-              ${continued(booleans[0], i)}
-            }
-          `);
-        }
-
         const numerics = S.filter(o => isOrIncludes(ctx, o.typeList[d], t => Types.numericTypes.has(t.idlType)));
-        if (numerics.length) {
-          possibilities.push(`
-            if (typeof curArg === "number") {
-              ${continued(numerics[0], i)}
-            }
-          `);
-        }
-
         const strings = S.filter(o => {
           return isOrIncludes(ctx, o.typeList[d], t => {
             return Types.stringTypes.has(t.idlType) || ctx.enumerations.has(t.idlType);
           });
         });
+
         const any = S.filter(o => isOrIncludes(ctx, o.typeList[d], t => t.idlType === "any"));
         if (strings.length) {
+          if (booleans.length) {
+            possibilities.push(`
+              if (typeof curArg === "boolean") {
+                ${continued(booleans[0], i)}
+              }
+            `);
+          }
+
+          if (numerics.length) {
+            possibilities.push(`
+              if (typeof curArg === "number") {
+                ${continued(numerics[0], i)}
+              }
+            `);
+          }
+
           possibilities.push(`{ ${continued(strings[0], i)} }`);
         } else if (numerics.length) {
+          if (booleans.length) {
+            possibilities.push(`
+              if (typeof curArg === "boolean") {
+                ${continued(booleans[0], i)}
+              }
+            `);
+          }
+
           possibilities.push(`{ ${continued(numerics[0], i)} }`);
         } else if (booleans.length) {
           possibilities.push(`{ ${continued(booleans[0], i)} }`);

--- a/lib/types.js
+++ b/lib/types.js
@@ -208,7 +208,8 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
     if (union.ArrayBufferViews.size > 0 || union.object) {
       let condition = `ArrayBuffer.isView(${name})`;
       // Skip specific type check if all ArrayBufferView member types are allowed.
-      if (union.ArrayBufferViews.size !== arrayBufferViewTypes.size) {
+      if (union.ArrayBufferViews.size !== 0 &&
+          union.ArrayBufferViews.size !== arrayBufferViewTypes.size) {
         const exprs = [...union.ArrayBufferViews].map(a => `${name}.constructor.name === "${a}"`);
         condition += ` && (${exprs.join(" || ")})`;
       }

--- a/lib/types.js
+++ b/lib/types.js
@@ -273,25 +273,26 @@ function generateTypeConversion(ctx, name, idlType, argAttrs = [], parentName, e
       output.push(code);
     }
 
-    if (union.boolean) {
-      output.push(`
-        if (typeof ${name} === "boolean") {
-          ${generateTypeConversion(ctx, name, union.boolean, [], parentName, errPrefix).body}
-        }
-      `);
-    }
-
-    if (union.numeric) {
-      output.push(`
-        if (typeof ${name} === "number") {
-          ${generateTypeConversion(ctx, name, union.numeric, [], parentName, errPrefix).body}
-        }
-      `);
-    }
-
     {
+      const { string, numeric, boolean } = union;
+      if (boolean && (string || numeric)) {
+        output.push(`
+          if (typeof ${name} === "boolean") {
+            ${generateTypeConversion(ctx, name, boolean, [], parentName, errPrefix).body}
+          }
+        `);
+      }
+
+      if (numeric && string) {
+        output.push(`
+          if (typeof ${name} === "number") {
+            ${generateTypeConversion(ctx, name, numeric, [], parentName, errPrefix).body}
+          }
+        `);
+      }
+
       let code = "{";
-      const type = union.string || union.numeric || union.boolean;
+      const type = string || numeric || boolean;
       if (type) {
         const conv = generateTypeConversion(ctx, name, type, [], parentName, errPrefix);
         code += conv.body;

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -4441,14 +4441,6 @@ exports.install = (globalObject, globalNames) => {
             });
             args.push(curArg);
           }
-        } else if (typeof curArg === \\"boolean\\") {
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"boolean\\"](curArg, {
-              context: \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
-            });
-            args.push(curArg);
-          }
         } else {
           {
             let curArg = arguments[0];
@@ -4496,14 +4488,6 @@ exports.install = (globalObject, globalNames) => {
             });
             args.push(curArg);
           }
-        } else if (typeof curArg === \\"number\\") {
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"long\\"](curArg, {
-              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-            });
-            args.push(curArg);
-          }
         } else {
           {
             let curArg = arguments[0];
@@ -4543,14 +4527,6 @@ exports.install = (globalObject, globalNames) => {
             });
             args.push(curArg);
           }
-        } else if (typeof curArg === \\"number\\") {
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"long\\"](curArg, {
-              context: \\"Failed to execute 'overloadsObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-            });
-            args.push(curArg);
-          }
         } else {
           {
             let curArg = arguments[0];
@@ -4586,14 +4562,6 @@ exports.install = (globalObject, globalNames) => {
           {
             let curArg = arguments[0];
             curArg = conversions[\\"boolean\\"](curArg, {
-              context: \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-            });
-            args.push(curArg);
-          }
-        } else if (typeof curArg === \\"number\\") {
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"long\\"](curArg, {
               context: \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
             });
             args.push(curArg);
@@ -4831,10 +4799,6 @@ exports.install = (globalObject, globalNames) => {
         } else if (ArrayBuffer.isView(curArg)) {
         } else if (typeof curArg === \\"function\\") {
         } else if (utils.isObject(curArg)) {
-        } else if (typeof curArg === \\"boolean\\") {
-          curArg = conversions[\\"boolean\\"](curArg, {
-            context: \\"Failed to execute 'unionObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
-          });
         } else {
           curArg = conversions[\\"boolean\\"](curArg, {
             context: \\"Failed to execute 'unionObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
@@ -4873,10 +4837,6 @@ exports.install = (globalObject, globalNames) => {
           curArg = conversions[\\"boolean\\"](curArg, {
             context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
           });
-        } else if (typeof curArg === \\"number\\") {
-          curArg = conversions[\\"long\\"](curArg, {
-            context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-          });
         } else {
           curArg = conversions[\\"long\\"](curArg, {
             context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
@@ -4911,10 +4871,6 @@ exports.install = (globalObject, globalNames) => {
         } else if (ArrayBuffer.isView(curArg)) {
         } else if (typeof curArg === \\"function\\") {
         } else if (utils.isObject(curArg)) {
-        } else if (typeof curArg === \\"number\\") {
-          curArg = conversions[\\"long\\"](curArg, {
-            context: \\"Failed to execute 'unionObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-          });
         } else {
           curArg = conversions[\\"long\\"](curArg, {
             context: \\"Failed to execute 'unionObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
@@ -4945,10 +4901,6 @@ exports.install = (globalObject, globalNames) => {
         let curArg = arguments[0];
         if (typeof curArg === \\"boolean\\") {
           curArg = conversions[\\"boolean\\"](curArg, {
-            context: \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-          });
-        } else if (typeof curArg === \\"number\\") {
-          curArg = conversions[\\"long\\"](curArg, {
             context: \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
           });
         } else {
@@ -15379,14 +15331,6 @@ exports.install = (globalObject, globalNames) => {
             });
             args.push(curArg);
           }
-        } else if (typeof curArg === \\"boolean\\") {
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"boolean\\"](curArg, {
-              context: \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
-            });
-            args.push(curArg);
-          }
         } else {
           {
             let curArg = arguments[0];
@@ -15434,14 +15378,6 @@ exports.install = (globalObject, globalNames) => {
             });
             args.push(curArg);
           }
-        } else if (typeof curArg === \\"number\\") {
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"long\\"](curArg, {
-              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-            });
-            args.push(curArg);
-          }
         } else {
           {
             let curArg = arguments[0];
@@ -15481,14 +15417,6 @@ exports.install = (globalObject, globalNames) => {
             });
             args.push(curArg);
           }
-        } else if (typeof curArg === \\"number\\") {
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"long\\"](curArg, {
-              context: \\"Failed to execute 'overloadsObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-            });
-            args.push(curArg);
-          }
         } else {
           {
             let curArg = arguments[0];
@@ -15524,14 +15452,6 @@ exports.install = (globalObject, globalNames) => {
           {
             let curArg = arguments[0];
             curArg = conversions[\\"boolean\\"](curArg, {
-              context: \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-            });
-            args.push(curArg);
-          }
-        } else if (typeof curArg === \\"number\\") {
-          {
-            let curArg = arguments[0];
-            curArg = conversions[\\"long\\"](curArg, {
               context: \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
             });
             args.push(curArg);
@@ -15769,10 +15689,6 @@ exports.install = (globalObject, globalNames) => {
         } else if (ArrayBuffer.isView(curArg)) {
         } else if (typeof curArg === \\"function\\") {
         } else if (utils.isObject(curArg)) {
-        } else if (typeof curArg === \\"boolean\\") {
-          curArg = conversions[\\"boolean\\"](curArg, {
-            context: \\"Failed to execute 'unionObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
-          });
         } else {
           curArg = conversions[\\"boolean\\"](curArg, {
             context: \\"Failed to execute 'unionObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
@@ -15811,10 +15727,6 @@ exports.install = (globalObject, globalNames) => {
           curArg = conversions[\\"boolean\\"](curArg, {
             context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
           });
-        } else if (typeof curArg === \\"number\\") {
-          curArg = conversions[\\"long\\"](curArg, {
-            context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-          });
         } else {
           curArg = conversions[\\"long\\"](curArg, {
             context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
@@ -15849,10 +15761,6 @@ exports.install = (globalObject, globalNames) => {
         } else if (ArrayBuffer.isView(curArg)) {
         } else if (typeof curArg === \\"function\\") {
         } else if (utils.isObject(curArg)) {
-        } else if (typeof curArg === \\"number\\") {
-          curArg = conversions[\\"long\\"](curArg, {
-            context: \\"Failed to execute 'unionObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-          });
         } else {
           curArg = conversions[\\"long\\"](curArg, {
             context: \\"Failed to execute 'unionObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
@@ -15883,10 +15791,6 @@ exports.install = (globalObject, globalNames) => {
         let curArg = arguments[0];
         if (typeof curArg === \\"boolean\\") {
           curArg = conversions[\\"boolean\\"](curArg, {
-            context: \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
-          });
-        } else if (typeof curArg === \\"number\\") {
-          curArg = conversions[\\"long\\"](curArg, {
             context: \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
           });
         } else {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -4323,6 +4323,833 @@ const Impl = require(\\"../implementations/MixedIn.js\\");
 "
 `;
 
+exports[`with processors NoUselessIfElse.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
+
+const interfaceName = \\"NoUselessIfElse\\";
+
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+};
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
+};
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
+  }
+  throw new TypeError(\`\${context} is not of type 'NoUselessIfElse'.\`);
+};
+
+function makeWrapper(globalObject) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistrySymbol][\\"NoUselessIfElse\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor NoUselessIfElse is not installed on the passed global object\\");
+  }
+
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper[implSymbol];
+};
+
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
+    return;
+  }
+  class NoUselessIfElse {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    overloadsObjectOrBoolean(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrBoolean' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrBoolean(...args));
+    }
+
+    overloadsObjectOrBooleanOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrBooleanOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrBooleanOrNumeric(...args));
+    }
+
+    overloadsObjectOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrNumeric(...args));
+    }
+
+    overloadsBooleanOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsBooleanOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsBooleanOrNumeric(...args));
+    }
+
+    overloadsObjectOrBooleanOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrBooleanOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrBooleanOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrBooleanOrString(...args));
+    }
+
+    overloadsObjectOrBooleanOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrBooleanOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrBooleanOrNumericOrString(...args));
+    }
+
+    overloadsObjectOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrNumericOrString(...args));
+    }
+
+    overloadsBooleanOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsBooleanOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsBooleanOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsBooleanOrNumericOrString(...args));
+    }
+
+    unionObjectOrBoolean(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrBoolean' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrBoolean' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrBoolean(...args));
+    }
+
+    unionObjectOrBooleanOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrBooleanOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrBooleanOrNumeric(...args));
+    }
+
+    unionObjectOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrNumeric(...args));
+    }
+
+    unionBooleanOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionBooleanOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionBooleanOrNumeric(...args));
+    }
+
+    unionObjectOrBooleanOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrBooleanOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrBooleanOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrBooleanOrString(...args));
+    }
+
+    unionObjectOrBooleanOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrBooleanOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrBooleanOrNumericOrString(...args));
+    }
+
+    unionObjectOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrNumericOrString(...args));
+    }
+
+    unionBooleanOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionBooleanOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionBooleanOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionBooleanOrNumericOrString(...args));
+    }
+  }
+  Object.defineProperties(NoUselessIfElse.prototype, {
+    overloadsObjectOrBoolean: { enumerable: true },
+    overloadsObjectOrBooleanOrNumeric: { enumerable: true },
+    overloadsObjectOrNumeric: { enumerable: true },
+    overloadsBooleanOrNumeric: { enumerable: true },
+    overloadsObjectOrBooleanOrString: { enumerable: true },
+    overloadsObjectOrBooleanOrNumericOrString: { enumerable: true },
+    overloadsObjectOrNumericOrString: { enumerable: true },
+    overloadsBooleanOrNumericOrString: { enumerable: true },
+    unionObjectOrBoolean: { enumerable: true },
+    unionObjectOrBooleanOrNumeric: { enumerable: true },
+    unionObjectOrNumeric: { enumerable: true },
+    unionBooleanOrNumeric: { enumerable: true },
+    unionObjectOrBooleanOrString: { enumerable: true },
+    unionObjectOrBooleanOrNumericOrString: { enumerable: true },
+    unionObjectOrNumericOrString: { enumerable: true },
+    unionBooleanOrNumericOrString: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"NoUselessIfElse\\", configurable: true }
+  });
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
+  }
+  globalObject[ctorRegistrySymbol][interfaceName] = NoUselessIfElse;
+
+  Object.defineProperty(globalObject, interfaceName, {
+    configurable: true,
+    writable: true,
+    value: NoUselessIfElse
+  });
+};
+
+const Impl = require(\\"../implementations/NoUselessIfElse.js\\");
+"
+`;
+
 exports[`with processors NodeFilter.webidl 1`] = `
 "\\"use strict\\";
 
@@ -14431,6 +15258,833 @@ exports.install = (globalObject, globalNames) => {
 };
 
 const Impl = require(\\"../implementations/MixedIn.js\\");
+"
+`;
+
+exports[`without processors NoUselessIfElse.webidl 1`] = `
+"\\"use strict\\";
+
+const conversions = require(\\"webidl-conversions\\");
+const utils = require(\\"./utils.js\\");
+
+const implSymbol = utils.implSymbol;
+const ctorRegistrySymbol = utils.ctorRegistrySymbol;
+
+const interfaceName = \\"NoUselessIfElse\\";
+
+exports.is = value => {
+  return utils.isObject(value) && utils.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+};
+exports.isImpl = value => {
+  return utils.isObject(value) && value instanceof Impl.implementation;
+};
+exports.convert = (value, { context = \\"The provided value\\" } = {}) => {
+  if (exports.is(value)) {
+    return utils.implForWrapper(value);
+  }
+  throw new TypeError(\`\${context} is not of type 'NoUselessIfElse'.\`);
+};
+
+function makeWrapper(globalObject) {
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    throw new Error(\\"Internal error: invalid global object\\");
+  }
+
+  const ctor = globalObject[ctorRegistrySymbol][\\"NoUselessIfElse\\"];
+  if (ctor === undefined) {
+    throw new Error(\\"Internal error: constructor NoUselessIfElse is not installed on the passed global object\\");
+  }
+
+  return Object.create(ctor.prototype);
+}
+
+exports.create = (globalObject, constructorArgs, privateData) => {
+  const wrapper = makeWrapper(globalObject);
+  return exports.setup(wrapper, globalObject, constructorArgs, privateData);
+};
+
+exports.createImpl = (globalObject, constructorArgs, privateData) => {
+  const wrapper = exports.create(globalObject, constructorArgs, privateData);
+  return utils.implForWrapper(wrapper);
+};
+
+exports._internalSetup = (wrapper, globalObject) => {};
+
+exports.setup = (wrapper, globalObject, constructorArgs = [], privateData = {}) => {
+  privateData.wrapper = wrapper;
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: new Impl.implementation(globalObject, constructorArgs, privateData),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper;
+};
+
+exports.new = globalObject => {
+  const wrapper = makeWrapper(globalObject);
+
+  exports._internalSetup(wrapper, globalObject);
+  Object.defineProperty(wrapper, implSymbol, {
+    value: Object.create(Impl.implementation.prototype),
+    configurable: true
+  });
+
+  wrapper[implSymbol][utils.wrapperSymbol] = wrapper;
+  if (Impl.init) {
+    Impl.init(wrapper[implSymbol]);
+  }
+  return wrapper[implSymbol];
+};
+
+const exposed = new Set([\\"Window\\"]);
+
+exports.install = (globalObject, globalNames) => {
+  if (!globalNames.some(globalName => exposed.has(globalName))) {
+    return;
+  }
+  class NoUselessIfElse {
+    constructor() {
+      throw new TypeError(\\"Illegal constructor\\");
+    }
+
+    overloadsObjectOrBoolean(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrBoolean' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrBoolean(...args));
+    }
+
+    overloadsObjectOrBooleanOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrBooleanOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrBooleanOrNumeric(...args));
+    }
+
+    overloadsObjectOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrNumeric(...args));
+    }
+
+    overloadsBooleanOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsBooleanOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsBooleanOrNumeric(...args));
+    }
+
+    overloadsObjectOrBooleanOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrBooleanOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrBooleanOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrBooleanOrString(...args));
+    }
+
+    overloadsObjectOrBooleanOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrBooleanOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrBooleanOrNumericOrString(...args));
+    }
+
+    overloadsObjectOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsObjectOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsObjectOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg)) {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"object\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'overloadsObjectOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsObjectOrNumericOrString(...args));
+    }
+
+    overloadsBooleanOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'overloadsBooleanOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'overloadsBooleanOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (typeof curArg === \\"boolean\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"boolean\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else if (typeof curArg === \\"number\\") {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"long\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        } else {
+          {
+            let curArg = arguments[0];
+            curArg = conversions[\\"DOMString\\"](curArg, {
+              context: \\"Failed to execute 'overloadsBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+            });
+            args.push(curArg);
+          }
+        }
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].overloadsBooleanOrNumericOrString(...args));
+    }
+
+    unionObjectOrBoolean(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrBoolean' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrBoolean' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrBoolean(...args));
+    }
+
+    unionObjectOrBooleanOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrBooleanOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrBooleanOrNumeric(...args));
+    }
+
+    unionObjectOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrNumeric(...args));
+    }
+
+    unionBooleanOrNumeric(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionBooleanOrNumeric' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumeric' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionBooleanOrNumeric(...args));
+    }
+
+    unionObjectOrBooleanOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrBooleanOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrBooleanOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrBooleanOrString(...args));
+    }
+
+    unionObjectOrBooleanOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrBooleanOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrBooleanOrNumericOrString(...args));
+    }
+
+    unionObjectOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionObjectOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionObjectOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (utils.isObject(curArg) && curArg[utils.implSymbol]) {
+          curArg = utils.implForWrapper(curArg);
+        } else if (utils.isArrayBuffer(curArg)) {
+        } else if (ArrayBuffer.isView(curArg)) {
+        } else if (typeof curArg === \\"function\\") {
+        } else if (utils.isObject(curArg)) {
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'unionObjectOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionObjectOrNumericOrString(...args));
+    }
+
+    unionBooleanOrNumericOrString(arg1) {
+      const esValue = this !== null && this !== undefined ? this : globalObject;
+      if (!exports.is(esValue)) {
+        throw new TypeError(
+          \\"'unionBooleanOrNumericOrString' called on an object that is not a valid instance of NoUselessIfElse.\\"
+        );
+      }
+
+      if (arguments.length < 1) {
+        throw new TypeError(
+          \\"Failed to execute 'unionBooleanOrNumericOrString' on 'NoUselessIfElse': 1 argument required, but only \\" +
+            arguments.length +
+            \\" present.\\"
+        );
+      }
+      const args = [];
+      {
+        let curArg = arguments[0];
+        if (typeof curArg === \\"boolean\\") {
+          curArg = conversions[\\"boolean\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else if (typeof curArg === \\"number\\") {
+          curArg = conversions[\\"long\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        } else {
+          curArg = conversions[\\"DOMString\\"](curArg, {
+            context: \\"Failed to execute 'unionBooleanOrNumericOrString' on 'NoUselessIfElse': parameter 1\\"
+          });
+        }
+        args.push(curArg);
+      }
+      return utils.tryWrapperForImpl(esValue[implSymbol].unionBooleanOrNumericOrString(...args));
+    }
+  }
+  Object.defineProperties(NoUselessIfElse.prototype, {
+    overloadsObjectOrBoolean: { enumerable: true },
+    overloadsObjectOrBooleanOrNumeric: { enumerable: true },
+    overloadsObjectOrNumeric: { enumerable: true },
+    overloadsBooleanOrNumeric: { enumerable: true },
+    overloadsObjectOrBooleanOrString: { enumerable: true },
+    overloadsObjectOrBooleanOrNumericOrString: { enumerable: true },
+    overloadsObjectOrNumericOrString: { enumerable: true },
+    overloadsBooleanOrNumericOrString: { enumerable: true },
+    unionObjectOrBoolean: { enumerable: true },
+    unionObjectOrBooleanOrNumeric: { enumerable: true },
+    unionObjectOrNumeric: { enumerable: true },
+    unionBooleanOrNumeric: { enumerable: true },
+    unionObjectOrBooleanOrString: { enumerable: true },
+    unionObjectOrBooleanOrNumericOrString: { enumerable: true },
+    unionObjectOrNumericOrString: { enumerable: true },
+    unionBooleanOrNumericOrString: { enumerable: true },
+    [Symbol.toStringTag]: { value: \\"NoUselessIfElse\\", configurable: true }
+  });
+  if (globalObject[ctorRegistrySymbol] === undefined) {
+    globalObject[ctorRegistrySymbol] = Object.create(null);
+  }
+  globalObject[ctorRegistrySymbol][interfaceName] = NoUselessIfElse;
+
+  Object.defineProperty(globalObject, interfaceName, {
+    configurable: true,
+    writable: true,
+    value: NoUselessIfElse
+  });
+};
+
+const Impl = require(\\"../implementations/NoUselessIfElse.js\\");
 "
 `;
 

--- a/test/cases/NoUselessIfElse.webidl
+++ b/test/cases/NoUselessIfElse.webidl
@@ -1,0 +1,46 @@
+[Exposed=Window]
+interface NoUselessIfElse {
+  // # Overloads:
+  undefined overloadsObjectOrBoolean(object arg1);
+  undefined overloadsObjectOrBoolean(boolean arg1);
+
+  undefined overloadsObjectOrBooleanOrNumeric(object arg1);
+  undefined overloadsObjectOrBooleanOrNumeric(boolean arg1);
+  undefined overloadsObjectOrBooleanOrNumeric(long arg1);
+
+  undefined overloadsObjectOrNumeric(object arg1);
+  undefined overloadsObjectOrNumeric(long arg1);
+
+  undefined overloadsBooleanOrNumeric(boolean arg1);
+  undefined overloadsBooleanOrNumeric(long arg1);
+
+  // ## Avoid regressions:
+  undefined overloadsObjectOrBooleanOrString(object arg1);
+  undefined overloadsObjectOrBooleanOrString(boolean arg1);
+  undefined overloadsObjectOrBooleanOrString(DOMString arg1);
+
+  undefined overloadsObjectOrBooleanOrNumericOrString(object arg1);
+  undefined overloadsObjectOrBooleanOrNumericOrString(boolean arg1);
+  undefined overloadsObjectOrBooleanOrNumericOrString(long arg1);
+  undefined overloadsObjectOrBooleanOrNumericOrString(DOMString arg1);
+
+  undefined overloadsObjectOrNumericOrString(object arg1);
+  undefined overloadsObjectOrNumericOrString(long arg1);
+  undefined overloadsObjectOrNumericOrString(DOMString arg1);
+
+  undefined overloadsBooleanOrNumericOrString(boolean arg1);
+  undefined overloadsBooleanOrNumericOrString(long arg1);
+  undefined overloadsBooleanOrNumericOrString(DOMString arg1);
+
+  // # Unions:
+  undefined unionObjectOrBoolean((object or boolean) arg1);
+  undefined unionObjectOrBooleanOrNumeric((object or boolean or long) arg1);
+  undefined unionObjectOrNumeric((object or long) arg1);
+  undefined unionBooleanOrNumeric((boolean or long) arg1);
+
+  // ## Avoid regressions:
+  undefined unionObjectOrBooleanOrString((object or boolean or DOMString) arg1);
+  undefined unionObjectOrBooleanOrNumericOrString((object or boolean or long or DOMString) arg1);
+  undefined unionObjectOrNumericOrString((object or long or DOMString) arg1);
+  undefined unionBooleanOrNumericOrString((boolean or long or DOMString) arg1);
+};


### PR DESCRIPTION
This makes it so that for fallback types (e.g. `boolean` and `number`), if it’s the last fallback type among overloads or in a union, then the conversion will no longer be duplicated in the `if`‑and‑`else` branches:
```diff js
-} else if (typeof curArg === \\"boolean\\") {
-	{
-		let curArg = arguments[0];
-		curArg = conversions[\\"boolean\\"](curArg, {
-			context: \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
-		});
-		args.push(curArg);
-	}
 } else {
 	{
 		let curArg = arguments[0];
 		curArg = conversions[\\"boolean\\"](curArg, {
 			context: \\"Failed to execute 'overloadsObjectOrBoolean' on 'NoUselessIfElse': parameter 1\\"
 		});
 		args.push(curArg);
 	}
 }
```

## Depends on:
- [ ] <https://github.com/jsdom/webidl2js/pull/231>