### PR TITLE
Close a brand check bypass through a transparent Proxy

### DIFF
--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -582,7 +582,8 @@ class Interface {
   generateExport() {
     this.str += `
       exports.is = value => {
-        return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+        return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation &&
+          value[implSymbol][utils.wrapperSymbol] === value;
       };
       exports.isImpl = value => {
         return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/cases/BrandCheck.webidl
+++ b/test/cases/BrandCheck.webidl
@@ -1,0 +1,5 @@
+[Exposed=Window]
+interface BrandCheck {
+  attribute DOMString value;
+  DOMString method();
+};

--- a/test/implementations/BrandCheck.js
+++ b/test/implementations/BrandCheck.js
@@ -1,0 +1,19 @@
+"use strict";
+
+exports.implementation = class BrandCheckImpl {
+  constructor() {
+    this._value = "";
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  set value(v) {
+    this._value = v;
+  }
+
+  method() {
+    return "called";
+  }
+};

--- a/test/snapshots/with-processors/AsyncIterablePairArgs.js
+++ b/test/snapshots/with-processors/AsyncIterablePairArgs.js
@@ -11,7 +11,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "AsyncIterablePairArgs";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/AsyncIterablePairNoArgs.js
+++ b/test/snapshots/with-processors/AsyncIterablePairNoArgs.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "AsyncIterablePairNoArgs";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/AsyncIterableValueArgs.js
+++ b/test/snapshots/with-processors/AsyncIterableValueArgs.js
@@ -11,7 +11,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "AsyncIterableValueArgs";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/AsyncIterableValueNoArgs.js
+++ b/test/snapshots/with-processors/AsyncIterableValueNoArgs.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "AsyncIterableValueNoArgs";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/AsyncIterableWithReturn.js
+++ b/test/snapshots/with-processors/AsyncIterableWithReturn.js
@@ -11,7 +11,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "AsyncIterableWithReturn";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/BrandCheck.js
+++ b/test/snapshots/with-processors/BrandCheck.js
@@ -6,7 +6,7 @@ const utils = require("./utils.js");
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
-const interfaceName = "LegacyLenientAttributes";
+const interfaceName = "BrandCheck";
 
 exports.is = value => {
   return (
@@ -23,7 +23,7 @@ exports.convert = (globalObject, value, { context = "The provided value" } = {})
   if (exports.is(value)) {
     return utils.implForWrapper(value);
   }
-  throw new globalObject.TypeError(`${context} is not of type 'LegacyLenientAttributes'.`);
+  throw new globalObject.TypeError(`${context} is not of type 'BrandCheck'.`);
 };
 
 function makeWrapper(globalObject, newTarget) {
@@ -33,7 +33,7 @@ function makeWrapper(globalObject, newTarget) {
   }
 
   if (!utils.isObject(proto)) {
-    proto = globalObject[ctorRegistrySymbol]["LegacyLenientAttributes"].prototype;
+    proto = globalObject[ctorRegistrySymbol]["BrandCheck"].prototype;
   }
 
   return Object.create(proto);
@@ -91,116 +91,57 @@ exports.install = (globalObject, globalNames) => {
   }
 
   const ctorRegistry = utils.initCtorRegistry(globalObject);
-  class LegacyLenientAttributes {
+  class BrandCheck {
     constructor() {
       throw new globalObject.TypeError("Illegal constructor");
     }
 
-    get lenientSetter() {
+    method() {
       const esValue = this !== null && this !== undefined ? this : globalObject;
-
       if (!exports.is(esValue)) {
-        throw new globalObject.TypeError(
-          "'get lenientSetter' called on an object that is not a valid instance of LegacyLenientAttributes."
-        );
+        throw new globalObject.TypeError("'method' called on an object that is not a valid instance of BrandCheck.");
       }
 
-      return esValue[implSymbol]["lenientSetter"];
+      return esValue[implSymbol].method();
     }
 
-    set lenientSetter(V) {
+    get value() {
       const esValue = this !== null && this !== undefined ? this : globalObject;
 
       if (!exports.is(esValue)) {
-        throw new globalObject.TypeError(
-          "'set lenientSetter' called on an object that is not a valid instance of LegacyLenientAttributes."
-        );
-      }
-    }
-
-    get lenientThisSetter() {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      if (!exports.is(esValue)) {
-        return;
+        throw new globalObject.TypeError("'get value' called on an object that is not a valid instance of BrandCheck.");
       }
 
-      return esValue[implSymbol]["lenientThisSetter"];
+      return esValue[implSymbol]["value"];
     }
 
-    set lenientThisSetter(V) {}
-
-    get lenientThis() {
+    set value(V) {
       const esValue = this !== null && this !== undefined ? this : globalObject;
 
       if (!exports.is(esValue)) {
-        return;
-      }
-
-      return esValue[implSymbol]["lenientThis"];
-    }
-
-    set lenientThis(V) {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      if (!exports.is(esValue)) {
-        return;
+        throw new globalObject.TypeError("'set value' called on an object that is not a valid instance of BrandCheck.");
       }
 
       V = conversions["DOMString"](V, {
-        context: "Failed to set the 'lenientThis' property on 'LegacyLenientAttributes': The provided value",
+        context: "Failed to set the 'value' property on 'BrandCheck': The provided value",
         globals: globalObject
       });
 
-      esValue[implSymbol]["lenientThis"] = V;
-    }
-
-    get readonlyLenientThis() {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      if (!exports.is(esValue)) {
-        return;
-      }
-
-      return esValue[implSymbol]["readonlyLenientThis"];
-    }
-
-    get replaceableLenientThis() {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      if (!exports.is(esValue)) {
-        return;
-      }
-
-      return esValue[implSymbol]["replaceableLenientThis"];
-    }
-
-    set replaceableLenientThis(V) {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      Object.defineProperty(esValue, "replaceableLenientThis", {
-        configurable: true,
-        enumerable: true,
-        value: V,
-        writable: true
-      });
+      esValue[implSymbol]["value"] = V;
     }
   }
-  Object.defineProperties(LegacyLenientAttributes.prototype, {
-    lenientSetter: { enumerable: true },
-    lenientThisSetter: { enumerable: true },
-    lenientThis: { enumerable: true },
-    readonlyLenientThis: { enumerable: true },
-    replaceableLenientThis: { enumerable: true },
-    [Symbol.toStringTag]: { value: "LegacyLenientAttributes", configurable: true }
+  Object.defineProperties(BrandCheck.prototype, {
+    method: { enumerable: true },
+    value: { enumerable: true },
+    [Symbol.toStringTag]: { value: "BrandCheck", configurable: true }
   });
-  ctorRegistry[interfaceName] = LegacyLenientAttributes;
+  ctorRegistry[interfaceName] = BrandCheck;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
     writable: true,
-    value: LegacyLenientAttributes
+    value: BrandCheck
   });
 };
 
-const Impl = require("../implementations/LegacyLenientAttributes.js");
+const Impl = require("../implementations/BrandCheck.js");

--- a/test/snapshots/with-processors/BufferSourceTypes.js
+++ b/test/snapshots/with-processors/BufferSourceTypes.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "BufferSourceTypes";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/CEReactions.js
+++ b/test/snapshots/with-processors/CEReactions.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "CEReactions";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/DOMImplementation.js
+++ b/test/snapshots/with-processors/DOMImplementation.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "DOMImplementation";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/DOMRect.js
+++ b/test/snapshots/with-processors/DOMRect.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "DOMRect";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/DictionaryConvert.js
+++ b/test/snapshots/with-processors/DictionaryConvert.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "DictionaryConvert";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/Enum.js
+++ b/test/snapshots/with-processors/Enum.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Enum";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/EventTarget.js
+++ b/test/snapshots/with-processors/EventTarget.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "EventTarget";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/Global.js
+++ b/test/snapshots/with-processors/Global.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Global";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/HTMLCollection.js
+++ b/test/snapshots/with-processors/HTMLCollection.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "HTMLCollection";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/HTMLConstructor.js
+++ b/test/snapshots/with-processors/HTMLConstructor.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "HTMLConstructor";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/HTMLFormControlsCollection.js
+++ b/test/snapshots/with-processors/HTMLFormControlsCollection.js
@@ -10,7 +10,12 @@ const HTMLCollection = require("./HTMLCollection.js");
 const interfaceName = "HTMLFormControlsCollection";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/LegacyNoInterfaceObject.js
+++ b/test/snapshots/with-processors/LegacyNoInterfaceObject.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "LegacyNoInterfaceObject";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/LegacyOverrideBuiltins.js
+++ b/test/snapshots/with-processors/LegacyOverrideBuiltins.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "LegacyOverrideBuiltins";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/LegacyUnforgeable.js
+++ b/test/snapshots/with-processors/LegacyUnforgeable.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "LegacyUnforgeable";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/LegacyUnforgeableMap.js
+++ b/test/snapshots/with-processors/LegacyUnforgeableMap.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "LegacyUnforgeableMap";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/MixedIn.js
+++ b/test/snapshots/with-processors/MixedIn.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "MixedIn";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/Overloads.js
+++ b/test/snapshots/with-processors/Overloads.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Overloads";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/PromiseTypes.js
+++ b/test/snapshots/with-processors/PromiseTypes.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "PromiseTypes";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/Reflect.js
+++ b/test/snapshots/with-processors/Reflect.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Reflect";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/Replaceable.js
+++ b/test/snapshots/with-processors/Replaceable.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Replaceable";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/SeqAndRec.js
+++ b/test/snapshots/with-processors/SeqAndRec.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "SeqAndRec";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/Static.js
+++ b/test/snapshots/with-processors/Static.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Static";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/Storage.js
+++ b/test/snapshots/with-processors/Storage.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Storage";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/StringifierAttribute.js
+++ b/test/snapshots/with-processors/StringifierAttribute.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "StringifierAttribute";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/StringifierDefaultOperation.js
+++ b/test/snapshots/with-processors/StringifierDefaultOperation.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "StringifierDefaultOperation";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/StringifierNamedOperation.js
+++ b/test/snapshots/with-processors/StringifierNamedOperation.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "StringifierNamedOperation";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/StringifierOperation.js
+++ b/test/snapshots/with-processors/StringifierOperation.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "StringifierOperation";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/TypedefsAndUnions.js
+++ b/test/snapshots/with-processors/TypedefsAndUnions.js
@@ -13,7 +13,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "TypedefsAndUnions";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/URL.js
+++ b/test/snapshots/with-processors/URL.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "URL";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/URLList.js
+++ b/test/snapshots/with-processors/URLList.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "URLList";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/URLSearchParams.js
+++ b/test/snapshots/with-processors/URLSearchParams.js
@@ -11,7 +11,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "URLSearchParams";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/URLSearchParamsCollection.js
+++ b/test/snapshots/with-processors/URLSearchParamsCollection.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "URLSearchParamsCollection";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/URLSearchParamsCollection2.js
+++ b/test/snapshots/with-processors/URLSearchParamsCollection2.js
@@ -11,7 +11,12 @@ const URLSearchParamsCollection = require("./URLSearchParamsCollection.js");
 const interfaceName = "URLSearchParamsCollection2";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/UnderscoredProperties.js
+++ b/test/snapshots/with-processors/UnderscoredProperties.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "UnderscoredProperties";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/Unscopable.js
+++ b/test/snapshots/with-processors/Unscopable.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Unscopable";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/Variadic.js
+++ b/test/snapshots/with-processors/Variadic.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Variadic";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/with-processors/ZeroArgConstructor.js
+++ b/test/snapshots/with-processors/ZeroArgConstructor.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "ZeroArgConstructor";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/AsyncIterablePairArgs.js
+++ b/test/snapshots/without-processors/AsyncIterablePairArgs.js
@@ -11,7 +11,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "AsyncIterablePairArgs";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/AsyncIterablePairNoArgs.js
+++ b/test/snapshots/without-processors/AsyncIterablePairNoArgs.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "AsyncIterablePairNoArgs";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/AsyncIterableValueArgs.js
+++ b/test/snapshots/without-processors/AsyncIterableValueArgs.js
@@ -11,7 +11,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "AsyncIterableValueArgs";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/AsyncIterableValueNoArgs.js
+++ b/test/snapshots/without-processors/AsyncIterableValueNoArgs.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "AsyncIterableValueNoArgs";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/AsyncIterableWithReturn.js
+++ b/test/snapshots/without-processors/AsyncIterableWithReturn.js
@@ -11,7 +11,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "AsyncIterableWithReturn";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/BrandCheck.js
+++ b/test/snapshots/without-processors/BrandCheck.js
@@ -6,7 +6,7 @@ const utils = require("./utils.js");
 const implSymbol = utils.implSymbol;
 const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
-const interfaceName = "LegacyLenientAttributes";
+const interfaceName = "BrandCheck";
 
 exports.is = value => {
   return (
@@ -23,7 +23,7 @@ exports.convert = (globalObject, value, { context = "The provided value" } = {})
   if (exports.is(value)) {
     return utils.implForWrapper(value);
   }
-  throw new globalObject.TypeError(`${context} is not of type 'LegacyLenientAttributes'.`);
+  throw new globalObject.TypeError(`${context} is not of type 'BrandCheck'.`);
 };
 
 function makeWrapper(globalObject, newTarget) {
@@ -33,7 +33,7 @@ function makeWrapper(globalObject, newTarget) {
   }
 
   if (!utils.isObject(proto)) {
-    proto = globalObject[ctorRegistrySymbol]["LegacyLenientAttributes"].prototype;
+    proto = globalObject[ctorRegistrySymbol]["BrandCheck"].prototype;
   }
 
   return Object.create(proto);
@@ -91,116 +91,57 @@ exports.install = (globalObject, globalNames) => {
   }
 
   const ctorRegistry = utils.initCtorRegistry(globalObject);
-  class LegacyLenientAttributes {
+  class BrandCheck {
     constructor() {
       throw new globalObject.TypeError("Illegal constructor");
     }
 
-    get lenientSetter() {
+    method() {
       const esValue = this !== null && this !== undefined ? this : globalObject;
-
       if (!exports.is(esValue)) {
-        throw new globalObject.TypeError(
-          "'get lenientSetter' called on an object that is not a valid instance of LegacyLenientAttributes."
-        );
+        throw new globalObject.TypeError("'method' called on an object that is not a valid instance of BrandCheck.");
       }
 
-      return esValue[implSymbol]["lenientSetter"];
+      return esValue[implSymbol].method();
     }
 
-    set lenientSetter(V) {
+    get value() {
       const esValue = this !== null && this !== undefined ? this : globalObject;
 
       if (!exports.is(esValue)) {
-        throw new globalObject.TypeError(
-          "'set lenientSetter' called on an object that is not a valid instance of LegacyLenientAttributes."
-        );
-      }
-    }
-
-    get lenientThisSetter() {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      if (!exports.is(esValue)) {
-        return;
+        throw new globalObject.TypeError("'get value' called on an object that is not a valid instance of BrandCheck.");
       }
 
-      return esValue[implSymbol]["lenientThisSetter"];
+      return esValue[implSymbol]["value"];
     }
 
-    set lenientThisSetter(V) {}
-
-    get lenientThis() {
+    set value(V) {
       const esValue = this !== null && this !== undefined ? this : globalObject;
 
       if (!exports.is(esValue)) {
-        return;
-      }
-
-      return esValue[implSymbol]["lenientThis"];
-    }
-
-    set lenientThis(V) {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      if (!exports.is(esValue)) {
-        return;
+        throw new globalObject.TypeError("'set value' called on an object that is not a valid instance of BrandCheck.");
       }
 
       V = conversions["DOMString"](V, {
-        context: "Failed to set the 'lenientThis' property on 'LegacyLenientAttributes': The provided value",
+        context: "Failed to set the 'value' property on 'BrandCheck': The provided value",
         globals: globalObject
       });
 
-      esValue[implSymbol]["lenientThis"] = V;
-    }
-
-    get readonlyLenientThis() {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      if (!exports.is(esValue)) {
-        return;
-      }
-
-      return esValue[implSymbol]["readonlyLenientThis"];
-    }
-
-    get replaceableLenientThis() {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      if (!exports.is(esValue)) {
-        return;
-      }
-
-      return esValue[implSymbol]["replaceableLenientThis"];
-    }
-
-    set replaceableLenientThis(V) {
-      const esValue = this !== null && this !== undefined ? this : globalObject;
-
-      Object.defineProperty(esValue, "replaceableLenientThis", {
-        configurable: true,
-        enumerable: true,
-        value: V,
-        writable: true
-      });
+      esValue[implSymbol]["value"] = V;
     }
   }
-  Object.defineProperties(LegacyLenientAttributes.prototype, {
-    lenientSetter: { enumerable: true },
-    lenientThisSetter: { enumerable: true },
-    lenientThis: { enumerable: true },
-    readonlyLenientThis: { enumerable: true },
-    replaceableLenientThis: { enumerable: true },
-    [Symbol.toStringTag]: { value: "LegacyLenientAttributes", configurable: true }
+  Object.defineProperties(BrandCheck.prototype, {
+    method: { enumerable: true },
+    value: { enumerable: true },
+    [Symbol.toStringTag]: { value: "BrandCheck", configurable: true }
   });
-  ctorRegistry[interfaceName] = LegacyLenientAttributes;
+  ctorRegistry[interfaceName] = BrandCheck;
 
   Object.defineProperty(globalObject, interfaceName, {
     configurable: true,
     writable: true,
-    value: LegacyLenientAttributes
+    value: BrandCheck
   });
 };
 
-const Impl = require("../implementations/LegacyLenientAttributes.js");
+const Impl = require("../implementations/BrandCheck.js");

--- a/test/snapshots/without-processors/BufferSourceTypes.js
+++ b/test/snapshots/without-processors/BufferSourceTypes.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "BufferSourceTypes";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/CEReactions.js
+++ b/test/snapshots/without-processors/CEReactions.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "CEReactions";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/DOMImplementation.js
+++ b/test/snapshots/without-processors/DOMImplementation.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "DOMImplementation";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/DOMRect.js
+++ b/test/snapshots/without-processors/DOMRect.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "DOMRect";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/DictionaryConvert.js
+++ b/test/snapshots/without-processors/DictionaryConvert.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "DictionaryConvert";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/Enum.js
+++ b/test/snapshots/without-processors/Enum.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Enum";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/EventTarget.js
+++ b/test/snapshots/without-processors/EventTarget.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "EventTarget";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/Global.js
+++ b/test/snapshots/without-processors/Global.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Global";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/HTMLCollection.js
+++ b/test/snapshots/without-processors/HTMLCollection.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "HTMLCollection";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/HTMLConstructor.js
+++ b/test/snapshots/without-processors/HTMLConstructor.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "HTMLConstructor";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/HTMLFormControlsCollection.js
+++ b/test/snapshots/without-processors/HTMLFormControlsCollection.js
@@ -10,7 +10,12 @@ const HTMLCollection = require("./HTMLCollection.js");
 const interfaceName = "HTMLFormControlsCollection";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/LegacyLenientAttributes.js
+++ b/test/snapshots/without-processors/LegacyLenientAttributes.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "LegacyLenientAttributes";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/LegacyNoInterfaceObject.js
+++ b/test/snapshots/without-processors/LegacyNoInterfaceObject.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "LegacyNoInterfaceObject";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/LegacyOverrideBuiltins.js
+++ b/test/snapshots/without-processors/LegacyOverrideBuiltins.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "LegacyOverrideBuiltins";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/LegacyUnforgeable.js
+++ b/test/snapshots/without-processors/LegacyUnforgeable.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "LegacyUnforgeable";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/LegacyUnforgeableMap.js
+++ b/test/snapshots/without-processors/LegacyUnforgeableMap.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "LegacyUnforgeableMap";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/MixedIn.js
+++ b/test/snapshots/without-processors/MixedIn.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "MixedIn";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/Overloads.js
+++ b/test/snapshots/without-processors/Overloads.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Overloads";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/PromiseTypes.js
+++ b/test/snapshots/without-processors/PromiseTypes.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "PromiseTypes";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/Reflect.js
+++ b/test/snapshots/without-processors/Reflect.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Reflect";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/Replaceable.js
+++ b/test/snapshots/without-processors/Replaceable.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Replaceable";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/SeqAndRec.js
+++ b/test/snapshots/without-processors/SeqAndRec.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "SeqAndRec";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/Static.js
+++ b/test/snapshots/without-processors/Static.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Static";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/Storage.js
+++ b/test/snapshots/without-processors/Storage.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Storage";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/StringifierAttribute.js
+++ b/test/snapshots/without-processors/StringifierAttribute.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "StringifierAttribute";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/StringifierDefaultOperation.js
+++ b/test/snapshots/without-processors/StringifierDefaultOperation.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "StringifierDefaultOperation";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/StringifierNamedOperation.js
+++ b/test/snapshots/without-processors/StringifierNamedOperation.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "StringifierNamedOperation";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/StringifierOperation.js
+++ b/test/snapshots/without-processors/StringifierOperation.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "StringifierOperation";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/TypedefsAndUnions.js
+++ b/test/snapshots/without-processors/TypedefsAndUnions.js
@@ -13,7 +13,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "TypedefsAndUnions";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/URL.js
+++ b/test/snapshots/without-processors/URL.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "URL";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/URLList.js
+++ b/test/snapshots/without-processors/URLList.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "URLList";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/URLSearchParams.js
+++ b/test/snapshots/without-processors/URLSearchParams.js
@@ -11,7 +11,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "URLSearchParams";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/URLSearchParamsCollection.js
+++ b/test/snapshots/without-processors/URLSearchParamsCollection.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "URLSearchParamsCollection";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/URLSearchParamsCollection2.js
+++ b/test/snapshots/without-processors/URLSearchParamsCollection2.js
@@ -11,7 +11,12 @@ const URLSearchParamsCollection = require("./URLSearchParamsCollection.js");
 const interfaceName = "URLSearchParamsCollection2";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/UnderscoredProperties.js
+++ b/test/snapshots/without-processors/UnderscoredProperties.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "UnderscoredProperties";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/Unscopable.js
+++ b/test/snapshots/without-processors/Unscopable.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Unscopable";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/Variadic.js
+++ b/test/snapshots/without-processors/Variadic.js
@@ -10,7 +10,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "Variadic";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/snapshots/without-processors/ZeroArgConstructor.js
+++ b/test/snapshots/without-processors/ZeroArgConstructor.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 const interfaceName = "ZeroArgConstructor";
 
 exports.is = value => {
-  return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
+  return (
+    utils.isObject(value) &&
+    Object.hasOwn(value, implSymbol) &&
+    value[implSymbol] instanceof Impl.implementation &&
+    value[implSymbol][utils.wrapperSymbol] === value
+  );
 };
 exports.isImpl = value => {
   return utils.isObject(value) && value instanceof Impl.implementation;

--- a/test/test.js
+++ b/test/test.js
@@ -160,6 +160,28 @@ describe("generation", () => {
         assert.strictEqual(wrapperWithOwnProperty.own, "own property");
       });
     });
+
+    describe("brand checks", () => {
+      test("a no-op Proxy wrapping a wrapper does not pass the brand check", () => {
+        const { wrapper } = createLegacyPlatformObject("BrandCheck", {});
+        const proxy = new Proxy(wrapper, {});
+
+        assert.throws(() => {
+          proxy.value = "evil";
+        }, /is not a valid instance of BrandCheck/);
+        assert.throws(() => {
+          return proxy.value;
+        }, /is not a valid instance of BrandCheck/);
+        assert.throws(() => {
+          proxy.method();
+        }, /is not a valid instance of BrandCheck/);
+
+        // Direct (non-proxied) usage keeps working.
+        wrapper.value = "fine";
+        assert.strictEqual(wrapper.value, "fine");
+        assert.strictEqual(wrapper.method(), "called");
+      });
+    });
   });
 
   describe("with processors", () => {


### PR DESCRIPTION
`exports.is()` checks whether an object owns the internal impl symbol with `Object.hasOwn()`. That check goes through a Proxy's default `getOwnPropertyDescriptor` trap, which forwards straight to the target, so a plain no-op `Proxy` wrapping a real wrapper reads as a valid instance too. Once the brand check passes, property access on the proxy also forwards to the target's impl, so getters, setters, and regular operations all run as if the proxy were the genuine object, instead of throwing.

A real browser doesn't have this problem, because the brand check isn't fooled by a transparent wrapper, and calling a DOM method through a no-op Proxy throws `Illegal invocation`. jsdom hit exactly this: setting `innerHTML` through a no-op Proxy around an `Element` silently succeeds instead of throwing (jsdom/jsdom#2265). I ran the repro from that issue against current jsdom `main` and it still reproduces.

Every generated wrapper already stashes a back-reference to itself on its own impl object via `wrapperSymbol` (that's how `utils.wrapperForImpl` finds it). Comparing that stored reference against the value under test with strict equality closes the hole: a Proxy and its target are never the same object, so the comparison correctly fails for the proxy while the get/set traps still forward transparently underneath it.

Added a small `BrandCheck` test case that exercises this through a no-op Proxy for an attribute getter, an attribute setter, and a regular operation, plus the direct non-proxied path to confirm ordinary usage is unaffected. Ran with the fix reverted first to confirm the new test actually catches the bug (`Missing expected exception`), then with it back in to confirm green.

This touches the generated output for basically every interface (the `exports.is` body gets one more line), so most of the snapshot diff here is just that, regenerated with `npm run update-snapshots`.