### PR TITLE
Cache type checks for generated proxies

### DIFF
--- a/lib/constructs/interface.js
+++ b/lib/constructs/interface.js
@@ -581,7 +581,15 @@ class Interface {
 
   generateExport() {
     this.str += `
+      ${this.isLegacyPlatformObj ? "const knownWrappers = new WeakSet();" : ""}
       exports.is = value => {
+        ${this.isLegacyPlatformObj ?
+          `
+          if (knownWrappers.has(value)) {
+            return true;
+          }
+        ` :
+          ""}
         return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
       };
       exports.isImpl = value => {
@@ -1189,7 +1197,9 @@ class Interface {
             proxyHandler = new ProxyHandler(globalObject);
             proxyHandlerCache.set(globalObject, proxyHandler);
           }
-          return new Proxy(wrapper, proxyHandler);
+          const proxy = new Proxy(wrapper, proxyHandler);
+          knownWrappers.add(proxy);
+          return proxy;
         }
       `;
 

--- a/test/snapshots/with-processors/CEReactions.js
+++ b/test/snapshots/with-processors/CEReactions.js
@@ -9,7 +9,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "CEReactions";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -41,7 +46,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/with-processors/HTMLCollection.js
+++ b/test/snapshots/with-processors/HTMLCollection.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "HTMLCollection";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/with-processors/HTMLFormControlsCollection.js
+++ b/test/snapshots/with-processors/HTMLFormControlsCollection.js
@@ -9,7 +9,12 @@ const HTMLCollection = require("./HTMLCollection.js");
 
 const interfaceName = "HTMLFormControlsCollection";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -41,7 +46,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/with-processors/LegacyOverrideBuiltins.js
+++ b/test/snapshots/with-processors/LegacyOverrideBuiltins.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "LegacyOverrideBuiltins";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/with-processors/LegacyUnforgeableMap.js
+++ b/test/snapshots/with-processors/LegacyUnforgeableMap.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "LegacyUnforgeableMap";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/with-processors/Storage.js
+++ b/test/snapshots/with-processors/Storage.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "Storage";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/with-processors/URLList.js
+++ b/test/snapshots/with-processors/URLList.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "URLList";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/with-processors/URLSearchParamsCollection.js
+++ b/test/snapshots/with-processors/URLSearchParamsCollection.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "URLSearchParamsCollection";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/with-processors/URLSearchParamsCollection2.js
+++ b/test/snapshots/with-processors/URLSearchParamsCollection2.js
@@ -10,7 +10,12 @@ const URLSearchParamsCollection = require("./URLSearchParamsCollection.js");
 
 const interfaceName = "URLSearchParamsCollection2";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -42,7 +47,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/without-processors/CEReactions.js
+++ b/test/snapshots/without-processors/CEReactions.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "CEReactions";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/without-processors/HTMLCollection.js
+++ b/test/snapshots/without-processors/HTMLCollection.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "HTMLCollection";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/without-processors/HTMLFormControlsCollection.js
+++ b/test/snapshots/without-processors/HTMLFormControlsCollection.js
@@ -9,7 +9,12 @@ const HTMLCollection = require("./HTMLCollection.js");
 
 const interfaceName = "HTMLFormControlsCollection";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -41,7 +46,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/without-processors/LegacyOverrideBuiltins.js
+++ b/test/snapshots/without-processors/LegacyOverrideBuiltins.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "LegacyOverrideBuiltins";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/without-processors/LegacyUnforgeableMap.js
+++ b/test/snapshots/without-processors/LegacyUnforgeableMap.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "LegacyUnforgeableMap";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/without-processors/Storage.js
+++ b/test/snapshots/without-processors/Storage.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "Storage";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/without-processors/URLList.js
+++ b/test/snapshots/without-processors/URLList.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "URLList";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/without-processors/URLSearchParamsCollection.js
+++ b/test/snapshots/without-processors/URLSearchParamsCollection.js
@@ -8,7 +8,12 @@ const ctorRegistrySymbol = utils.ctorRegistrySymbol;
 
 const interfaceName = "URLSearchParamsCollection";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -40,7 +45,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/snapshots/without-processors/URLSearchParamsCollection2.js
+++ b/test/snapshots/without-processors/URLSearchParamsCollection2.js
@@ -10,7 +10,12 @@ const URLSearchParamsCollection = require("./URLSearchParamsCollection.js");
 
 const interfaceName = "URLSearchParamsCollection2";
 
+const knownWrappers = new WeakSet();
 exports.is = value => {
+  if (knownWrappers.has(value)) {
+    return true;
+  }
+
   return utils.isObject(value) && Object.hasOwn(value, implSymbol) && value[implSymbol] instanceof Impl.implementation;
 };
 exports.isImpl = value => {
@@ -42,7 +47,9 @@ function makeProxy(wrapper, globalObject) {
     proxyHandler = new ProxyHandler(globalObject);
     proxyHandlerCache.set(globalObject, proxyHandler);
   }
-  return new Proxy(wrapper, proxyHandler);
+  const proxy = new Proxy(wrapper, proxyHandler);
+  knownWrappers.add(proxy);
+  return proxy;
 }
 
 exports.create = (globalObject, constructorArgs, privateData) => {

--- a/test/test.js
+++ b/test/test.js
@@ -69,6 +69,22 @@ describe("generation", () => {
     }
 
     describe("legacy platform object property access", () => {
+      test("borrowed methods accept wrappers from another realm and reject invalid receivers", () => {
+        const first = createLegacyPlatformObject("HTMLCollection", {});
+        const indexed = ["first"];
+        const second = createLegacyPlatformObject("HTMLCollection", { indexed });
+        const { item } = first.globalObject.HTMLCollection.prototype;
+
+        assert.strictEqual(item.call(second.wrapper, 0), "first");
+        indexed.push("second");
+        assert.strictEqual(second.wrapper.length, 2);
+        assert.strictEqual(item.call(second.wrapper, 1), "second");
+
+        for (const receiver of [null, {}, Object.create(second.wrapper)]) {
+          assert.throws(() => item.call(receiver, 0), /not a valid instance of HTMLCollection/);
+        }
+      });
+
       test("indexed properties and ordinary fallbacks", () => {
         const { globalObject, wrapper } = createLegacyPlatformObject("URLList", { values: ["zero"] });
 


### PR DESCRIPTION
Repeated jsdom collection and document checks go through Proxy traps to read the implementation symbol. Register generated proxies in a WeakSet and return early for known wrappers; unfamiliar objects still use the existing validation.

A React list with 500 rows, 20 rerenders, and RTL text queries measured:

| CPU per workload | Main | This PR |
|---|---:|---:|
| First run | 315.9 ms | 295.9 ms |
| Warmed | 142.6 ms | 126.7 ms |

Seven alternating fresh-process pairs, comparing generated jsdom bindings from current webidl2js main against this change. All seven warmed pairs improved; median paired CPU reduction was 12.1% (95% bootstrap interval: 6.5–18.4%). First-run times exclude module loading.

The tradeoff is about 1 MiB of additional retained heap with 30,000 collection wrappers. Weak-reference probes confirmed wrappers and old documents can still be collected.

Related to #284, but this does not change validation of user-created proxies. Most of the diff is regenerated snapshots; the generator change is in `lib/constructs/interface.js`.
