### PR TITLE
Inline legacy platform object property lookups

### DIFF
--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -674,6 +674,72 @@ class Interface {
       return conditions.join(" && ");
     }
 
+    const generatePropertyLookup = ({ indexedResult, namedResult }) => {
+      const suppressNamedPropertiesForIndexes = this.supportsIndexedProperties && this.supportsNamedProperties;
+      let output = suppressNamedPropertiesForIndexes ? "let ignoreNamedProps = false;\n" : "";
+
+      if (this.supportsIndexedProperties) {
+        const func = this.indexedGetter.name ? `.${this.indexedGetter.name}` : "[utils.indexedGet]";
+        let lookup;
+        if (utils.getExtAttr(this.indexedGetter.extAttrs, "WebIDL2JSValueAsUnsupported")) {
+          lookup = `
+            const indexedValue = target[implSymbol]${func}(index);
+            if (${supportsPropertyIndex("target", "index", "indexedValue")}) {
+              ${indexedResult("indexedValue")}
+            }
+          `;
+        } else {
+          lookup = `
+            if (${supportsPropertyIndex("target", "index")}) {
+              const indexedValue = target[implSymbol]${func}(index);
+              ${indexedResult("indexedValue")}
+            }
+          `;
+        }
+
+        output += `
+          if (utils.isArrayIndexPropName(P)) {
+            const index = P >>> 0;
+            ${lookup}
+            ${suppressNamedPropertiesForIndexes ? "ignoreNamedProps = true;" : ""}
+          }
+        `;
+      }
+
+      if (this.supportsNamedProperties) {
+        const func = this.namedGetter.name ? `.${this.namedGetter.name}` : "[utils.namedGet]";
+        let lookup;
+        if (utils.getExtAttr(this.namedGetter.extAttrs, "WebIDL2JSValueAsUnsupported")) {
+          lookup = `
+            const namedValue = target[implSymbol]${func}(P);
+            if (${supportsPropertyName("target", "P", "namedValue")} &&
+                ${namedPropertyVisible("P", "target", true)}) {
+              ${namedResult("namedValue")}
+            }
+          `;
+        } else {
+          lookup = `
+            if (${namedPropertyVisible("P", "target", false)}) {
+              const namedValue = target[implSymbol]${func}(P);
+              ${namedResult("namedValue")}
+            }
+          `;
+        }
+
+        if (suppressNamedPropertiesForIndexes) {
+          output += `
+            if (!ignoreNamedProps) {
+              ${lookup}
+            }
+          `;
+        } else {
+          output += lookup;
+        }
+      }
+
+      return output;
+    };
+
     // "invoke an indexed property setter"
     const invokeIndexedSetter = (O, P, V) => {
       const arg = this.indexedSetter.arguments[1];
@@ -775,22 +841,11 @@ class Interface {
           if (typeof P === "symbol") {
             return Reflect.get(target, P, receiver);
           }
-          const desc = this.getOwnPropertyDescriptor(target, P);
-          if (desc === undefined) {
-            const parent = Object.getPrototypeOf(target);
-            if (parent === null) {
-              return undefined;
-            }
-            return Reflect.get(target, P, receiver);
-          }
-          if (!desc.get && !desc.set) {
-            return desc.value;
-          }
-          const getter = desc.get;
-          if (getter === undefined) {
-            return undefined;
-          }
-          return Reflect.apply(getter, receiver, []);
+          ${generatePropertyLookup({
+            indexedResult: value => `return utils.tryWrapperForImpl(${value});`,
+            namedResult: value => `return utils.tryWrapperForImpl(${value});`
+          })}
+          return Reflect.get(target, P, receiver);
         }
     `;
 
@@ -844,75 +899,26 @@ class Interface {
     `;
 
     // [[GetOwnProperty]]
+    const namedEnumerable = !utils.getExtAttr(this.idl.extAttrs, "LegacyUnenumerableNamedProperties");
     this.str += `
         getOwnPropertyDescriptor(target, P) {
           if (typeof P === "symbol") {
             return Reflect.getOwnPropertyDescriptor(target, P);
           }
-          let ignoreNamedProps = false;
-    `;
-    if (this.supportsIndexedProperties) {
-      this.str += `
-          if (utils.isArrayIndexPropName(P)) {
-            const index = P >>> 0;
-      `;
-
-      const func = this.indexedGetter.name ? `.${this.indexedGetter.name}` : "[utils.indexedGet]";
-      let preamble = "";
-      let condition;
-      if (utils.getExtAttr(this.indexedGetter.extAttrs, "WebIDL2JSValueAsUnsupported")) {
-        this.str += `const indexedValue = target[implSymbol]${func}(index);`;
-        condition = supportsPropertyIndex("target", "index", "indexedValue");
-      } else {
-        preamble = `const indexedValue = target[implSymbol]${func}(index);`;
-        condition = supportsPropertyIndex("target", "index");
-      }
-
-      this.str += `
-            if (${condition}) {
-              ${preamble}
-              return {
-                writable: ${hasIndexedSetter},
-                enumerable: true,
-                configurable: true,
-                value: utils.tryWrapperForImpl(indexedValue)
-              };
-            }
-            ignoreNamedProps = true;
-          }
-      `;
-    }
-    if (this.supportsNamedProperties) {
-      const func = this.namedGetter.name ? `.${this.namedGetter.name}` : "[utils.namedGet]";
-      const enumerable = !utils.getExtAttr(this.idl.extAttrs, "LegacyUnenumerableNamedProperties");
-      let preamble = "";
-      const conditions = [];
-      if (utils.getExtAttr(this.namedGetter.extAttrs, "WebIDL2JSValueAsUnsupported")) {
-        this.str += `
-          const namedValue = target[implSymbol]${func}(P);
-        `;
-        conditions.push(supportsPropertyName("target", "index", "namedValue"));
-        conditions.push(namedPropertyVisible("P", "target", true));
-      } else {
-        preamble = `
-          const namedValue = target[implSymbol]${func}(P);
-        `;
-        conditions.push(namedPropertyVisible("P", "target", false));
-      }
-      conditions.push("!ignoreNamedProps");
-      this.str += `
-          if (${conditions.join(" && ")}) {
-            ${preamble}
-            return {
-              writable: ${hasNamedSetter},
-              enumerable: ${enumerable},
+          ${generatePropertyLookup({
+            indexedResult: value => `return {
+              writable: ${hasIndexedSetter},
+              enumerable: true,
               configurable: true,
-              value: utils.tryWrapperForImpl(namedValue)
-            };
-          }
-      `;
-    }
-    this.str += `
+              value: utils.tryWrapperForImpl(${value})
+            };`,
+            namedResult: value => `return {
+              writable: ${hasNamedSetter},
+              enumerable: ${namedEnumerable},
+              configurable: true,
+              value: utils.tryWrapperForImpl(${value})
+            };`
+          })}
           return Reflect.getOwnPropertyDescriptor(target, P);
         }
     `;

--- a/test/cases/LegacyOverrideBuiltins.webidl
+++ b/test/cases/LegacyOverrideBuiltins.webidl
@@ -1,0 +1,4 @@
+[Exposed=Window, LegacyOverrideBuiltins]
+interface LegacyOverrideBuiltins {
+  getter DOMString (DOMString name);
+};

--- a/test/implementations/HTMLCollection.js
+++ b/test/implementations/HTMLCollection.js
@@ -1,0 +1,24 @@
+"use strict";
+
+exports.implementation = class HTMLCollectionImpl {
+  constructor(globalObject, constructorArgs, { indexed = [], named = {} }) {
+    this._indexed = indexed;
+    this._named = named;
+    this.indexedCalls = [];
+    this.namedCalls = [];
+  }
+
+  get length() {
+    return this._indexed.length;
+  }
+
+  item(index) {
+    this.indexedCalls.push(index);
+    return this._indexed[index] ?? null;
+  }
+
+  namedItem(name) {
+    this.namedCalls.push(name);
+    return this._named[name] ?? null;
+  }
+};

--- a/test/implementations/LegacyOverrideBuiltins.js
+++ b/test/implementations/LegacyOverrideBuiltins.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const utils = require("../output/utils.js");
+
+exports.implementation = class LegacyOverrideBuiltinsImpl {
+  constructor(globalObject, constructorArgs, { entries = {} }) {
+    this._entries = entries;
+  }
+
+  [utils.supportsPropertyName](name) {
+    return Object.hasOwn(this._entries, name);
+  }
+
+  [utils.namedGet](name) {
+    return this._entries[name];
+  }
+};

--- a/test/implementations/URLList.js
+++ b/test/implementations/URLList.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const utils = require("../output/utils.js");
+
+exports.implementation = class URLListImpl {
+  constructor(globalObject, constructorArgs, { values = [] }) {
+    this._values = values;
+  }
+
+  get length() {
+    return this._values.length;
+  }
+
+  [utils.supportsPropertyIndex](index) {
+    return index < this.length;
+  }
+
+  item(index) {
+    return this._values[index];
+  }
+};

--- a/test/snapshots/with-processors/CEReactions.js
+++ b/test/snapshots/with-processors/CEReactions.js
@@ -221,22 +221,13 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
-      }
-      return Reflect.get(target, P, receiver);
+
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
+      return utils.tryWrapperForImpl(namedValue);
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
-    }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -273,11 +264,9 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.getOwnPropertyDescriptor(target, P);
     }
-    let ignoreNamedProps = false;
 
-    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
       const namedValue = target[implSymbol][utils.namedGet](P);
-
       return {
         writable: true,
         enumerable: true,

--- a/test/snapshots/with-processors/HTMLCollection.js
+++ b/test/snapshots/with-processors/HTMLCollection.js
@@ -190,22 +190,27 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      const indexedValue = target[implSymbol].item(index);
+      if (indexedValue !== null) {
+        return utils.tryWrapperForImpl(indexedValue);
       }
-      return Reflect.get(target, P, receiver);
+
+      ignoreNamedProps = true;
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
+
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return utils.tryWrapperForImpl(namedValue);
+      }
     }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -250,6 +255,7 @@ class ProxyHandler {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
+
       const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== null) {
         return {
@@ -259,18 +265,20 @@ class ProxyHandler {
           value: utils.tryWrapperForImpl(indexedValue)
         };
       }
+
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[implSymbol].namedItem(P);
-
-    if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
-      return {
-        writable: false,
-        enumerable: false,
-        configurable: true,
-        value: utils.tryWrapperForImpl(namedValue)
-      };
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return {
+          writable: false,
+          enumerable: false,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);

--- a/test/snapshots/with-processors/HTMLFormControlsCollection.js
+++ b/test/snapshots/with-processors/HTMLFormControlsCollection.js
@@ -156,22 +156,27 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      const indexedValue = target[implSymbol].item(index);
+      if (indexedValue !== null) {
+        return utils.tryWrapperForImpl(indexedValue);
       }
-      return Reflect.get(target, P, receiver);
+
+      ignoreNamedProps = true;
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
+
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return utils.tryWrapperForImpl(namedValue);
+      }
     }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -216,6 +221,7 @@ class ProxyHandler {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
+
       const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== null) {
         return {
@@ -225,18 +231,20 @@ class ProxyHandler {
           value: utils.tryWrapperForImpl(indexedValue)
         };
       }
+
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[implSymbol].namedItem(P);
-
-    if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
-      return {
-        writable: false,
-        enumerable: true,
-        configurable: true,
-        value: utils.tryWrapperForImpl(namedValue)
-      };
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return {
+          writable: false,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);

--- a/test/snapshots/with-processors/LegacyOverrideBuiltins.js
+++ b/test/snapshots/with-processors/LegacyOverrideBuiltins.js
@@ -6,7 +6,7 @@ const utils = require("./utils.js");
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
-const interfaceName = "URLList";
+const interfaceName = "LegacyOverrideBuiltins";
 
 exports.is = value => {
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
@@ -18,7 +18,7 @@ exports.convert = (globalObject, value, { context = "The provided value" } = {})
   if (exports.is(value)) {
     return utils.implForWrapper(value);
   }
-  throw new globalObject.TypeError(`${context} is not of type 'URLList'.`);
+  throw new globalObject.TypeError(`${context} is not of type 'LegacyOverrideBuiltins'.`);
 };
 
 function makeWrapper(globalObject, newTarget) {
@@ -28,7 +28,7 @@ function makeWrapper(globalObject, newTarget) {
   }
 
   if (!utils.isObject(proto)) {
-    proto = globalObject[ctorRegistrySymbol]["URLList"].prototype;
+    proto = globalObject[ctorRegistrySymbol]["LegacyOverrideBuiltins"].prototype;
   }
 
   return Object.create(proto);
@@ -99,60 +99,20 @@ exports.install = (globalObject, globalNames) => {
   }
 
   const ctorRegistry = utils.initCtorRegistry(globalObject);
-  class URLList {
+  class LegacyOverrideBuiltins {
     constructor() {
       throw new globalObject.TypeError("Illegal constructor");
     }
-
-    item(index) {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-      if (!exports.is(esValue)) {
-        throw new globalObject.TypeError("'item' called on an object that is not a valid instance of URLList.");
-      }
-
-      if (arguments.length < 1) {
-        throw new globalObject.TypeError(
-          `Failed to execute 'item' on 'URLList': 1 argument required, but only ${arguments.length} present.`
-        );
-      }
-      const args = [];
-      {
-        let curArg = arguments[0];
-        curArg = conversions["unsigned long"](curArg, {
-          context: "Failed to execute 'item' on 'URLList': parameter 1",
-          globals: globalObject
-        });
-        args.push(curArg);
-      }
-      return utils.tryWrapperForImpl(esValue[implSymbol].item(...args));
-    }
-
-    get length() {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      if (!exports.is(esValue)) {
-        throw new globalObject.TypeError("'get length' called on an object that is not a valid instance of URLList.");
-      }
-
-      return esValue[implSymbol]["length"];
-    }
   }
-  Object.defineProperties(URLList.prototype, {
-    item: { enumerable: true },
-    length: { enumerable: true },
-    [Symbol.toStringTag]: { value: "URLList", configurable: true },
-    [Symbol.iterator]: { value: globalObject.Array.prototype[Symbol.iterator], configurable: true, writable: true },
-    keys: { value: globalObject.Array.prototype.keys, configurable: true, enumerable: true, writable: true },
-    values: { value: globalObject.Array.prototype.values, configurable: true, enumerable: true, writable: true },
-    entries: { value: globalObject.Array.prototype.entries, configurable: true, enumerable: true, writable: true },
-    forEach: { value: globalObject.Array.prototype.forEach, configurable: true, enumerable: true, writable: true }
+  Object.defineProperties(LegacyOverrideBuiltins.prototype, {
+    [Symbol.toStringTag]: { value: "LegacyOverrideBuiltins", configurable: true }
   });
-  ctorRegistry[interfaceName] = URLList;
+  ctorRegistry[interfaceName] = LegacyOverrideBuiltins;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
     writable: true,
-    value: URLList
+    value: LegacyOverrideBuiltins
   });
 };
 
@@ -167,13 +127,9 @@ class ProxyHandler {
       return Reflect.get(target, P, receiver);
     }
 
-    if (utils.isArrayIndexPropName(P)) {
-      const index = P >>> 0;
-
-      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
-        const indexedValue = target[implSymbol].item(index);
-        return utils.tryWrapperForImpl(indexedValue);
-      }
+    if (target[implSymbol][utils.supportsPropertyName](P) && !Object.hasOwn(target, P)) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
+      return utils.tryWrapperForImpl(namedValue);
     }
 
     return Reflect.get(target, P, receiver);
@@ -197,8 +153,10 @@ class ProxyHandler {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[implSymbol][utils.supportedPropertyIndices]) {
-      keys.add(`${key}`);
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
+      if (!Object.hasOwn(target, key)) {
+        keys.add(`${key}`);
+      }
     }
 
     for (const key of Reflect.ownKeys(target)) {
@@ -212,18 +170,14 @@ class ProxyHandler {
       return Reflect.getOwnPropertyDescriptor(target, P);
     }
 
-    if (utils.isArrayIndexPropName(P)) {
-      const index = P >>> 0;
-
-      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
-        const indexedValue = target[implSymbol].item(index);
-        return {
-          writable: false,
-          enumerable: true,
-          configurable: true,
-          value: utils.tryWrapperForImpl(indexedValue)
-        };
-      }
+    if (target[implSymbol][utils.supportsPropertyName](P) && !Object.hasOwn(target, P)) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
+      return {
+        writable: false,
+        enumerable: true,
+        configurable: true,
+        value: utils.tryWrapperForImpl(namedValue)
+      };
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);
@@ -240,20 +194,6 @@ class ProxyHandler {
     }
     let ownDesc;
 
-    if (utils.isArrayIndexPropName(P)) {
-      const index = P >>> 0;
-
-      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
-        const indexedValue = target[implSymbol].item(index);
-        ownDesc = {
-          writable: false,
-          enumerable: true,
-          configurable: true,
-          value: utils.tryWrapperForImpl(indexedValue)
-        };
-      }
-    }
-
     if (ownDesc === undefined) {
       ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
     }
@@ -267,7 +207,8 @@ class ProxyHandler {
 
     const globalObject = this._globalObject;
 
-    if (utils.isArrayIndexPropName(P)) {
+    const creating = !target[implSymbol][utils.supportsPropertyName](P);
+    if (!creating) {
       return false;
     }
 
@@ -281,9 +222,8 @@ class ProxyHandler {
 
     const globalObject = this._globalObject;
 
-    if (utils.isArrayIndexPropName(P)) {
-      const index = P >>> 0;
-      return !target[implSymbol][utils.supportsPropertyIndex](index);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !Object.hasOwn(target, P)) {
+      return false;
     }
 
     return Reflect.deleteProperty(target, P);
@@ -294,4 +234,4 @@ class ProxyHandler {
   }
 }
 
-const Impl = require("../implementations/URLList.js");
+const Impl = require("../implementations/LegacyOverrideBuiltins.js");

--- a/test/snapshots/with-processors/LegacyUnforgeableMap.js
+++ b/test/snapshots/with-processors/LegacyUnforgeableMap.js
@@ -154,22 +154,13 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
-      }
-      return Reflect.get(target, P, receiver);
+
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
+      return utils.tryWrapperForImpl(namedValue);
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
-    }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -206,11 +197,9 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.getOwnPropertyDescriptor(target, P);
     }
-    let ignoreNamedProps = false;
 
-    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
       const namedValue = target[implSymbol][utils.namedGet](P);
-
       return {
         writable: true,
         enumerable: true,

--- a/test/snapshots/with-processors/Storage.js
+++ b/test/snapshots/with-processors/Storage.js
@@ -251,22 +251,13 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
-      }
-      return Reflect.get(target, P, receiver);
+
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      const namedValue = target[implSymbol].getItem(P);
+      return utils.tryWrapperForImpl(namedValue);
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
-    }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -303,11 +294,9 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.getOwnPropertyDescriptor(target, P);
     }
-    let ignoreNamedProps = false;
 
-    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
       const namedValue = target[implSymbol].getItem(P);
-
       return {
         writable: true,
         enumerable: true,

--- a/test/snapshots/with-processors/URLSearchParamsCollection.js
+++ b/test/snapshots/with-processors/URLSearchParamsCollection.js
@@ -192,22 +192,27 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      const indexedValue = target[implSymbol].item(index);
+      if (indexedValue !== undefined) {
+        return utils.tryWrapperForImpl(indexedValue);
       }
-      return Reflect.get(target, P, receiver);
+
+      ignoreNamedProps = true;
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
+
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return utils.tryWrapperForImpl(namedValue);
+      }
     }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -252,6 +257,7 @@ class ProxyHandler {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
+
       const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         return {
@@ -261,18 +267,20 @@ class ProxyHandler {
           value: utils.tryWrapperForImpl(indexedValue)
         };
       }
+
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[implSymbol].namedItem(P);
-
-    if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
-      return {
-        writable: false,
-        enumerable: false,
-        configurable: true,
-        value: utils.tryWrapperForImpl(namedValue)
-      };
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return {
+          writable: false,
+          enumerable: false,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);

--- a/test/snapshots/with-processors/URLSearchParamsCollection2.js
+++ b/test/snapshots/with-processors/URLSearchParamsCollection2.js
@@ -131,22 +131,27 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      const indexedValue = target[implSymbol].item(index);
+      if (indexedValue !== undefined) {
+        return utils.tryWrapperForImpl(indexedValue);
       }
-      return Reflect.get(target, P, receiver);
+
+      ignoreNamedProps = true;
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
+
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return utils.tryWrapperForImpl(namedValue);
+      }
     }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -191,6 +196,7 @@ class ProxyHandler {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
+
       const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         return {
@@ -200,18 +206,20 @@ class ProxyHandler {
           value: utils.tryWrapperForImpl(indexedValue)
         };
       }
+
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[implSymbol].namedItem(P);
-
-    if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
-      return {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value: utils.tryWrapperForImpl(namedValue)
-      };
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return {
+          writable: true,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);

--- a/test/snapshots/without-processors/CEReactions.js
+++ b/test/snapshots/without-processors/CEReactions.js
@@ -195,22 +195,13 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
-      }
-      return Reflect.get(target, P, receiver);
+
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
+      return utils.tryWrapperForImpl(namedValue);
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
-    }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -247,11 +238,9 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.getOwnPropertyDescriptor(target, P);
     }
-    let ignoreNamedProps = false;
 
-    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
       const namedValue = target[implSymbol][utils.namedGet](P);
-
       return {
         writable: true,
         enumerable: true,

--- a/test/snapshots/without-processors/HTMLCollection.js
+++ b/test/snapshots/without-processors/HTMLCollection.js
@@ -190,22 +190,27 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      const indexedValue = target[implSymbol].item(index);
+      if (indexedValue !== null) {
+        return utils.tryWrapperForImpl(indexedValue);
       }
-      return Reflect.get(target, P, receiver);
+
+      ignoreNamedProps = true;
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
+
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return utils.tryWrapperForImpl(namedValue);
+      }
     }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -250,6 +255,7 @@ class ProxyHandler {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
+
       const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== null) {
         return {
@@ -259,18 +265,20 @@ class ProxyHandler {
           value: utils.tryWrapperForImpl(indexedValue)
         };
       }
+
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[implSymbol].namedItem(P);
-
-    if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
-      return {
-        writable: false,
-        enumerable: false,
-        configurable: true,
-        value: utils.tryWrapperForImpl(namedValue)
-      };
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return {
+          writable: false,
+          enumerable: false,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);

--- a/test/snapshots/without-processors/HTMLFormControlsCollection.js
+++ b/test/snapshots/without-processors/HTMLFormControlsCollection.js
@@ -156,22 +156,27 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      const indexedValue = target[implSymbol].item(index);
+      if (indexedValue !== null) {
+        return utils.tryWrapperForImpl(indexedValue);
       }
-      return Reflect.get(target, P, receiver);
+
+      ignoreNamedProps = true;
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
+
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return utils.tryWrapperForImpl(namedValue);
+      }
     }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -216,6 +221,7 @@ class ProxyHandler {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
+
       const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== null) {
         return {
@@ -225,18 +231,20 @@ class ProxyHandler {
           value: utils.tryWrapperForImpl(indexedValue)
         };
       }
+
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[implSymbol].namedItem(P);
-
-    if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
-      return {
-        writable: false,
-        enumerable: true,
-        configurable: true,
-        value: utils.tryWrapperForImpl(namedValue)
-      };
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return {
+          writable: false,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);

--- a/test/snapshots/without-processors/LegacyOverrideBuiltins.js
+++ b/test/snapshots/without-processors/LegacyOverrideBuiltins.js
@@ -6,7 +6,7 @@ const utils = require("./utils.js");
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
-const interfaceName = "URLList";
+const interfaceName = "LegacyOverrideBuiltins";
 
 exports.is = value => {
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
@@ -18,7 +18,7 @@ exports.convert = (globalObject, value, { context = "The provided value" } = {})
   if (exports.is(value)) {
     return utils.implForWrapper(value);
   }
-  throw new globalObject.TypeError(`${context} is not of type 'URLList'.`);
+  throw new globalObject.TypeError(`${context} is not of type 'LegacyOverrideBuiltins'.`);
 };
 
 function makeWrapper(globalObject, newTarget) {
@@ -28,7 +28,7 @@ function makeWrapper(globalObject, newTarget) {
   }
 
   if (!utils.isObject(proto)) {
-    proto = globalObject[ctorRegistrySymbol]["URLList"].prototype;
+    proto = globalObject[ctorRegistrySymbol]["LegacyOverrideBuiltins"].prototype;
   }
 
   return Object.create(proto);
@@ -99,60 +99,20 @@ exports.install = (globalObject, globalNames) => {
   }
 
   const ctorRegistry = utils.initCtorRegistry(globalObject);
-  class URLList {
+  class LegacyOverrideBuiltins {
     constructor() {
       throw new globalObject.TypeError("Illegal constructor");
     }
-
-    item(index) {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-      if (!exports.is(esValue)) {
-        throw new globalObject.TypeError("'item' called on an object that is not a valid instance of URLList.");
-      }
-
-      if (arguments.length < 1) {
-        throw new globalObject.TypeError(
-          `Failed to execute 'item' on 'URLList': 1 argument required, but only ${arguments.length} present.`
-        );
-      }
-      const args = [];
-      {
-        let curArg = arguments[0];
-        curArg = conversions["unsigned long"](curArg, {
-          context: "Failed to execute 'item' on 'URLList': parameter 1",
-          globals: globalObject
-        });
-        args.push(curArg);
-      }
-      return utils.tryWrapperForImpl(esValue[implSymbol].item(...args));
-    }
-
-    get length() {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      if (!exports.is(esValue)) {
-        throw new globalObject.TypeError("'get length' called on an object that is not a valid instance of URLList.");
-      }
-
-      return esValue[implSymbol]["length"];
-    }
   }
-  Object.defineProperties(URLList.prototype, {
-    item: { enumerable: true },
-    length: { enumerable: true },
-    [Symbol.toStringTag]: { value: "URLList", configurable: true },
-    [Symbol.iterator]: { value: globalObject.Array.prototype[Symbol.iterator], configurable: true, writable: true },
-    keys: { value: globalObject.Array.prototype.keys, configurable: true, enumerable: true, writable: true },
-    values: { value: globalObject.Array.prototype.values, configurable: true, enumerable: true, writable: true },
-    entries: { value: globalObject.Array.prototype.entries, configurable: true, enumerable: true, writable: true },
-    forEach: { value: globalObject.Array.prototype.forEach, configurable: true, enumerable: true, writable: true }
+  Object.defineProperties(LegacyOverrideBuiltins.prototype, {
+    [Symbol.toStringTag]: { value: "LegacyOverrideBuiltins", configurable: true }
   });
-  ctorRegistry[interfaceName] = URLList;
+  ctorRegistry[interfaceName] = LegacyOverrideBuiltins;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
     writable: true,
-    value: URLList
+    value: LegacyOverrideBuiltins
   });
 };
 
@@ -167,13 +127,9 @@ class ProxyHandler {
       return Reflect.get(target, P, receiver);
     }
 
-    if (utils.isArrayIndexPropName(P)) {
-      const index = P >>> 0;
-
-      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
-        const indexedValue = target[implSymbol].item(index);
-        return utils.tryWrapperForImpl(indexedValue);
-      }
+    if (target[implSymbol][utils.supportsPropertyName](P) && !Object.hasOwn(target, P)) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
+      return utils.tryWrapperForImpl(namedValue);
     }
 
     return Reflect.get(target, P, receiver);
@@ -197,8 +153,10 @@ class ProxyHandler {
   ownKeys(target) {
     const keys = new Set();
 
-    for (const key of target[implSymbol][utils.supportedPropertyIndices]) {
-      keys.add(`${key}`);
+    for (const key of target[implSymbol][utils.supportedPropertyNames]) {
+      if (!Object.hasOwn(target, key)) {
+        keys.add(`${key}`);
+      }
     }
 
     for (const key of Reflect.ownKeys(target)) {
@@ -212,18 +170,14 @@ class ProxyHandler {
       return Reflect.getOwnPropertyDescriptor(target, P);
     }
 
-    if (utils.isArrayIndexPropName(P)) {
-      const index = P >>> 0;
-
-      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
-        const indexedValue = target[implSymbol].item(index);
-        return {
-          writable: false,
-          enumerable: true,
-          configurable: true,
-          value: utils.tryWrapperForImpl(indexedValue)
-        };
-      }
+    if (target[implSymbol][utils.supportsPropertyName](P) && !Object.hasOwn(target, P)) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
+      return {
+        writable: false,
+        enumerable: true,
+        configurable: true,
+        value: utils.tryWrapperForImpl(namedValue)
+      };
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);
@@ -240,20 +194,6 @@ class ProxyHandler {
     }
     let ownDesc;
 
-    if (utils.isArrayIndexPropName(P)) {
-      const index = P >>> 0;
-
-      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
-        const indexedValue = target[implSymbol].item(index);
-        ownDesc = {
-          writable: false,
-          enumerable: true,
-          configurable: true,
-          value: utils.tryWrapperForImpl(indexedValue)
-        };
-      }
-    }
-
     if (ownDesc === undefined) {
       ownDesc = Reflect.getOwnPropertyDescriptor(target, P);
     }
@@ -267,7 +207,8 @@ class ProxyHandler {
 
     const globalObject = this._globalObject;
 
-    if (utils.isArrayIndexPropName(P)) {
+    const creating = !target[implSymbol][utils.supportsPropertyName](P);
+    if (!creating) {
       return false;
     }
 
@@ -281,9 +222,8 @@ class ProxyHandler {
 
     const globalObject = this._globalObject;
 
-    if (utils.isArrayIndexPropName(P)) {
-      const index = P >>> 0;
-      return !target[implSymbol][utils.supportsPropertyIndex](index);
+    if (target[implSymbol][utils.supportsPropertyName](P) && !Object.hasOwn(target, P)) {
+      return false;
     }
 
     return Reflect.deleteProperty(target, P);
@@ -294,4 +234,4 @@ class ProxyHandler {
   }
 }
 
-const Impl = require("../implementations/URLList.js");
+const Impl = require("../implementations/LegacyOverrideBuiltins.js");

--- a/test/snapshots/without-processors/LegacyUnforgeableMap.js
+++ b/test/snapshots/without-processors/LegacyUnforgeableMap.js
@@ -154,22 +154,13 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
-      }
-      return Reflect.get(target, P, receiver);
+
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      const namedValue = target[implSymbol][utils.namedGet](P);
+      return utils.tryWrapperForImpl(namedValue);
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
-    }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -206,11 +197,9 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.getOwnPropertyDescriptor(target, P);
     }
-    let ignoreNamedProps = false;
 
-    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
       const namedValue = target[implSymbol][utils.namedGet](P);
-
       return {
         writable: true,
         enumerable: true,

--- a/test/snapshots/without-processors/Storage.js
+++ b/test/snapshots/without-processors/Storage.js
@@ -251,22 +251,13 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
-      }
-      return Reflect.get(target, P, receiver);
+
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
+      const namedValue = target[implSymbol].getItem(P);
+      return utils.tryWrapperForImpl(namedValue);
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
-    }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -303,11 +294,9 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.getOwnPropertyDescriptor(target, P);
     }
-    let ignoreNamedProps = false;
 
-    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target) && !ignoreNamedProps) {
+    if (target[implSymbol][utils.supportsPropertyName](P) && !(P in target)) {
       const namedValue = target[implSymbol].getItem(P);
-
       return {
         writable: true,
         enumerable: true,

--- a/test/snapshots/without-processors/URLList.js
+++ b/test/snapshots/without-processors/URLList.js
@@ -166,22 +166,17 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      if (target[implSymbol][utils.supportsPropertyIndex](index)) {
+        const indexedValue = target[implSymbol].item(index);
+        return utils.tryWrapperForImpl(indexedValue);
       }
-      return Reflect.get(target, P, receiver);
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
-    }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -216,7 +211,6 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.getOwnPropertyDescriptor(target, P);
     }
-    let ignoreNamedProps = false;
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
@@ -230,7 +224,6 @@ class ProxyHandler {
           value: utils.tryWrapperForImpl(indexedValue)
         };
       }
-      ignoreNamedProps = true;
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);

--- a/test/snapshots/without-processors/URLSearchParamsCollection.js
+++ b/test/snapshots/without-processors/URLSearchParamsCollection.js
@@ -192,22 +192,27 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      const indexedValue = target[implSymbol].item(index);
+      if (indexedValue !== undefined) {
+        return utils.tryWrapperForImpl(indexedValue);
       }
-      return Reflect.get(target, P, receiver);
+
+      ignoreNamedProps = true;
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
+
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return utils.tryWrapperForImpl(namedValue);
+      }
     }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -252,6 +257,7 @@ class ProxyHandler {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
+
       const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         return {
@@ -261,18 +267,20 @@ class ProxyHandler {
           value: utils.tryWrapperForImpl(indexedValue)
         };
       }
+
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[implSymbol].namedItem(P);
-
-    if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
-      return {
-        writable: false,
-        enumerable: false,
-        configurable: true,
-        value: utils.tryWrapperForImpl(namedValue)
-      };
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return {
+          writable: false,
+          enumerable: false,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);

--- a/test/snapshots/without-processors/URLSearchParamsCollection2.js
+++ b/test/snapshots/without-processors/URLSearchParamsCollection2.js
@@ -131,22 +131,27 @@ class ProxyHandler {
     if (typeof P === "symbol") {
       return Reflect.get(target, P, receiver);
     }
-    const desc = this.getOwnPropertyDescriptor(target, P);
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(target);
-      if (parent === null) {
-        return undefined;
+    let ignoreNamedProps = false;
+
+    if (utils.isArrayIndexPropName(P)) {
+      const index = P >>> 0;
+
+      const indexedValue = target[implSymbol].item(index);
+      if (indexedValue !== undefined) {
+        return utils.tryWrapperForImpl(indexedValue);
       }
-      return Reflect.get(target, P, receiver);
+
+      ignoreNamedProps = true;
     }
-    if (!desc.get && !desc.set) {
-      return desc.value;
+
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return utils.tryWrapperForImpl(namedValue);
+      }
     }
-    const getter = desc.get;
-    if (getter === undefined) {
-      return undefined;
-    }
-    return Reflect.apply(getter, receiver, []);
+
+    return Reflect.get(target, P, receiver);
   }
 
   has(target, P) {
@@ -191,6 +196,7 @@ class ProxyHandler {
 
     if (utils.isArrayIndexPropName(P)) {
       const index = P >>> 0;
+
       const indexedValue = target[implSymbol].item(index);
       if (indexedValue !== undefined) {
         return {
@@ -200,18 +206,20 @@ class ProxyHandler {
           value: utils.tryWrapperForImpl(indexedValue)
         };
       }
+
       ignoreNamedProps = true;
     }
 
-    const namedValue = target[implSymbol].namedItem(P);
-
-    if (namedValue !== null && !(P in target) && !ignoreNamedProps) {
-      return {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value: utils.tryWrapperForImpl(namedValue)
-      };
+    if (!ignoreNamedProps) {
+      const namedValue = target[implSymbol].namedItem(P);
+      if (namedValue !== null && !(P in target)) {
+        return {
+          writable: true,
+          enumerable: true,
+          configurable: true,
+          value: utils.tryWrapperForImpl(namedValue)
+        };
+      }
     }
 
     return Reflect.getOwnPropertyDescriptor(target, P);

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ const { describe, test, before, snapshot } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("fs");
 const path = require("path");
+const vm = require("vm");
 
 snapshot.setDefaultSnapshotSerializers([value => value]);
 const Transformer = require("..");
@@ -16,6 +17,16 @@ const outputDir = path.resolve(__dirname, "output");
 const snapshotsDir = path.resolve(__dirname, "snapshots");
 
 const idlFiles = fs.readdirSync(casesDir);
+
+function createLegacyPlatformObject(name, privateData) {
+  const generated = require(path.resolve(outputDir, `${name}.js`));
+  const utils = require(path.resolve(outputDir, "utils.js"));
+  const context = vm.createContext();
+  const globalObject = vm.runInContext("globalThis", context);
+  generated.install(globalObject, ["Window"]);
+  const wrapper = generated.create(globalObject, [], privateData);
+  return { globalObject, implementation: utils.implForWrapper(wrapper), wrapper };
+}
 
 describe("generation", () => {
   describe("built-in types", () => {
@@ -56,6 +67,99 @@ describe("generation", () => {
         t.assert.fileSnapshot(output, path.resolve(snapshotsDir, "without-processors", `${basename}.js`));
       });
     }
+
+    describe("legacy platform object property access", () => {
+      test("indexed properties and ordinary fallbacks", () => {
+        const { globalObject, wrapper } = createLegacyPlatformObject("URLList", { values: ["zero"] });
+
+        assert.strictEqual(wrapper[0], "zero");
+        assert.strictEqual(wrapper[1], undefined);
+
+        Object.defineProperty(globalObject.URLList.prototype, "receiver", {
+          configurable: true,
+          get() {
+            return this;
+          }
+        });
+        const derived = Object.create(wrapper);
+        assert.strictEqual(derived.receiver, derived);
+
+        Object.defineProperty(wrapper, "ownAccessor", {
+          configurable: true,
+          get() {
+            return this;
+          }
+        });
+        assert.strictEqual(wrapper.ownAccessor, wrapper);
+
+        const symbol = Symbol("test");
+        wrapper[symbol] = "symbol value";
+        assert.strictEqual(wrapper[symbol], "symbol value");
+
+        Object.setPrototypeOf(wrapper, null);
+        assert.strictEqual(wrapper.missing, undefined);
+      });
+
+      test("combined indexed and named properties", () => {
+        const named = {
+          1: "named numeric property",
+          item: "named prototype property",
+          person: "named property"
+        };
+        const { implementation, wrapper } = createLegacyPlatformObject("HTMLCollection", {
+          indexed: ["indexed property"],
+          named
+        });
+
+        implementation.indexedCalls.length = 0;
+        implementation.namedCalls.length = 0;
+        assert.strictEqual(wrapper[0], "indexed property");
+        assert.deepStrictEqual(implementation.indexedCalls, [0]);
+        assert.deepStrictEqual(implementation.namedCalls, []);
+
+        assert.strictEqual(wrapper[1], undefined);
+        assert.deepStrictEqual(implementation.indexedCalls, [0, 1]);
+        assert.deepStrictEqual(implementation.namedCalls, []);
+
+        assert.strictEqual(Object.getOwnPropertyDescriptor(wrapper, "1"), undefined);
+        assert.deepStrictEqual(implementation.indexedCalls, [0, 1, 1]);
+        assert.deepStrictEqual(implementation.namedCalls, []);
+
+        assert.strictEqual(wrapper.person, "named property");
+        assert.deepStrictEqual(implementation.namedCalls, ["person"]);
+        assert.strictEqual(typeof wrapper.item, "function");
+
+        const ownNamed = {};
+        const { wrapper: wrapperWithOwnProperty } = createLegacyPlatformObject("HTMLCollection", { named: ownNamed });
+        Object.defineProperty(wrapperWithOwnProperty, "person", {
+          configurable: true,
+          value: "own property"
+        });
+        ownNamed.person = "named property";
+        assert.strictEqual(wrapperWithOwnProperty.person, "own property");
+      });
+
+      test("LegacyOverrideBuiltins named properties", () => {
+        const entries = { inherited: "named property" };
+        const { globalObject, wrapper } = createLegacyPlatformObject("LegacyOverrideBuiltins", { entries });
+        Object.defineProperty(globalObject.LegacyOverrideBuiltins.prototype, "inherited", {
+          configurable: true,
+          value: "inherited property"
+        });
+        assert.strictEqual(wrapper.inherited, "named property");
+
+        const ownEntries = {};
+        const { wrapper: wrapperWithOwnProperty } = createLegacyPlatformObject("LegacyOverrideBuiltins", {
+          entries: ownEntries
+        });
+        Object.defineProperty(wrapperWithOwnProperty, "own", {
+          configurable: true,
+          value: "own property"
+        });
+        ownEntries.own = "named property";
+        assert.strictEqual(wrapperWithOwnProperty.own, "own property");
+      });
+    });
   });
 
   describe("with processors", () => {


### PR DESCRIPTION
Legacy platform object reads currently go through `getOwnPropertyDescriptor()`. This builds a full descriptor even when the `get` trap only needs the value.

This change generates the indexed and named property lookup once for both `get()` and `getOwnPropertyDescriptor()`. `get()` returns the value directly and falls back to `Reflect.get()` for ordinary properties. `getOwnPropertyDescriptor()` returns a descriptor from the same lookup.

Most of the diff is regenerated snapshots. The generator change is in `lib/constructs/interface.js`, with the behavior covered in `test/test.js`.

In a 500-row Testing Library benchmark with the target at the end, median `getByText()` time dropped from 48.524 ms to 45.725 ms, a 6.55% paired-median improvement across 11 processes.

A jsdom-only benchmark traversed a 1,000-element `NodeList` with a normal `i < nodes.length` loop and read `nodes[i]` on each iteration. For 1,000 traversals, median time dropped from 283.886 ms to 266.574 ms. This was 6.29% faster by paired median across 11 alternating main/candidate processes, and every pair improved by 5.1-7.3%.

The shared lookup also fixes unsupported numeric indexes calling the named getter before ignoring its result. For example, reading `collection[1]` when index 1 does not exist no longer calls `namedItem("1")`.