### PR TITLE
Avoid "TypeError: Cannot convert undefined or null to object" in Angular Universal

### DIFF
--- a/lib/output/utils.js
+++ b/lib/output/utils.js
@@ -31,7 +31,8 @@ const implSymbol = Symbol("impl");
 const sameObjectCaches = Symbol("SameObject caches");
 const ctorRegistrySymbol = Symbol.for("[webidl2js] constructor registry");
 
-const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);
+const AsyncFnPrototype = Object.getPrototypeOf(async function* () {}).prototype;
+const AsyncIteratorPrototype = AsyncFnPrototype && Object.getPrototypeOf(AsyncFnPrototype);
 
 function initCtorRegistry(globalObject) {
   if (hasOwn(globalObject, ctorRegistrySymbol)) {


### PR DESCRIPTION
Sorry for the somewhat odd PR, but this issue is making the MongoDB Node driver and Mongoose fail in Angular Universal. Angular Universal does some strange transpiling that breaks how this lib is getting AsyncIteratorPrototype.

I tracked this down from https://github.com/Automattic/mongoose/issues/11155, https://github.com/angular/angular-cli/issues/21735, and opened a PR to work around this issue in Angular here: https://github.com/angular/angular-cli/pull/22550. 