### PR TITLE
Create async iterators and iterator result objects in the correct realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,10 @@ This can be useful when you are given a wrapper, but need to modify its inaccess
 
 Returns the corresponding impl class instance for a given wrapper class instance, or returns the argument back if it is not an implementation class instance.
 
+### `registerConstructor(globalObject, key, constructor)`
+
+Tells webidl2js about a type associated with the given realm (`globalObject`). This can be called prior to installing interfaces to supply the correct in-realm value for types not exposed on the global object itself. Currently the only documented key is `"%AsyncIteratorPrototype%"`, for specifying the prototype to inherit from when creating async iterators.
+
 ## Web IDL features
 
 webidl2js is implementing an ever-growing subset of the Web IDL specification. So far we have implemented:

--- a/README.md
+++ b/README.md
@@ -451,10 +451,6 @@ This can be useful when you are given a wrapper, but need to modify its inaccess
 
 Returns the corresponding impl class instance for a given wrapper class instance, or returns the argument back if it is not an implementation class instance.
 
-### `registerIntrinsic(globalObject, key, intrinsic)`
-
-Tells webidl2js about a type or value (`intrinsic`) associated with the given realm (`globalObject`). This can be called prior to installing interfaces to supply the correct in-realm value for types not exposed on the global object itself. Currently the only documented key is `"%AsyncIteratorPrototype%"`, for specifying the prototype to inherit from when creating async iterators.
-
 ## Web IDL features
 
 webidl2js is implementing an ever-growing subset of the Web IDL specification. So far we have implemented:

--- a/README.md
+++ b/README.md
@@ -451,9 +451,9 @@ This can be useful when you are given a wrapper, but need to modify its inaccess
 
 Returns the corresponding impl class instance for a given wrapper class instance, or returns the argument back if it is not an implementation class instance.
 
-### `registerConstructor(globalObject, key, constructor)`
+### `registerIntrinsic(globalObject, key, intrinsic)`
 
-Tells webidl2js about a type associated with the given realm (`globalObject`). This can be called prior to installing interfaces to supply the correct in-realm value for types not exposed on the global object itself. Currently the only documented key is `"%AsyncIteratorPrototype%"`, for specifying the prototype to inherit from when creating async iterators.
+Tells webidl2js about a type or value (`intrinsic`) associated with the given realm (`globalObject`). This can be called prior to installing interfaces to supply the correct in-realm value for types not exposed on the global object itself. Currently the only documented key is `"%AsyncIteratorPrototype%"`, for specifying the prototype to inherit from when creating async iterators.
 
 ## Web IDL features
 

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -423,7 +423,9 @@ class Interface {
       return;
     }
 
+
     if (iterable.isAsync) {
+      this.requires.addRaw("newObjectInRealm", "utils.newObjectInRealm");
       this.str += `
         ctorRegistry["${this.name} AsyncIterator"] =
           Object.create(ctorRegistry["%AsyncIteratorPrototype%"], {
@@ -441,7 +443,7 @@ class Interface {
 
             const nextSteps = () => {
               if (internal.isFinished) {
-                return Promise.resolve({ value: undefined, done: true });
+                return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
               }
 
               const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -450,15 +452,15 @@ class Interface {
                   internal.ongoingPromise = null;
                   if (next === utils.asyncIteratorEOI) {
                     internal.isFinished = true;
-                    return { value: undefined, done: true };
+                    return newObjectInRealm(globalObject, { value: undefined, done: true });
                   }`;
       if (iterable.isPair) {
         this.str += `
-                  return utils.iteratorResult(next.map(utils.tryWrapperForImpl), kind);
+                  return newObjectInRealm(globalObject, utils.iteratorResult(next.map(utils.tryWrapperForImpl), kind));
         `;
       } else {
         this.str += `
-                  return { value: utils.tryWrapperForImpl(next), done: false };
+                  return newObjectInRealm(globalObject, { value: utils.tryWrapperForImpl(next), done: false });
         `;
       }
       this.str += `
@@ -488,7 +490,7 @@ class Interface {
 
             const returnSteps = () => {
               if (internal.isFinished) {
-                return Promise.resolve({ value, done: true });
+                return Promise.resolve(newObjectInRealm(globalObject, { value, done: true }));
               }
               internal.isFinished = true;
 
@@ -498,7 +500,7 @@ class Interface {
             const returnPromise = internal.ongoingPromise ?
               internal.ongoingPromise.then(returnSteps, returnSteps) :
               returnSteps();
-            return returnPromise.then(() => ({ value, done: true }));
+            return returnPromise.then(() => newObjectInRealm(globalObject, { value, done: true }));
           }
         `;
       }
@@ -506,6 +508,7 @@ class Interface {
         });
       `;
     } else if (iterable.isPair) {
+      this.requires.addRaw("newObjectInRealm", "utils.newObjectInRealm");
       this.str += `
         ctorRegistry["${this.name} Iterator"] =
           Object.create(ctorRegistry["%IteratorPrototype%"], {
@@ -527,12 +530,12 @@ class Interface {
               const values = Array.from(target[implSymbol]);
               const len = values.length;
               if (index >= len) {
-                return { value: undefined, done: true };
+                return newObjectInRealm(globalObject, { value: undefined, done: true });
               }
 
               const pair = values[index];
               internal.index = index + 1;
-              return utils.iteratorResult(pair.map(utils.tryWrapperForImpl), kind);
+              return newObjectInRealm(globalObject, utils.iteratorResult(pair.map(utils.tryWrapperForImpl), kind));
             }
           }
         );

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -423,7 +423,6 @@ class Interface {
       return;
     }
 
-
     if (iterable.isAsync) {
       this.requires.addRaw("newObjectInRealm", "utils.newObjectInRealm");
       this.str += `

--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -425,12 +425,13 @@ class Interface {
 
     if (iterable.isAsync) {
       this.str += `
-        ctorRegistry["${this.name} AsyncIterator"] = Object.create(utils.AsyncIteratorPrototype, {
-          [Symbol.toStringTag]: {
-            value: "${this.name} AsyncIterator",
-            configurable: true
-          }
-        });
+        ctorRegistry["${this.name} AsyncIterator"] =
+          Object.create(ctorRegistry["%AsyncIteratorPrototype%"], {
+            [Symbol.toStringTag]: {
+              value: "${this.name} AsyncIterator",
+              configurable: true
+            }
+          });
         utils.define(ctorRegistry["${this.name} AsyncIterator"], {
           next() {
             const internal = this && this[utils.iterInternalSymbol];

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -50,21 +50,14 @@ function initCtorRegistry(globalObject) {
   ctorRegistry["%IteratorPrototype%"] = Object.getPrototypeOf(
     Object.getPrototypeOf(new ctorRegistry["%Array%"]()[Symbol.iterator]())
   );
-  // This is (usually) the wrong realm's AsyncIteratorPrototype. Integrators
-  // should call registerIntrinsic() to specify the correct
-  // AsyncIteratorPrototype.
-  ctorRegistry["%AsyncIteratorPrototype%"] = AsyncIteratorPrototype;
+  ctorRegistry["%AsyncIteratorPrototype%"] = Object.getPrototypeOf(
+    Object.getPrototypeOf(
+      globalObject.eval("(async function* () {})").prototype
+    )
+  );
 
   globalObject[ctorRegistrySymbol] = ctorRegistry;
   return ctorRegistry;
-}
-
-// Associates a constructor or other intrinsic with the given global object.
-// Intended as a public utility for the purpose of registering
-// "%AsyncIteratorPrototype%".
-function registerIntrinsic(globalObject, key, intrinsic) {
-  const ctorRegistry = initCtorRegistry(globalObject);
-  ctorRegistry[key] = intrinsic;
 }
 
 function getSameObject(wrapper, prop, creator) {
@@ -169,7 +162,6 @@ module.exports = exports = {
   getSameObject,
   ctorRegistrySymbol,
   initCtorRegistry,
-  registerIntrinsic,
   wrapperForImpl,
   implForWrapper,
   tryWrapperForImpl,

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -50,6 +50,9 @@ function initCtorRegistry(globalObject) {
   ctorRegistry["%IteratorPrototype%"] = Object.getPrototypeOf(
     Object.getPrototypeOf(new ctorRegistry["%Array%"]()[Symbol.iterator]())
   );
+  // This is (usually) the wrong realm's AsyncIteratorPrototype. Integrators
+  // should call registerIntrinsic() to specify the correct
+  // AsyncIteratorPrototype.
   ctorRegistry["%AsyncIteratorPrototype%"] = AsyncIteratorPrototype;
 
   globalObject[ctorRegistrySymbol] = ctorRegistry;

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -34,9 +34,6 @@ const ctorRegistrySymbol = Symbol.for("[webidl2js]  constructor registry");
 // This only contains the intrinsic names that are referenced from the `ctorRegistry`:
 const intrinsicConstructors = ["Array"];
 
-// IteratorPrototype is unused, and AsyncIteratorPrototype doesn't need to be
-// exported. Consider removing at next major version bump.
-const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
 const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);
 
 function initCtorRegistry(globalObject) {
@@ -175,8 +172,6 @@ module.exports = exports = {
   tryWrapperForImpl,
   tryImplForWrapper,
   iterInternalSymbol,
-  IteratorPrototype,
-  AsyncIteratorPrototype,
   isArrayBuffer,
   isArrayIndexPropName,
   supportsPropertyIndex,

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -58,7 +58,7 @@ function initCtorRegistry(globalObject) {
         globalObject.eval("(async function* () {})").prototype
       )
     );
-  } catch (error) {
+  } catch {
     ctorRegistry["%AsyncIteratorPrototype%"] = AsyncIteratorPrototype;
   }
 

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -19,8 +19,9 @@ function define(target, source) {
 }
 
 function newObjectInRealm(globalObject, object) {
+  const ctorRegistry = initCtorRegistry(globalObject);
   return Object.defineProperties(
-    Object.create(globalObject.Object.prototype),
+    Object.create(ctorRegistry["%Object%"].prototype),
     Object.getOwnPropertyDescriptors(object)
   );
 }
@@ -31,7 +32,7 @@ const sameObjectCaches = Symbol("SameObject caches");
 const ctorRegistrySymbol = Symbol.for("[webidl2js]  constructor registry");
 
 // This only contains the intrinsic names that are referenced from the `ctorRegistry`:
-const intrinsicConstructors = ["Array"];
+const intrinsicConstructors = ["Array", "Object"];
 
 const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
 const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -21,7 +21,7 @@ function define(target, source) {
 function newObjectInRealm(globalObject, object) {
   const ctorRegistry = initCtorRegistry(globalObject);
   return Object.defineProperties(
-    Object.create(ctorRegistry["%Object%"].prototype),
+    Object.create(ctorRegistry["%Object.prototype%"]),
     Object.getOwnPropertyDescriptors(object)
   );
 }
@@ -32,7 +32,7 @@ const sameObjectCaches = Symbol("SameObject caches");
 const ctorRegistrySymbol = Symbol.for("[webidl2js]  constructor registry");
 
 // This only contains the intrinsic names that are referenced from the `ctorRegistry`:
-const intrinsicConstructors = ["Array", "Object"];
+const intrinsicConstructors = ["Array"];
 
 const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
 const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);
@@ -47,6 +47,7 @@ function initCtorRegistry(globalObject) {
     ctorRegistry[`%${intrinsic}%`] = globalObject[intrinsic];
   }
 
+  ctorRegistry["%Object.prototype%"] = globalObject.Object.prototype;
   ctorRegistry["%IteratorPrototype%"] = Object.getPrototypeOf(
     Object.getPrototypeOf(new ctorRegistry["%Array%"]()[Symbol.iterator]())
   );

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -26,6 +26,9 @@ const ctorRegistrySymbol = Symbol.for("[webidl2js]  constructor registry");
 // This only contains the intrinsic names that are referenced from the `ctorRegistry`:
 const intrinsicConstructors = ["Array"];
 
+const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);
+
 function initCtorRegistry(globalObject) {
   if (hasOwn(globalObject, ctorRegistrySymbol)) {
     return globalObject[ctorRegistrySymbol];
@@ -36,10 +39,10 @@ function initCtorRegistry(globalObject) {
     ctorRegistry[`%${intrinsic}%`] = globalObject[intrinsic];
   }
 
-  // TODO: Also capture `%AsyncIteratorPrototype%`
   ctorRegistry["%IteratorPrototype%"] = Object.getPrototypeOf(
     Object.getPrototypeOf(new ctorRegistry["%Array%"]()[Symbol.iterator]())
   );
+  ctorRegistry["%AsyncIteratorPrototype%"] = AsyncIteratorPrototype;
 
   globalObject[ctorRegistrySymbol] = ctorRegistry;
   return ctorRegistry;
@@ -77,8 +80,6 @@ function tryImplForWrapper(wrapper) {
 }
 
 const iterInternalSymbol = Symbol("internal");
-const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
-const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);
 
 function isArrayIndexPropName(P) {
   if (typeof P !== "string") {

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -51,11 +51,16 @@ function initCtorRegistry(globalObject) {
   ctorRegistry["%IteratorPrototype%"] = Object.getPrototypeOf(
     Object.getPrototypeOf(new ctorRegistry["%Array%"]()[Symbol.iterator]())
   );
-  ctorRegistry["%AsyncIteratorPrototype%"] = Object.getPrototypeOf(
-    Object.getPrototypeOf(
-      globalObject.eval("(async function* () {})").prototype
-    )
-  );
+
+  try {
+    ctorRegistry["%AsyncIteratorPrototype%"] = Object.getPrototypeOf(
+      Object.getPrototypeOf(
+        globalObject.eval("(async function* () {})").prototype
+      )
+    );
+  } catch (error) {
+    ctorRegistry["%AsyncIteratorPrototype%"] = AsyncIteratorPrototype;
+  }
 
   globalObject[ctorRegistrySymbol] = ctorRegistry;
   return ctorRegistry;

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -18,6 +18,13 @@ function define(target, source) {
   }
 }
 
+function newObjectInRealm(globalObject, object) {
+  return Object.defineProperties(
+    Object.create(globalObject.Object.prototype),
+    Object.getOwnPropertyDescriptors(object)
+  );
+}
+
 const wrapperSymbol = Symbol("wrapper");
 const implSymbol = Symbol("impl");
 const sameObjectCaches = Symbol("SameObject caches");
@@ -151,6 +158,7 @@ module.exports = exports = {
   isObject,
   hasOwn,
   define,
+  newObjectInRealm,
   wrapperSymbol,
   implSymbol,
   getSameObject,

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -56,11 +56,12 @@ function initCtorRegistry(globalObject) {
   return ctorRegistry;
 }
 
-// Associates a constructor with the given global object. Intended as a public
-// utility for the purpose of registering "%AsyncIteratorPrototype%".
-function registerConstructor(globalObject, key, constructor) {
+// Associates a constructor or other intrinsic with the given global object.
+// Intended as a public utility for the purpose of registering
+// "%AsyncIteratorPrototype%".
+function registerIntrinsic(globalObject, key, intrinsic) {
   const ctorRegistry = initCtorRegistry(globalObject);
-  ctorRegistry[key] = constructor;
+  ctorRegistry[key] = intrinsic;
 }
 
 function getSameObject(wrapper, prop, creator) {
@@ -165,7 +166,7 @@ module.exports = exports = {
   getSameObject,
   ctorRegistrySymbol,
   initCtorRegistry,
-  registerConstructor,
+  registerIntrinsic,
   wrapperForImpl,
   implForWrapper,
   tryWrapperForImpl,

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -48,6 +48,13 @@ function initCtorRegistry(globalObject) {
   return ctorRegistry;
 }
 
+// Associates a constructor with the given global object. Intended as a public
+// utility for the purpose of registering "%AsyncIteratorPrototype%".
+function registerConstructor(globalObject, key, constructor) {
+  const ctorRegistry = initCtorRegistry(globalObject);
+  ctorRegistry[key] = constructor;
+}
+
 function getSameObject(wrapper, prop, creator) {
   if (!wrapper[sameObjectCaches]) {
     wrapper[sameObjectCaches] = Object.create(null);
@@ -149,6 +156,7 @@ module.exports = exports = {
   getSameObject,
   ctorRegistrySymbol,
   initCtorRegistry,
+  registerConstructor,
   wrapperForImpl,
   implForWrapper,
   tryWrapperForImpl,

--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -34,6 +34,8 @@ const ctorRegistrySymbol = Symbol.for("[webidl2js]  constructor registry");
 // This only contains the intrinsic names that are referenced from the `ctorRegistry`:
 const intrinsicConstructors = ["Array"];
 
+// IteratorPrototype is unused, and AsyncIteratorPrototype doesn't need to be
+// exported. Consider removing at next major version bump.
 const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
 const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);
 

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -380,7 +380,7 @@ exports.install = (globalObject, globalNames) => {
   });
   ctorRegistry[interfaceName] = AsyncIterablePairArgs;
 
-  ctorRegistry[\\"AsyncIterablePairArgs AsyncIterator\\"] = Object.create(utils.AsyncIteratorPrototype, {
+  ctorRegistry[\\"AsyncIterablePairArgs AsyncIterator\\"] = Object.create(ctorRegistry[\\"%AsyncIteratorPrototype%\\"], {
     [Symbol.toStringTag]: {
       value: \\"AsyncIterablePairArgs AsyncIterator\\",
       configurable: true
@@ -592,7 +592,7 @@ exports.install = (globalObject, globalNames) => {
   });
   ctorRegistry[interfaceName] = AsyncIterablePairNoArgs;
 
-  ctorRegistry[\\"AsyncIterablePairNoArgs AsyncIterator\\"] = Object.create(utils.AsyncIteratorPrototype, {
+  ctorRegistry[\\"AsyncIterablePairNoArgs AsyncIterator\\"] = Object.create(ctorRegistry[\\"%AsyncIteratorPrototype%\\"], {
     [Symbol.toStringTag]: {
       value: \\"AsyncIterablePairNoArgs AsyncIterator\\",
       configurable: true
@@ -783,7 +783,7 @@ exports.install = (globalObject, globalNames) => {
   });
   ctorRegistry[interfaceName] = AsyncIterableValueArgs;
 
-  ctorRegistry[\\"AsyncIterableValueArgs AsyncIterator\\"] = Object.create(utils.AsyncIteratorPrototype, {
+  ctorRegistry[\\"AsyncIterableValueArgs AsyncIterator\\"] = Object.create(ctorRegistry[\\"%AsyncIteratorPrototype%\\"], {
     [Symbol.toStringTag]: {
       value: \\"AsyncIterableValueArgs AsyncIterator\\",
       configurable: true
@@ -965,7 +965,7 @@ exports.install = (globalObject, globalNames) => {
   });
   ctorRegistry[interfaceName] = AsyncIterableValueNoArgs;
 
-  ctorRegistry[\\"AsyncIterableValueNoArgs AsyncIterator\\"] = Object.create(utils.AsyncIteratorPrototype, {
+  ctorRegistry[\\"AsyncIterableValueNoArgs AsyncIterator\\"] = Object.create(ctorRegistry[\\"%AsyncIteratorPrototype%\\"], {
     [Symbol.toStringTag]: {
       value: \\"AsyncIterableValueNoArgs AsyncIterator\\",
       configurable: true
@@ -1152,7 +1152,7 @@ exports.install = (globalObject, globalNames) => {
   });
   ctorRegistry[interfaceName] = AsyncIterableWithReturn;
 
-  ctorRegistry[\\"AsyncIterableWithReturn AsyncIterator\\"] = Object.create(utils.AsyncIteratorPrototype, {
+  ctorRegistry[\\"AsyncIterableWithReturn AsyncIterator\\"] = Object.create(ctorRegistry[\\"%AsyncIteratorPrototype%\\"], {
     [Symbol.toStringTag]: {
       value: \\"AsyncIterableWithReturn AsyncIterator\\",
       configurable: true
@@ -10644,7 +10644,7 @@ exports.install = (globalObject, globalNames) => {
   });
   ctorRegistry[interfaceName] = AsyncIterablePairArgs;
 
-  ctorRegistry[\\"AsyncIterablePairArgs AsyncIterator\\"] = Object.create(utils.AsyncIteratorPrototype, {
+  ctorRegistry[\\"AsyncIterablePairArgs AsyncIterator\\"] = Object.create(ctorRegistry[\\"%AsyncIteratorPrototype%\\"], {
     [Symbol.toStringTag]: {
       value: \\"AsyncIterablePairArgs AsyncIterator\\",
       configurable: true
@@ -10856,7 +10856,7 @@ exports.install = (globalObject, globalNames) => {
   });
   ctorRegistry[interfaceName] = AsyncIterablePairNoArgs;
 
-  ctorRegistry[\\"AsyncIterablePairNoArgs AsyncIterator\\"] = Object.create(utils.AsyncIteratorPrototype, {
+  ctorRegistry[\\"AsyncIterablePairNoArgs AsyncIterator\\"] = Object.create(ctorRegistry[\\"%AsyncIteratorPrototype%\\"], {
     [Symbol.toStringTag]: {
       value: \\"AsyncIterablePairNoArgs AsyncIterator\\",
       configurable: true
@@ -11047,7 +11047,7 @@ exports.install = (globalObject, globalNames) => {
   });
   ctorRegistry[interfaceName] = AsyncIterableValueArgs;
 
-  ctorRegistry[\\"AsyncIterableValueArgs AsyncIterator\\"] = Object.create(utils.AsyncIteratorPrototype, {
+  ctorRegistry[\\"AsyncIterableValueArgs AsyncIterator\\"] = Object.create(ctorRegistry[\\"%AsyncIteratorPrototype%\\"], {
     [Symbol.toStringTag]: {
       value: \\"AsyncIterableValueArgs AsyncIterator\\",
       configurable: true
@@ -11229,7 +11229,7 @@ exports.install = (globalObject, globalNames) => {
   });
   ctorRegistry[interfaceName] = AsyncIterableValueNoArgs;
 
-  ctorRegistry[\\"AsyncIterableValueNoArgs AsyncIterator\\"] = Object.create(utils.AsyncIteratorPrototype, {
+  ctorRegistry[\\"AsyncIterableValueNoArgs AsyncIterator\\"] = Object.create(ctorRegistry[\\"%AsyncIteratorPrototype%\\"], {
     [Symbol.toStringTag]: {
       value: \\"AsyncIterableValueNoArgs AsyncIterator\\",
       configurable: true
@@ -11416,7 +11416,7 @@ exports.install = (globalObject, globalNames) => {
   });
   ctorRegistry[interfaceName] = AsyncIterableWithReturn;
 
-  ctorRegistry[\\"AsyncIterableWithReturn AsyncIterator\\"] = Object.create(utils.AsyncIteratorPrototype, {
+  ctorRegistry[\\"AsyncIterableWithReturn AsyncIterator\\"] = Object.create(ctorRegistry[\\"%AsyncIteratorPrototype%\\"], {
     [Symbol.toStringTag]: {
       value: \\"AsyncIterableWithReturn AsyncIterator\\",
       configurable: true

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -167,6 +167,7 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const Dictionary = require(\\"./Dictionary.js\\");
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -397,7 +398,7 @@ exports.install = (globalObject, globalNames) => {
 
       const nextSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
         }
 
         const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -406,9 +407,9 @@ exports.install = (globalObject, globalNames) => {
             internal.ongoingPromise = null;
             if (next === utils.asyncIteratorEOI) {
               internal.isFinished = true;
-              return { value: undefined, done: true };
+              return newObjectInRealm(globalObject, { value: undefined, done: true });
             }
-            return utils.iteratorResult(next.map(utils.tryWrapperForImpl), kind);
+            return newObjectInRealm(globalObject, utils.iteratorResult(next.map(utils.tryWrapperForImpl), kind));
           },
           reason => {
             internal.ongoingPromise = null;
@@ -442,6 +443,7 @@ exports[`generation with processors AsyncIterablePairNoArgs.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -609,7 +611,7 @@ exports.install = (globalObject, globalNames) => {
 
       const nextSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
         }
 
         const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -618,9 +620,9 @@ exports.install = (globalObject, globalNames) => {
             internal.ongoingPromise = null;
             if (next === utils.asyncIteratorEOI) {
               internal.isFinished = true;
-              return { value: undefined, done: true };
+              return newObjectInRealm(globalObject, { value: undefined, done: true });
             }
-            return utils.iteratorResult(next.map(utils.tryWrapperForImpl), kind);
+            return newObjectInRealm(globalObject, utils.iteratorResult(next.map(utils.tryWrapperForImpl), kind));
           },
           reason => {
             internal.ongoingPromise = null;
@@ -655,6 +657,7 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -800,7 +803,7 @@ exports.install = (globalObject, globalNames) => {
 
       const nextSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
         }
 
         const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -809,9 +812,9 @@ exports.install = (globalObject, globalNames) => {
             internal.ongoingPromise = null;
             if (next === utils.asyncIteratorEOI) {
               internal.isFinished = true;
-              return { value: undefined, done: true };
+              return newObjectInRealm(globalObject, { value: undefined, done: true });
             }
-            return { value: utils.tryWrapperForImpl(next), done: false };
+            return newObjectInRealm(globalObject, { value: utils.tryWrapperForImpl(next), done: false });
           },
           reason => {
             internal.ongoingPromise = null;
@@ -845,6 +848,7 @@ exports[`generation with processors AsyncIterableValueNoArgs.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -982,7 +986,7 @@ exports.install = (globalObject, globalNames) => {
 
       const nextSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
         }
 
         const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -991,9 +995,9 @@ exports.install = (globalObject, globalNames) => {
             internal.ongoingPromise = null;
             if (next === utils.asyncIteratorEOI) {
               internal.isFinished = true;
-              return { value: undefined, done: true };
+              return newObjectInRealm(globalObject, { value: undefined, done: true });
             }
-            return { value: utils.tryWrapperForImpl(next), done: false };
+            return newObjectInRealm(globalObject, { value: utils.tryWrapperForImpl(next), done: false });
           },
           reason => {
             internal.ongoingPromise = null;
@@ -1028,6 +1032,7 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const Dictionary = require(\\"./Dictionary.js\\");
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -1169,7 +1174,7 @@ exports.install = (globalObject, globalNames) => {
 
       const nextSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
         }
 
         const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -1178,9 +1183,9 @@ exports.install = (globalObject, globalNames) => {
             internal.ongoingPromise = null;
             if (next === utils.asyncIteratorEOI) {
               internal.isFinished = true;
-              return { value: undefined, done: true };
+              return newObjectInRealm(globalObject, { value: undefined, done: true });
             }
-            return { value: utils.tryWrapperForImpl(next), done: false };
+            return newObjectInRealm(globalObject, { value: utils.tryWrapperForImpl(next), done: false });
           },
           reason => {
             internal.ongoingPromise = null;
@@ -1206,7 +1211,7 @@ exports.install = (globalObject, globalNames) => {
 
       const returnSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value, done: true }));
         }
         internal.isFinished = true;
 
@@ -1216,7 +1221,7 @@ exports.install = (globalObject, globalNames) => {
       const returnPromise = internal.ongoingPromise
         ? internal.ongoingPromise.then(returnSteps, returnSteps)
         : returnSteps();
-      return returnPromise.then(() => ({ value, done: true }));
+      return returnPromise.then(() => newObjectInRealm(globalObject, { value, done: true }));
     }
   });
 
@@ -8448,6 +8453,7 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const Function = require(\\"./Function.js\\");
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -8880,12 +8886,12 @@ exports.install = (globalObject, globalNames) => {
       const values = Array.from(target[implSymbol]);
       const len = values.length;
       if (index >= len) {
-        return { value: undefined, done: true };
+        return newObjectInRealm(globalObject, { value: undefined, done: true });
       }
 
       const pair = values[index];
       internal.index = index + 1;
-      return utils.iteratorResult(pair.map(utils.tryWrapperForImpl), kind);
+      return newObjectInRealm(globalObject, utils.iteratorResult(pair.map(utils.tryWrapperForImpl), kind));
     }
   });
 
@@ -10431,6 +10437,7 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const Dictionary = require(\\"./Dictionary.js\\");
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -10661,7 +10668,7 @@ exports.install = (globalObject, globalNames) => {
 
       const nextSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
         }
 
         const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -10670,9 +10677,9 @@ exports.install = (globalObject, globalNames) => {
             internal.ongoingPromise = null;
             if (next === utils.asyncIteratorEOI) {
               internal.isFinished = true;
-              return { value: undefined, done: true };
+              return newObjectInRealm(globalObject, { value: undefined, done: true });
             }
-            return utils.iteratorResult(next.map(utils.tryWrapperForImpl), kind);
+            return newObjectInRealm(globalObject, utils.iteratorResult(next.map(utils.tryWrapperForImpl), kind));
           },
           reason => {
             internal.ongoingPromise = null;
@@ -10706,6 +10713,7 @@ exports[`generation without processors AsyncIterablePairNoArgs.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -10873,7 +10881,7 @@ exports.install = (globalObject, globalNames) => {
 
       const nextSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
         }
 
         const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -10882,9 +10890,9 @@ exports.install = (globalObject, globalNames) => {
             internal.ongoingPromise = null;
             if (next === utils.asyncIteratorEOI) {
               internal.isFinished = true;
-              return { value: undefined, done: true };
+              return newObjectInRealm(globalObject, { value: undefined, done: true });
             }
-            return utils.iteratorResult(next.map(utils.tryWrapperForImpl), kind);
+            return newObjectInRealm(globalObject, utils.iteratorResult(next.map(utils.tryWrapperForImpl), kind));
           },
           reason => {
             internal.ongoingPromise = null;
@@ -10919,6 +10927,7 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const URL = require(\\"./URL.js\\");
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -11064,7 +11073,7 @@ exports.install = (globalObject, globalNames) => {
 
       const nextSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
         }
 
         const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -11073,9 +11082,9 @@ exports.install = (globalObject, globalNames) => {
             internal.ongoingPromise = null;
             if (next === utils.asyncIteratorEOI) {
               internal.isFinished = true;
-              return { value: undefined, done: true };
+              return newObjectInRealm(globalObject, { value: undefined, done: true });
             }
-            return { value: utils.tryWrapperForImpl(next), done: false };
+            return newObjectInRealm(globalObject, { value: utils.tryWrapperForImpl(next), done: false });
           },
           reason => {
             internal.ongoingPromise = null;
@@ -11109,6 +11118,7 @@ exports[`generation without processors AsyncIterableValueNoArgs.webidl 1`] = `
 const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -11246,7 +11256,7 @@ exports.install = (globalObject, globalNames) => {
 
       const nextSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
         }
 
         const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -11255,9 +11265,9 @@ exports.install = (globalObject, globalNames) => {
             internal.ongoingPromise = null;
             if (next === utils.asyncIteratorEOI) {
               internal.isFinished = true;
-              return { value: undefined, done: true };
+              return newObjectInRealm(globalObject, { value: undefined, done: true });
             }
-            return { value: utils.tryWrapperForImpl(next), done: false };
+            return newObjectInRealm(globalObject, { value: utils.tryWrapperForImpl(next), done: false });
           },
           reason => {
             internal.ongoingPromise = null;
@@ -11292,6 +11302,7 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const Dictionary = require(\\"./Dictionary.js\\");
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -11433,7 +11444,7 @@ exports.install = (globalObject, globalNames) => {
 
       const nextSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value: undefined, done: true }));
         }
 
         const nextPromise = internal.target[implSymbol][utils.asyncIteratorNext](this);
@@ -11442,9 +11453,9 @@ exports.install = (globalObject, globalNames) => {
             internal.ongoingPromise = null;
             if (next === utils.asyncIteratorEOI) {
               internal.isFinished = true;
-              return { value: undefined, done: true };
+              return newObjectInRealm(globalObject, { value: undefined, done: true });
             }
-            return { value: utils.tryWrapperForImpl(next), done: false };
+            return newObjectInRealm(globalObject, { value: utils.tryWrapperForImpl(next), done: false });
           },
           reason => {
             internal.ongoingPromise = null;
@@ -11470,7 +11481,7 @@ exports.install = (globalObject, globalNames) => {
 
       const returnSteps = () => {
         if (internal.isFinished) {
-          return Promise.resolve({ value, done: true });
+          return Promise.resolve(newObjectInRealm(globalObject, { value, done: true }));
         }
         internal.isFinished = true;
 
@@ -11480,7 +11491,7 @@ exports.install = (globalObject, globalNames) => {
       const returnPromise = internal.ongoingPromise
         ? internal.ongoingPromise.then(returnSteps, returnSteps)
         : returnSteps();
-      return returnPromise.then(() => ({ value, done: true }));
+      return returnPromise.then(() => newObjectInRealm(globalObject, { value, done: true }));
     }
   });
 
@@ -18655,6 +18666,7 @@ const conversions = require(\\"webidl-conversions\\");
 const utils = require(\\"./utils.js\\");
 
 const Function = require(\\"./Function.js\\");
+const newObjectInRealm = utils.newObjectInRealm;
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
@@ -19087,12 +19099,12 @@ exports.install = (globalObject, globalNames) => {
       const values = Array.from(target[implSymbol]);
       const len = values.length;
       if (index >= len) {
-        return { value: undefined, done: true };
+        return newObjectInRealm(globalObject, { value: undefined, done: true });
       }
 
       const pair = values[index];
       internal.index = index + 1;
-      return utils.iteratorResult(pair.map(utils.tryWrapperForImpl), kind);
+      return newObjectInRealm(globalObject, utils.iteratorResult(pair.map(utils.tryWrapperForImpl), kind));
     }
   });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -48,4 +48,22 @@ describe("utils.js", () => {
       expect(globalObject[utils.ctorRegistrySymbol]).toBeDefined();
     });
   });
+
+  describe("newObjectInRealm", () => {
+    test("creates a new object in the given realm with the properties of the given object", () => {
+      const realm = { Object: function Object() {}, Array };
+      const object = utils.newObjectInRealm(realm, { foo: 42 });
+      expect(object).toBeInstanceOf(realm.Object);
+      expect(object).toEqual({ foo: 42 });
+    });
+
+    test("uses the captured intrinsic Object, not the current realm.Object", () => {
+      const realm = { Object, Array };
+      utils.initCtorRegistry(realm);
+      realm.Object = function Object() {};
+      const object = utils.newObjectInRealm(realm, {});
+      expect(object).toBeInstanceOf(Object);
+      expect(object).not.toBeInstanceOf(realm.Object);
+    });
+  });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -31,4 +31,21 @@ describe("utils.js", () => {
       expect(utils.isObject(() => {})).toBe(true);
     });
   });
+
+  describe("registerConstructor", () => {
+    test("sets a value in the ctorRegistry", () => {
+      const globalObject = { Array };
+      const ctorRegistry = utils.initCtorRegistry(globalObject);
+      expect(ctorRegistry["%AsyncIteratorPrototype%"]).toBe(utils.AsyncIteratorPrototype);
+      const asyncIteratorPrototype = {};
+      utils.registerConstructor(globalObject, "%AsyncIteratorPrototype%", asyncIteratorPrototype);
+      expect(ctorRegistry["%AsyncIteratorPrototype%"]).toBe(asyncIteratorPrototype);
+    });
+
+    test("initializes the ctorRegistry if it doesn't exist", () => {
+      const globalObject = { Array };
+      utils.registerConstructor(globalObject, "%AsyncIteratorPrototype%", {});
+      expect(globalObject[utils.ctorRegistrySymbol]).toBeDefined();
+    });
+  });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -34,16 +34,14 @@ describe("utils.js", () => {
 
   describe("newObjectInRealm", () => {
     test("creates a new object in the given realm with the properties of the given object", () => {
-      // eslint-disable-next-line no-eval
-      const realm = { Object: function Object() {}, Array, eval };
+      const realm = { Object: function Object() {}, Array };
       const object = utils.newObjectInRealm(realm, { foo: 42 });
       expect(object).toBeInstanceOf(realm.Object);
       expect(object).toEqual({ foo: 42 });
     });
 
     test("uses the captured intrinsic Object, not the current realm.Object", () => {
-      // eslint-disable-next-line no-eval
-      const realm = { Object, Array, eval };
+      const realm = { Object, Array };
       utils.initCtorRegistry(realm);
       realm.Object = function Object() {};
       const object = utils.newObjectInRealm(realm, {});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -32,33 +32,18 @@ describe("utils.js", () => {
     });
   });
 
-  describe("registerIntrinsic", () => {
-    test("sets a value in the ctorRegistry", () => {
-      const globalObject = { Array };
-      const ctorRegistry = utils.initCtorRegistry(globalObject);
-      expect(ctorRegistry["%AsyncIteratorPrototype%"]).toBe(utils.AsyncIteratorPrototype);
-      const asyncIteratorPrototype = {};
-      utils.registerIntrinsic(globalObject, "%AsyncIteratorPrototype%", asyncIteratorPrototype);
-      expect(ctorRegistry["%AsyncIteratorPrototype%"]).toBe(asyncIteratorPrototype);
-    });
-
-    test("initializes the ctorRegistry if it doesn't exist", () => {
-      const globalObject = { Array };
-      utils.registerIntrinsic(globalObject, "%AsyncIteratorPrototype%", {});
-      expect(globalObject[utils.ctorRegistrySymbol]).toBeDefined();
-    });
-  });
-
   describe("newObjectInRealm", () => {
     test("creates a new object in the given realm with the properties of the given object", () => {
-      const realm = { Object: function Object() {}, Array };
+      // eslint-disable-next-line no-eval
+      const realm = { Object: function Object() {}, Array, eval };
       const object = utils.newObjectInRealm(realm, { foo: 42 });
       expect(object).toBeInstanceOf(realm.Object);
       expect(object).toEqual({ foo: 42 });
     });
 
     test("uses the captured intrinsic Object, not the current realm.Object", () => {
-      const realm = { Object, Array };
+      // eslint-disable-next-line no-eval
+      const realm = { Object, Array, eval };
       utils.initCtorRegistry(realm);
       realm.Object = function Object() {};
       const object = utils.newObjectInRealm(realm, {});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -32,19 +32,19 @@ describe("utils.js", () => {
     });
   });
 
-  describe("registerConstructor", () => {
+  describe("registerIntrinsic", () => {
     test("sets a value in the ctorRegistry", () => {
       const globalObject = { Array };
       const ctorRegistry = utils.initCtorRegistry(globalObject);
       expect(ctorRegistry["%AsyncIteratorPrototype%"]).toBe(utils.AsyncIteratorPrototype);
       const asyncIteratorPrototype = {};
-      utils.registerConstructor(globalObject, "%AsyncIteratorPrototype%", asyncIteratorPrototype);
+      utils.registerIntrinsic(globalObject, "%AsyncIteratorPrototype%", asyncIteratorPrototype);
       expect(ctorRegistry["%AsyncIteratorPrototype%"]).toBe(asyncIteratorPrototype);
     });
 
     test("initializes the ctorRegistry if it doesn't exist", () => {
       const globalObject = { Array };
-      utils.registerConstructor(globalObject, "%AsyncIteratorPrototype%", {});
+      utils.registerIntrinsic(globalObject, "%AsyncIteratorPrototype%", {});
       expect(globalObject[utils.ctorRegistrySymbol]).toBeDefined();
     });
   });


### PR DESCRIPTION
This PR intends to allow webidl2js to use the correct realm's `AsyncIteratorPrototype`. It uses a structure similar to https://github.com/jsdom/webidl2js/pull/234, registering an `AsyncIteratorPrototype` in each global object's `ctorRegistry` and inheriting from that prototype in `install()`.

#234 obtained the `IteratorPrototype` from `globalObject.Array`; unfortunately, afaik there are no ecmascript globals that link to the `AsyncIteratorPrototype`, so that approach is not possible here.

~~This PR exposes a utility, `registerConstructor(globalObject, key, constructor)` (bikeshedding appreciated), which sets a binding in the `globalObject`'s `ctorRegistry`. Consumers can use this to register the correct `AsyncIteratorPrototype` prior to installing interfaces on their global object, using the key `"%AsyncIteratorPrototype%"`.~~

**Updated:** This PR uses `globalObject.eval("(async function* () {})")` to find the correct realm's `AsyncIteratorPrototype`. It also creates the iterator result objects (`{value, done}`) in the correct realm, though it does not use the correct realm's `Promise`s.

As a fallback, if `eval()` doesn't work, `initCtorRegistry()` initializes `"%AsyncIteratorPrototype%"` to the generated class's realm's `AsyncIteratorPrototype`.

Helps with https://github.com/jsdom/jsdom/pull/3200.

I'm not sure how to test this. Does `webidl2js` currently have any form of behavior testing, or just generated code snapshots? Currently, I'm testing by linking this into a local fork of jsdom.

Remaining issues:
- [x] the `{value, done}` objects returned by the async iterator are still created in the wrong realm, causing `readable-streams/async-iterator.any.js` to still fail...